### PR TITLE
fix: use Expr.summonIgnoring for true sanely-automatic derivation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,12 @@ Three Mill modules:
 
 Both encoder/decoder follow the same pattern:
 
-1. `auto.scala` provides `inline given` that delegates to `SanelyEncoder.derived` / `SanelyDecoder.derived`
+1. `auto.scala` provides named `inline given autoEncoder`/`autoDecoder` that delegate to `SanelyEncoder.derived` / `SanelyDecoder.derived`
 2. `derived` is an `inline def` that splices a macro (`deriveMacro`)
 3. The macro pattern-matches the `Mirror` to dispatch to `deriveProduct` or `deriveSum`
-4. **Recursive resolution** (`resolveOneEncoder`/`resolveOneDecoder`): first tries `Expr.summon[Encoder[T]]` for an existing given, then falls back to recursive macro derivation via the `Mirror`. This is the key "sanely-automatic" trick — nested types are derived inside the same macro expansion, not via implicit search chains.
+4. **Recursive resolution** (`resolveOneEncoder`/`resolveOneDecoder`): uses `Expr.summonIgnoring` (Scala 3.7+) to search for an existing `Encoder[T]`/`Decoder[T]` **while excluding our own auto-given symbol**. This ensures only user-provided or standard library instances are found. If none exists, the macro falls back to recursive internal derivation via the `Mirror` — deriving nested types inside the same macro expansion, not via implicit search chains. This is the core "sanely-automatic" trick from [kubuszok.com](https://kubuszok.com/2025/sanely-automatic-derivation/).
+
+The givens in `auto.scala` are named (`autoEncoder`/`autoDecoder`) specifically so the macros can reference their symbols to pass to `Expr.summonIgnoring`.
 
 ### Encoding format
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Drop-in replacement for circe's automatic Encoder/Decoder derivation, built with Scala 3 macros. No Shapeless. No circe-generic.
 
-Based on the [sanely-automatic derivation](https://kubuszok.com/2025/sanely-automatic-derivation/) approach: a single macro expansion recursively derives all nested instances at compile time, avoiding the implicit search chains that make circe-generic slow to compile.
+Based on the [sanely-automatic derivation](https://kubuszok.com/2025/sanely-automatic-derivation/) approach: uses `Expr.summonIgnoring` (Scala 3.7+) to exclude the auto-given from implicit search, then recursively derives all nested instances internally within a single macro expansion — avoiding the implicit search chains that make circe-generic slow to compile.
 
 **Scala 3.8.2+ only.**
 
@@ -56,7 +56,7 @@ Each test is a roundtrip: `encode(a) |> decode == Right(a)`. Circe uses property
 
 ### Phase 1 — Simple Products *(already working)*
 
-Basic case classes with primitive/standard-library fields. Our macro already handles these via `Mirror.ProductOf` + `resolveOneEncoder`/`resolveOneDecoder` with `Expr.summon`.
+Basic case classes with primitive/standard-library fields. Our macro handles these via `Mirror.ProductOf` + `resolveOneEncoder`/`resolveOneDecoder` with `Expr.summonIgnoring`.
 
 - [x] Multi-field product — `Simple(i: Int, s: String)`
 - [x] Single-field product — `Wub(x: Long)`
@@ -88,7 +88,7 @@ Case objects have no fields → should encode as `{}` inside the wrapper. Requir
 
 ### Phase 4 — User-Provided Instances Respected
 
-When a type already has an implicit `Encoder`/`Decoder`, our macro's `Expr.summon` should find it instead of re-deriving. This is core to the "sanely-automatic" approach.
+When a type already has an implicit `Encoder`/`Decoder`, our macro's `Expr.summonIgnoring` finds it (since it only excludes our own auto-given, not user-provided instances) instead of re-deriving. This is core to the "sanely-automatic" approach.
 
 - [ ] `Foo` with custom-encoded children — `Bar` has `Encoder.forProduct2`, `Baz` encodes as JSON array (not object)
 - [ ] `Outer(a: Option[Inner[String]])` — should use `Inner`'s derived encoder, not re-derive
@@ -151,7 +151,7 @@ Explicit `SanelyEncoder.derived[A]` / `SanelyDecoder.derived[A]` calls (already 
 | 1 | None — already works |
 | 2 | None — already works for case-class-only sums |
 | 3 | Case objects: `Mirror.ProductOf` with `EmptyTuple`, singleton encoding |
-| 4 | Priority: `Expr.summon` must find user instances over auto-derived ones |
+| 4 | `Expr.summonIgnoring` already skips auto-given; verify user instances are found |
 | 5 | Type params: macro must resolve `Encoder[A]` when `A` is abstract |
 | 6 | Recursion: break infinite macro expansion, likely needs lazy wrapper |
 | 7 | Inline budget for 33 fields/variants; sub-trait Mirror flattening |

--- a/sanely/src/sanely/SanelyDecoder.scala
+++ b/sanely/src/sanely/SanelyDecoder.scala
@@ -93,12 +93,20 @@ object SanelyDecoder:
         val dec = resolveOneDecoder[t]
         (labelStr, Type.of[t], dec) :: resolveFields[ts, ls]
 
+  /** Resolve a Decoder for type T using the "sanely-automatic" approach:
+    * Use Expr.summonIgnoring to skip our own auto-given, so that only user-provided
+    * or standard library decoders are found. If none exists, derive internally within
+    * this same macro expansion — avoiding separate implicit search chains.
+    */
   private def resolveOneDecoder[T: Type](using Quotes): Expr[Decoder[T]] =
     import quotes.reflect.*
 
-    Expr.summon[Decoder[T]] match
+    // Exclude our own auto-given so Expr.summon doesn't trigger a separate macro expansion
+    val autoDecoderSymbol = Symbol.requiredModule("sanely.auto").methodMember("autoDecoder").head
+    Expr.summonIgnoring[Decoder[T]](autoDecoderSymbol) match
       case Some(dec) => dec
       case None =>
+        // No user-provided decoder found — derive internally in this macro expansion
         Expr.summon[Mirror.Of[T]] match
           case Some(mirrorExpr) =>
             mirrorExpr match

--- a/sanely/src/sanely/SanelyEncoder.scala
+++ b/sanely/src/sanely/SanelyEncoder.scala
@@ -87,12 +87,20 @@ object SanelyEncoder:
         val enc = resolveOneEncoder[t]
         (labelStr, Type.of[t], enc) :: resolveFields[ts, ls]
 
+  /** Resolve an Encoder for type T using the "sanely-automatic" approach:
+    * Use Expr.summonIgnoring to skip our own auto-given, so that only user-provided
+    * or standard library encoders are found. If none exists, derive internally within
+    * this same macro expansion — avoiding separate implicit search chains.
+    */
   private def resolveOneEncoder[T: Type](using Quotes): Expr[Encoder[T]] =
     import quotes.reflect.*
 
-    Expr.summon[Encoder[T]] match
+    // Exclude our own auto-given so Expr.summon doesn't trigger a separate macro expansion
+    val autoEncoderSymbol = Symbol.requiredModule("sanely.auto").methodMember("autoEncoder").head
+    Expr.summonIgnoring[Encoder[T]](autoEncoderSymbol) match
       case Some(enc) => enc
       case None =>
+        // No user-provided encoder found — derive internally in this macro expansion
         Expr.summon[Mirror.Of[T]] match
           case Some(mirrorExpr) =>
             mirrorExpr match

--- a/sanely/src/sanely/auto.scala
+++ b/sanely/src/sanely/auto.scala
@@ -4,5 +4,5 @@ import io.circe.{Encoder, Decoder}
 import scala.deriving.Mirror
 
 object auto:
-  inline given [A](using inline m: Mirror.Of[A]): Encoder.AsObject[A] = SanelyEncoder.derived[A]
-  inline given [A](using inline m: Mirror.Of[A]): Decoder[A] = SanelyDecoder.derived[A]
+  inline given autoEncoder[A](using inline m: Mirror.Of[A]): Encoder.AsObject[A] = SanelyEncoder.derived[A]
+  inline given autoDecoder[A](using inline m: Mirror.Of[A]): Decoder[A] = SanelyDecoder.derived[A]


### PR DESCRIPTION
## Summary

- **Core fix**: Replace `Expr.summon` with `Expr.summonIgnoring` in `resolveOneEncoder`/`resolveOneDecoder` — the previous implementation found our own auto-given during implicit search, causing nested types to derive through separate macro expansions instead of internally. This now correctly implements the [sanely-automatic derivation](https://kubuszok.com/2025/sanely-automatic-derivation/) technique.
- **Named givens**: `auto.scala` givens renamed from anonymous to `autoEncoder`/`autoDecoder` so macros can reference their symbols via `Symbol.requiredModule("sanely.auto").methodMember(...)`.
- **Docs updated**: CLAUDE.md and README.md now accurately describe the `Expr.summonIgnoring` technique.

## Why this matters

Without `Expr.summonIgnoring`, every nested type triggers a **separate** macro expansion through implicit search chains — exactly the performance problem the blog post solves. With this fix:
- Nested types are derived within a **single** macro expansion
- Recursive types (Phase 6) become feasible — internal recursion can be tracked/broken
- User-provided instances are naturally respected (only our auto-given is excluded)

## Test plan

- [x] `./mill sanely.compile` — compiles cleanly
- [x] `./mill sanely.test` — all 3 tests pass (Simple product, Wub single-field, extreme values)
- [x] `./mill demo.run` — product + sum round-trips work

🤖 Generated with [Claude Code](https://claude.com/claude-code)