### PR TITLE
test: add Wub single-field product roundtrip tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Each test is a roundtrip: `encode(a) |> decode == Right(a)`. Circe uses property
 Basic case classes with primitive/standard-library fields. Our macro already handles these via `Mirror.ProductOf` + `resolveOneEncoder`/`resolveOneDecoder` with `Expr.summon`.
 
 - [x] Multi-field product — `Simple(i: Int, s: String)`
-- [ ] Single-field product — `Wub(x: Long)`
+- [x] Single-field product — `Wub(x: Long)`
 - [ ] Nested product — `Person(name: String, age: Int, address: Address)`
 - [ ] Option field — `Outer(a: Option[Inner[String]])` *(needs Inner to derive first)*
 - [ ] List field — `Baz(xs: List[String])`

--- a/sanely/test/src/sanely/SanelyAutoSuite.scala
+++ b/sanely/test/src/sanely/SanelyAutoSuite.scala
@@ -7,6 +7,7 @@ import io.circe.syntax.*
 import sanely.auto.given
 
 case class Simple(i: Int, s: String)
+case class Wub(x: Long)
 
 object SanelyAutoSuite extends TestSuite:
   val tests = Tests {
@@ -15,5 +16,27 @@ object SanelyAutoSuite extends TestSuite:
       val json = v.asJson
       val decoded = decode[Simple](json.noSpaces)
       assert(decoded == Right(v))
+    }
+
+    test("Single-field product round-trip (Wub)") {
+      val v = Wub(123L)
+      val json = v.asJson
+      assert(json == Json.obj("x" -> Json.fromLong(123L)))
+      val decoded = decode[Wub](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Single-field product with extreme values") {
+      val v = Wub(Long.MaxValue)
+      val decoded = decode[Wub](v.asJson.noSpaces)
+      assert(decoded == Right(v))
+
+      val v2 = Wub(Long.MinValue)
+      val decoded2 = decode[Wub](v2.asJson.noSpaces)
+      assert(decoded2 == Right(v2))
+
+      val v3 = Wub(0L)
+      val decoded3 = decode[Wub](v3.asJson.noSpaces)
+      assert(decoded3 == Right(v3))
     }
   }


### PR DESCRIPTION
## Summary
- Port Phase 1 test item: `Wub(x: Long)` single-field product
- Tests JSON shape (`{"x": 123}`), encode/decode roundtrip, and extreme Long values (MaxValue, MinValue, 0)
- All 3 tests pass — no implementation changes needed

## Test plan
- [x] `./mill sanely.test` — 3/3 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)