### PR TITLE
feat: implement Phase 6 — recursive type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ Type-parameterized case classes: `Box[A](a: A)`, `Qux[A](i: Int, a: A, j: Int)`.
 
 ### Phase 6 — Recursive Types
 
-Self-referencing types. The macro must break the recursion — can't inline-expand forever. Likely needs lazy val or by-name encoder/decoder.
+Self-referencing types. The macro breaks recursion using lazy val self-reference and container type detection.
 
-- [ ] Recursive sealed trait — `RecursiveAdtExample(Base(a: String) | Nested(r: RecursiveAdtExample))`
-- [ ] Recursive with Option — `RecursiveWithOptionExample(o: Option[RecursiveWithOptionExample])`
+- [x] Recursive sealed trait — `RecursiveAdtExample(Base(a: String) | Nested(r: RecursiveAdtExample))`
+- [x] Recursive with Option — `RecursiveWithOptionExample(o: Option[RecursiveWithOptionExample])`
 - [ ] Recursive enum — `RecursiveEnumAdt(Base(a: String) | Nested(r: RecursiveEnumAdt))`
 
 **What to test**: encode/decode trees of depth 0–3, `None` terminates recursion.

--- a/sanely/src/sanely/SanelyDecoder.scala
+++ b/sanely/src/sanely/SanelyDecoder.scala
@@ -11,108 +11,151 @@ object SanelyDecoder:
     ${ deriveMacro[A]('m) }
 
   private def deriveMacro[A: Type](mirror: Expr[Mirror.Of[A]])(using Quotes): Expr[Decoder[A]] =
+    val helper = new DecoderDerivation[A]
+    helper.derive(mirror)
+
+  private class DecoderDerivation[A: Type](using val quotes: Quotes):
     import quotes.reflect.*
 
-    mirror match
-      case '{ $m: Mirror.ProductOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-        deriveProduct[A, types, labels](m)
+    val selfType: TypeRepr = TypeRepr.of[A]
 
-      case '{ $m: Mirror.SumOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-        deriveSum[A, types, labels](m)
-
-  private def deriveProduct[A: Type, Types: Type, Labels: Type](
-    mirror: Expr[Mirror.ProductOf[A]]
-  )(using Quotes): Expr[Decoder[A]] =
-    import quotes.reflect.*
-
-    val fields = resolveFields[Types, Labels]
-
-    // Build nested flatMap chain with proper types
-    def buildDecodeChain(c: Expr[HCursor], remaining: List[(String, Type[?], Expr[Decoder[?]])], acc: List[Expr[Any]])(using Quotes): Expr[Decoder.Result[A]] =
-      remaining match
-        case Nil =>
-          val tupleExpr = acc.reverse.foldRight('{ EmptyTuple }: Expr[Tuple]) { (elem, tuple) =>
-            '{ $elem *: $tuple }
-          }
-          '{ Right($mirror.fromProduct($tupleExpr)) }
-        case (label, tpe, dec) :: rest =>
-          tpe match
-            case '[t] =>
-              val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
-              val labelExpr = Expr(label)
-              '{
-                $typedDec.tryDecode($c.downField($labelExpr)) match
-                  case Right(v) => ${ buildDecodeChain(c, rest, 'v :: acc) }
-                  case Left(e)  => Left(e)
-              }
-
-    '{
-      new Decoder[A]:
-        def apply(c: HCursor): Decoder.Result[A] =
-          ${ buildDecodeChain('c, fields, Nil) }
-    }
-
-  private def deriveSum[A: Type, Types: Type, Labels: Type](
-    mirror: Expr[Mirror.SumOf[A]]
-  )(using Quotes): Expr[Decoder[A]] =
-    import quotes.reflect.*
-
-    val cases = resolveFields[Types, Labels]
-
-    def buildMatch(c: Expr[HCursor], key: Expr[String]): Expr[Decoder.Result[A]] =
-      cases.foldRight('{ Left(DecodingFailure("Unknown variant", $c.history)) }: Expr[Decoder.Result[A]]) {
-        case ((label, tpe, dec), elseExpr) =>
-          tpe match
-            case '[t] =>
-              val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
-              val labelExpr = Expr(label)
-              '{ if $key == $labelExpr then $typedDec.tryDecode($c.downField($labelExpr)).asInstanceOf[Decoder.Result[A]] else $elseExpr }
+    def derive(mirror: Expr[Mirror.Of[A]]): Expr[Decoder[A]] =
+      // Wrap in lazy val for recursive self-reference support
+      '{
+        lazy val _selfDec: Decoder[A] = ${
+          val selfRef: Expr[Decoder[A]] = '{ _selfDec }
+          mirror match
+            case '{ $m: Mirror.ProductOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+              deriveProduct[A, types, labels](m, selfRef)
+            case '{ $m: Mirror.SumOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+              deriveSum[A, types, labels](m, selfRef)
+        }
+        _selfDec
       }
 
-    '{
-      new Decoder[A]:
-        def apply(c: HCursor): Decoder.Result[A] =
-          c.keys match
-            case Some(keys) =>
-              val key = keys.head
-              ${ buildMatch('c, 'key) }
+    private def deriveProduct[P: Type, Types: Type, Labels: Type](
+      mirror: Expr[Mirror.ProductOf[P]],
+      selfRef: Expr[Decoder[A]]
+    ): Expr[Decoder[P]] =
+      val fields = resolveFields[Types, Labels](selfRef)
+
+      def buildDecodeChain(c: Expr[HCursor], remaining: List[(String, Type[?], Expr[Decoder[?]])], acc: List[Expr[Any]]): Expr[Decoder.Result[P]] =
+        remaining match
+          case Nil =>
+            val tupleExpr = acc.reverse.foldRight('{ EmptyTuple }: Expr[Tuple]) { (elem, tuple) =>
+              '{ $elem *: $tuple }
+            }
+            '{ Right($mirror.fromProduct($tupleExpr)) }
+          case (label, tpe, dec) :: rest =>
+            tpe match
+              case '[t] =>
+                val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
+                val labelExpr = Expr(label)
+                '{
+                  $typedDec.tryDecode($c.downField($labelExpr)) match
+                    case Right(v) => ${ buildDecodeChain(c, rest, 'v :: acc) }
+                    case Left(e)  => Left(e)
+                }
+
+      '{
+        new Decoder[P]:
+          def apply(c: HCursor): Decoder.Result[P] =
+            ${ buildDecodeChain('c, fields, Nil) }
+      }
+
+    private def deriveSum[S: Type, Types: Type, Labels: Type](
+      mirror: Expr[Mirror.SumOf[S]],
+      selfRef: Expr[Decoder[A]]
+    ): Expr[Decoder[S]] =
+      val cases = resolveFields[Types, Labels](selfRef)
+
+      def buildMatch(c: Expr[HCursor], key: Expr[String]): Expr[Decoder.Result[S]] =
+        cases.foldRight('{ Left(DecodingFailure("Unknown variant", $c.history)) }: Expr[Decoder.Result[S]]) {
+          case ((label, tpe, dec), elseExpr) =>
+            tpe match
+              case '[t] =>
+                val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
+                val labelExpr = Expr(label)
+                '{ if $key == $labelExpr then $typedDec.tryDecode($c.downField($labelExpr)).asInstanceOf[Decoder.Result[S]] else $elseExpr }
+        }
+
+      '{
+        new Decoder[S]:
+          def apply(c: HCursor): Decoder.Result[S] =
+            c.keys match
+              case Some(keys) =>
+                val key = keys.head
+                ${ buildMatch('c, 'key) }
+              case None =>
+                Left(DecodingFailure("Expected JSON object for sum type", c.history))
+      }
+
+    private def resolveFields[Types: Type, Labels: Type](
+      selfRef: Expr[Decoder[A]]
+    ): List[(String, Type[?], Expr[Decoder[?]])] =
+      (Type.of[Types], Type.of[Labels]) match
+        case ('[EmptyTuple], '[EmptyTuple]) => Nil
+        case ('[t *: ts], '[label *: ls]) =>
+          val labelStr = Type.of[label] match
+            case '[l] =>
+              Type.valueOfConstant[l].getOrElse(
+                report.errorAndAbort(s"Expected literal string type")
+              ).toString
+          val dec = resolveOneDecoder[t](selfRef)
+          (labelStr, Type.of[t], dec) :: resolveFields[ts, ls](selfRef)
+
+    private def resolveOneDecoder[T: Type](
+      selfRef: Expr[Decoder[A]]
+    ): Expr[Decoder[T]] =
+      val tpe = TypeRepr.of[T]
+
+      // Direct recursion: T is the same type we're currently deriving
+      if tpe =:= selfType then
+        return selfRef.asInstanceOf[Expr[Decoder[T]]]
+
+      // Check if T contains the recursive type in its type params
+      if containsType(tpe, selfType) then
+        return constructRecursiveDecoder[T](tpe, selfRef)
+
+      // Safe path: no recursion risk
+      val autoDecoderSymbol = Symbol.requiredModule("sanely.auto").methodMember("autoDecoder").head
+      Expr.summonIgnoring[Decoder[T]](autoDecoderSymbol) match
+        case Some(dec) => dec
+        case None =>
+          Expr.summon[Mirror.Of[T]] match
+            case Some(mirrorExpr) =>
+              mirrorExpr match
+                case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                  deriveProduct[T, types, labels](m, selfRef)
+                case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                  deriveSum[T, types, labels](m, selfRef)
             case None =>
-              Left(DecodingFailure("Expected JSON object for sum type", c.history))
-    }
+              report.errorAndAbort(s"Cannot derive Decoder for ${Type.show[T]}: no implicit Decoder and no Mirror available")
 
-  private def resolveFields[Types: Type, Labels: Type](using Quotes): List[(String, Type[?], Expr[Decoder[?]])] =
-    import quotes.reflect.*
-    (Type.of[Types], Type.of[Labels]) match
-      case ('[EmptyTuple], '[EmptyTuple]) => Nil
-      case ('[t *: ts], '[label *: ls]) =>
-        val labelStr = Type.of[label] match
-          case '[l] =>
-            Type.valueOfConstant[l].getOrElse(
-              report.errorAndAbort(s"Expected literal string type")
-            ).toString
-        val dec = resolveOneDecoder[t]
-        (labelStr, Type.of[t], dec) :: resolveFields[ts, ls]
+    private def containsType(tpe: TypeRepr, target: TypeRepr): Boolean =
+      tpe match
+        case AppliedType(_, args) => args.exists(arg => (arg =:= target) || containsType(arg, target))
+        case _ => false
 
-  /** Resolve a Decoder for type T using the "sanely-automatic" approach:
-    * Use Expr.summonIgnoring to skip our own auto-given, so that only user-provided
-    * or standard library decoders are found. If none exists, derive internally within
-    * this same macro expansion — avoiding separate implicit search chains.
-    */
-  private def resolveOneDecoder[T: Type](using Quotes): Expr[Decoder[T]] =
-    import quotes.reflect.*
-
-    // Exclude our own auto-given so Expr.summon doesn't trigger a separate macro expansion
-    val autoDecoderSymbol = Symbol.requiredModule("sanely.auto").methodMember("autoDecoder").head
-    Expr.summonIgnoring[Decoder[T]](autoDecoderSymbol) match
-      case Some(dec) => dec
-      case None =>
-        // No user-provided decoder found — derive internally in this macro expansion
-        Expr.summon[Mirror.Of[T]] match
-          case Some(mirrorExpr) =>
-            mirrorExpr match
-              case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                deriveProduct[T, types, labels](m)
-              case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                deriveSum[T, types, labels](m)
-          case None =>
-            report.errorAndAbort(s"Cannot derive Decoder for ${Type.show[T]}: no implicit Decoder and no Mirror available")
+    private def constructRecursiveDecoder[T: Type](
+      tpe: TypeRepr,
+      selfRef: Expr[Decoder[A]]
+    ): Expr[Decoder[T]] =
+      tpe match
+        case AppliedType(tycon, List(arg)) if arg =:= selfType =>
+          arg.asType match
+            case '[a] =>
+              val innerDec = selfRef.asInstanceOf[Expr[Decoder[a]]]
+              tycon.typeSymbol.fullName match
+                case "scala.Option" =>
+                  '{ Decoder.decodeOption[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case s if s.endsWith(".List") =>
+                  '{ Decoder.decodeList[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case s if s.endsWith(".Vector") =>
+                  '{ Decoder.decodeVector[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case s if s.endsWith(".Set") =>
+                  '{ Decoder.decodeSet[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case other =>
+                  report.errorAndAbort(s"Cannot derive Decoder for recursive type in container ${other}[${Type.show[a]}]")
+        case _ =>
+          report.errorAndAbort(s"Cannot derive Decoder for recursive type application: ${Type.show[T]}")

--- a/sanely/src/sanely/SanelyEncoder.scala
+++ b/sanely/src/sanely/SanelyEncoder.scala
@@ -11,102 +11,147 @@ object SanelyEncoder:
     ${ deriveMacro[A]('m) }
 
   private def deriveMacro[A: Type](mirror: Expr[Mirror.Of[A]])(using Quotes): Expr[Encoder.AsObject[A]] =
+    val helper = new EncoderDerivation[A]
+    helper.derive(mirror)
+
+  private class EncoderDerivation[A: Type](using val quotes: Quotes):
     import quotes.reflect.*
 
-    mirror match
-      case '{ $m: Mirror.ProductOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-        deriveProduct[A, types, labels](m)
+    val selfType: TypeRepr = TypeRepr.of[A]
 
-      case '{ $m: Mirror.SumOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-        deriveSum[A, types, labels](m)
+    def derive(mirror: Expr[Mirror.Of[A]]): Expr[Encoder.AsObject[A]] =
+      // Wrap in lazy val for recursive self-reference support
+      '{
+        lazy val _selfEnc: Encoder.AsObject[A] = ${
+          val selfRef: Expr[Encoder.AsObject[A]] = '{ _selfEnc }
+          mirror match
+            case '{ $m: Mirror.ProductOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+              deriveProduct[A, types, labels](m, selfRef)
+            case '{ $m: Mirror.SumOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+              deriveSum[A, types, labels](m, selfRef)
+        }
+        _selfEnc
+      }
 
-  private def deriveProduct[A: Type, Types: Type, Labels: Type](
-    mirror: Expr[Mirror.ProductOf[A]]
-  )(using Quotes): Expr[Encoder.AsObject[A]] =
-    import quotes.reflect.*
+    private def deriveProduct[P: Type, Types: Type, Labels: Type](
+      mirror: Expr[Mirror.ProductOf[P]],
+      selfRef: Expr[Encoder.AsObject[A]]
+    ): Expr[Encoder.AsObject[P]] =
+      val fields = resolveFields[Types, Labels](selfRef)
 
-    val fields = resolveFields[Types, Labels]
+      def addField(base: Expr[JsonObject], product: Expr[Product], label: String, idx: Int, tpe: Type[?], enc: Expr[Encoder[?]]): Expr[JsonObject] =
+        tpe match
+          case '[t] =>
+            val typedEnc = enc.asInstanceOf[Expr[Encoder[t]]]
+            val labelExpr = Expr(label)
+            val idxExpr = Expr(idx)
+            '{ $base.add($labelExpr, $typedEnc($product.productElement($idxExpr).asInstanceOf[t])) }
 
-    def addField(base: Expr[JsonObject], product: Expr[Product], label: String, idx: Int, tpe: Type[?], enc: Expr[Encoder[?]])(using Quotes): Expr[JsonObject] =
-      tpe match
-        case '[t] =>
-          val typedEnc = enc.asInstanceOf[Expr[Encoder[t]]]
-          val labelExpr = Expr(label)
-          val idxExpr = Expr(idx)
-          '{ $base.add($labelExpr, $typedEnc($product.productElement($idxExpr).asInstanceOf[t])) }
-
-    '{
-      new Encoder.AsObject[A]:
-        def encodeObject(a: A): JsonObject =
-          ${
-            val product = '{ a.asInstanceOf[Product] }
-            fields.zipWithIndex.foldLeft('{ JsonObject.empty }) { case (acc, ((label, tpe, enc), idx)) =>
-              addField(acc, product, label, idx, tpe, enc)
+      '{
+        new Encoder.AsObject[P]:
+          def encodeObject(a: P): JsonObject =
+            ${
+              val product = '{ a.asInstanceOf[Product] }
+              fields.zipWithIndex.foldLeft('{ JsonObject.empty }) { case (acc, ((label, tpe, enc), idx)) =>
+                addField(acc, product, label, idx, tpe, enc)
+              }
             }
-          }
-    }
+      }
 
-  private def deriveSum[A: Type, Types: Type, Labels: Type](
-    mirror: Expr[Mirror.SumOf[A]]
-  )(using Quotes): Expr[Encoder.AsObject[A]] =
-    import quotes.reflect.*
+    private def deriveSum[S: Type, Types: Type, Labels: Type](
+      mirror: Expr[Mirror.SumOf[S]],
+      selfRef: Expr[Encoder.AsObject[A]]
+    ): Expr[Encoder.AsObject[S]] =
+      val cases = resolveFields[Types, Labels](selfRef)
 
-    val cases = resolveFields[Types, Labels]
+      def buildBranch(a: Expr[S], label: String, tpe: Type[?], enc: Expr[Encoder[?]]): Expr[JsonObject] =
+        tpe match
+          case '[t] =>
+            val typedEnc = enc.asInstanceOf[Expr[Encoder.AsObject[t]]]
+            val labelExpr = Expr(label)
+            '{ JsonObject.singleton($labelExpr, Json.fromJsonObject($typedEnc.encodeObject($a.asInstanceOf[t]))) }
 
-    def buildBranch(a: Expr[A], label: String, tpe: Type[?], enc: Expr[Encoder[?]])(using Quotes): Expr[JsonObject] =
-      tpe match
-        case '[t] =>
-          val typedEnc = enc.asInstanceOf[Expr[Encoder.AsObject[t]]]
-          val labelExpr = Expr(label)
-          '{ JsonObject.singleton($labelExpr, Json.fromJsonObject($typedEnc.encodeObject($a.asInstanceOf[t]))) }
-
-    '{
-      new Encoder.AsObject[A]:
-        def encodeObject(a: A): JsonObject =
-          val ord = $mirror.ordinal(a)
-          ${
-            cases.zipWithIndex.foldRight('{ throw new MatchError(ord) }: Expr[JsonObject]) {
-              case (((label, tpe, enc), idx), elseExpr) =>
-                val idxExpr = Expr(idx)
-                val branch = buildBranch('a, label, tpe, enc)
-                '{ if ord == $idxExpr then $branch else $elseExpr }
+      '{
+        new Encoder.AsObject[S]:
+          def encodeObject(a: S): JsonObject =
+            val ord = $mirror.ordinal(a)
+            ${
+              cases.zipWithIndex.foldRight('{ throw new MatchError(ord) }: Expr[JsonObject]) {
+                case (((label, tpe, enc), idx), elseExpr) =>
+                  val idxExpr = Expr(idx)
+                  val branch = buildBranch('a, label, tpe, enc)
+                  '{ if ord == $idxExpr then $branch else $elseExpr }
+              }
             }
-          }
-    }
+      }
 
-  private def resolveFields[Types: Type, Labels: Type](using Quotes): List[(String, Type[?], Expr[Encoder[?]])] =
-    import quotes.reflect.*
-    (Type.of[Types], Type.of[Labels]) match
-      case ('[EmptyTuple], '[EmptyTuple]) => Nil
-      case ('[t *: ts], '[label *: ls]) =>
-        val labelStr = Type.of[label] match
-          case '[l] =>
-            Type.valueOfConstant[l].getOrElse(
-              report.errorAndAbort(s"Expected literal string type")
-            ).toString
-        val enc = resolveOneEncoder[t]
-        (labelStr, Type.of[t], enc) :: resolveFields[ts, ls]
+    private def resolveFields[Types: Type, Labels: Type](
+      selfRef: Expr[Encoder.AsObject[A]]
+    ): List[(String, Type[?], Expr[Encoder[?]])] =
+      (Type.of[Types], Type.of[Labels]) match
+        case ('[EmptyTuple], '[EmptyTuple]) => Nil
+        case ('[t *: ts], '[label *: ls]) =>
+          val labelStr = Type.of[label] match
+            case '[l] =>
+              Type.valueOfConstant[l].getOrElse(
+                report.errorAndAbort(s"Expected literal string type")
+              ).toString
+          val enc = resolveOneEncoder[t](selfRef)
+          (labelStr, Type.of[t], enc) :: resolveFields[ts, ls](selfRef)
 
-  /** Resolve an Encoder for type T using the "sanely-automatic" approach:
-    * Use Expr.summonIgnoring to skip our own auto-given, so that only user-provided
-    * or standard library encoders are found. If none exists, derive internally within
-    * this same macro expansion — avoiding separate implicit search chains.
-    */
-  private def resolveOneEncoder[T: Type](using Quotes): Expr[Encoder[T]] =
-    import quotes.reflect.*
+    private def resolveOneEncoder[T: Type](
+      selfRef: Expr[Encoder.AsObject[A]]
+    ): Expr[Encoder[T]] =
+      val tpe = TypeRepr.of[T]
 
-    // Exclude our own auto-given so Expr.summon doesn't trigger a separate macro expansion
-    val autoEncoderSymbol = Symbol.requiredModule("sanely.auto").methodMember("autoEncoder").head
-    Expr.summonIgnoring[Encoder[T]](autoEncoderSymbol) match
-      case Some(enc) => enc
-      case None =>
-        // No user-provided encoder found — derive internally in this macro expansion
-        Expr.summon[Mirror.Of[T]] match
-          case Some(mirrorExpr) =>
-            mirrorExpr match
-              case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                deriveProduct[T, types, labels](m)
-              case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                deriveSum[T, types, labels](m)
-          case None =>
-            report.errorAndAbort(s"Cannot derive Encoder for ${Type.show[T]}: no implicit Encoder and no Mirror available")
+      // Direct recursion: T is the same type we're currently deriving
+      if tpe =:= selfType then
+        return selfRef.asInstanceOf[Expr[Encoder[T]]]
+
+      // Check if T contains the recursive type in its type params (e.g., Option[A], List[A])
+      // Must check BEFORE Expr.summonIgnoring to avoid exponential implicit search
+      if containsType(tpe, selfType) then
+        return constructRecursiveEncoder[T](tpe, selfRef)
+
+      // Safe path: no recursion risk
+      val autoEncoderSymbol = Symbol.requiredModule("sanely.auto").methodMember("autoEncoder").head
+      Expr.summonIgnoring[Encoder[T]](autoEncoderSymbol) match
+        case Some(enc) => enc
+        case None =>
+          Expr.summon[Mirror.Of[T]] match
+            case Some(mirrorExpr) =>
+              mirrorExpr match
+                case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                  deriveProduct[T, types, labels](m, selfRef)
+                case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                  deriveSum[T, types, labels](m, selfRef)
+            case None =>
+              report.errorAndAbort(s"Cannot derive Encoder for ${Type.show[T]}: no implicit Encoder and no Mirror available")
+
+    private def containsType(tpe: TypeRepr, target: TypeRepr): Boolean =
+      tpe match
+        case AppliedType(_, args) => args.exists(arg => (arg =:= target) || containsType(arg, target))
+        case _ => false
+
+    private def constructRecursiveEncoder[T: Type](
+      tpe: TypeRepr,
+      selfRef: Expr[Encoder.AsObject[A]]
+    ): Expr[Encoder[T]] =
+      tpe match
+        case AppliedType(tycon, List(arg)) if arg =:= selfType =>
+          arg.asType match
+            case '[a] =>
+              val innerEnc = selfRef.asInstanceOf[Expr[Encoder[a]]]
+              tycon.typeSymbol.fullName match
+                case "scala.Option" =>
+                  '{ Encoder.encodeOption[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case s if s.endsWith(".List") =>
+                  '{ Encoder.encodeList[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case s if s.endsWith(".Vector") =>
+                  '{ Encoder.encodeVector[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case s if s.endsWith(".Set") =>
+                  '{ Encoder.encodeSet[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case other =>
+                  report.errorAndAbort(s"Cannot derive Encoder for recursive type in container ${other}[${Type.show[a]}]")
+        case _ =>
+          report.errorAndAbort(s"Cannot derive Encoder for recursive type application: ${Type.show[T]}")

--- a/sanely/test/src/sanely/SanelyAutoSuite.scala
+++ b/sanely/test/src/sanely/SanelyAutoSuite.scala
@@ -63,6 +63,13 @@ case class WrapsRenamed(r: Renamed, extra: Boolean)
 case class Box[A](a: A)
 case class Qux[A](i: Int, a: A, j: Int)
 
+// Phase 6 types — recursive
+sealed trait RecursiveAdtExample
+case class BaseAdtExample(a: String) extends RecursiveAdtExample
+case class NestedAdtExample(r: RecursiveAdtExample) extends RecursiveAdtExample
+
+case class RecursiveWithOptionExample(o: Option[RecursiveWithOptionExample])
+
 object SanelyAutoSuite extends TestSuite:
   val tests = Tests {
     test("Simple product round-trip") {
@@ -314,6 +321,51 @@ object SanelyAutoSuite extends TestSuite:
       val none = Outer(None)
       assert(some.asJson == Json.obj("a" -> Json.obj("field" -> Json.fromString("c"))))
       assert(none.asJson == Json.obj("a" -> Json.Null))
+    }
+
+    // --- Phase 6: Recursive Types ---
+
+    test("Recursive sealed trait round-trip (base case)") {
+      val v: RecursiveAdtExample = BaseAdtExample("hello")
+      val json = v.asJson
+      val expected = Json.obj("BaseAdtExample" -> Json.obj("a" -> Json.fromString("hello")))
+      assert(json == expected)
+      val decoded = decode[RecursiveAdtExample](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Recursive sealed trait round-trip (nested depth 1)") {
+      val v: RecursiveAdtExample = NestedAdtExample(BaseAdtExample("inner"))
+      val json = v.asJson
+      val expected = Json.obj("NestedAdtExample" -> Json.obj(
+        "r" -> Json.obj("BaseAdtExample" -> Json.obj("a" -> Json.fromString("inner")))
+      ))
+      assert(json == expected)
+      val decoded = decode[RecursiveAdtExample](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Recursive sealed trait round-trip (nested depth 2)") {
+      val v: RecursiveAdtExample = NestedAdtExample(NestedAdtExample(BaseAdtExample("deep")))
+      val json = v.asJson
+      val decoded = decode[RecursiveAdtExample](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Recursive with Option round-trip (None terminates)") {
+      val v = RecursiveWithOptionExample(None)
+      val json = v.asJson
+      val expected = Json.obj("o" -> Json.Null)
+      assert(json == expected)
+      val decoded = decode[RecursiveWithOptionExample](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Recursive with Option round-trip (nested depth 2)") {
+      val v = RecursiveWithOptionExample(Some(RecursiveWithOptionExample(Some(RecursiveWithOptionExample(None)))))
+      val json = v.asJson
+      val decoded = decode[RecursiveWithOptionExample](json.noSpaces)
+      assert(decoded == Right(v))
     }
 
     // --- Phase 1 extras ---


### PR DESCRIPTION
## Summary
- Restructure SanelyEncoder/SanelyDecoder into helper class pattern (`EncoderDerivation[A]`/`DecoderDerivation[A]`) to support recursive types
- Wrap derived instances in `lazy val` for self-reference, detect direct recursion (`T =:= selfType`) and container recursion (`Option[A]`, `List[A]`, etc.)
- Add 5 recursive type tests: `RecursiveAdtExample` (sealed trait, depth 0–2), `RecursiveWithOptionExample` (None terminates, depth 2)

## Test plan
- [x] All 29 tests pass (`./mill sanely.test`)
- [x] Demo still works (`./mill demo.run`)
- [x] Recursive sealed trait roundtrips at depth 0, 1, 2
- [x] Recursive with Option roundtrips (None terminates, nested depth 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)