### PR TITLE
feat: implement Phase 7 — large types & edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ Self-referencing types. The macro breaks recursion using lazy val self-reference
 
 Stress tests and unusual patterns.
 
-- [ ] Large product — `LongClass` with 33 `String` fields *(may need `-Xmax-inlines` bump)*
-- [ ] Large sum — `LongSum` with 33 case variants
-- [ ] Large enum — `LongEnum` with 33 nullary cases
-- [ ] Sub-trait flattening — `ADTWithSubTraitExample` *(sealed trait → sealed sub-trait → case class)*
+- [x] Large product — `LongClass` with 33 `String` fields
+- [x] Large sum — `LongSum` with 33 case variants
+- [x] Large enum — `LongEnum` with 33 nullary cases
+- [x] Sub-trait flattening — `ADTWithSubTraitExample` *(sealed trait → sealed sub-trait → case class)*
 - [ ] Tagged type members — `ProductWithTaggedMember(x: TaggedString)` where `TaggedString = String with Tag`
-- [ ] Superfluous JSON keys ignored — decoder for `Adt1` handles `{"extraField":true,"Class1":{"int":3}}`
+- [x] Superfluous JSON keys ignored — decoder for `Adt1` handles `{"extraField":true,"Adt1Class1":{"int":3}}`
 
 ### Phase 8 — Error Cases
 

--- a/sanely/src/sanely/SanelyDecoder.scala
+++ b/sanely/src/sanely/SanelyDecoder.scala
@@ -69,9 +69,25 @@ object SanelyDecoder:
     ): Expr[Decoder[S]] =
       val cases = resolveFields[Types, Labels](selfRef)
 
+      // Detect which variants are themselves sum types (sub-traits)
+      val casesWithSubTrait = cases.map { case (label, tpe, dec) =>
+        val isSub = tpe match
+          case '[t] => Expr.summon[Mirror.SumOf[t]].isDefined
+        (label, tpe, dec, isSub)
+      }
+
       def buildMatch(c: Expr[HCursor], key: Expr[String]): Expr[Decoder.Result[S]] =
-        cases.foldRight('{ Left(DecodingFailure("Unknown variant", $c.history)) }: Expr[Decoder.Result[S]]) {
-          case ((label, tpe, dec), elseExpr) =>
+        casesWithSubTrait.foldRight('{ Left(DecodingFailure("Unknown variant", $c.history)) }: Expr[Decoder.Result[S]]) {
+          case ((label, tpe, dec, true), elseExpr) =>
+            // Sub-trait: try its decoder directly on the cursor (it handles its own key matching)
+            tpe match
+              case '[t] =>
+                val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
+                '{ $typedDec.tryDecode($c) match
+                    case Right(v) => Right(v.asInstanceOf[S])
+                    case Left(_)  => $elseExpr
+                }
+          case ((label, tpe, dec, false), elseExpr) =>
             tpe match
               case '[t] =>
                 val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
@@ -79,12 +95,17 @@ object SanelyDecoder:
                 '{ if $key == $labelExpr then $typedDec.tryDecode($c.downField($labelExpr)).asInstanceOf[Decoder.Result[S]] else $elseExpr }
         }
 
+      // Collect only non-sub-trait labels for key matching
+      val directLabels = casesWithSubTrait.collect { case (label, _, _, false) => label }
+      val directLabelsExpr = Expr(directLabels)
+
       '{
         new Decoder[S]:
+          private val _knownLabels: Set[String] = $directLabelsExpr.toSet
           def apply(c: HCursor): Decoder.Result[S] =
             c.keys match
               case Some(keys) =>
-                val key = keys.head
+                val key = keys.find(_knownLabels.contains).getOrElse("")
                 ${ buildMatch('c, 'key) }
               case None =>
                 Left(DecodingFailure("Expected JSON object for sum type", c.history))

--- a/sanely/src/sanely/SanelyEncoder.scala
+++ b/sanely/src/sanely/SanelyEncoder.scala
@@ -64,22 +64,33 @@ object SanelyEncoder:
     ): Expr[Encoder.AsObject[S]] =
       val cases = resolveFields[Types, Labels](selfRef)
 
-      def buildBranch(a: Expr[S], label: String, tpe: Type[?], enc: Expr[Encoder[?]]): Expr[JsonObject] =
+      def buildBranch(a: Expr[S], label: String, tpe: Type[?], enc: Expr[Encoder[?]], isSubTrait: Boolean): Expr[JsonObject] =
         tpe match
           case '[t] =>
             val typedEnc = enc.asInstanceOf[Expr[Encoder.AsObject[t]]]
-            val labelExpr = Expr(label)
-            '{ JsonObject.singleton($labelExpr, Json.fromJsonObject($typedEnc.encodeObject($a.asInstanceOf[t]))) }
+            if isSubTrait then
+              // Sub-trait: use encoder directly (it already wraps with variant name)
+              '{ $typedEnc.encodeObject($a.asInstanceOf[t]) }
+            else
+              val labelExpr = Expr(label)
+              '{ JsonObject.singleton($labelExpr, Json.fromJsonObject($typedEnc.encodeObject($a.asInstanceOf[t]))) }
+
+      // Detect which variants are themselves sum types (sub-traits)
+      val casesWithSubTrait = cases.map { case (label, tpe, enc) =>
+        val isSub = tpe match
+          case '[t] => Expr.summon[Mirror.SumOf[t]].isDefined
+        (label, tpe, enc, isSub)
+      }
 
       '{
         new Encoder.AsObject[S]:
           def encodeObject(a: S): JsonObject =
             val ord = $mirror.ordinal(a)
             ${
-              cases.zipWithIndex.foldRight('{ throw new MatchError(ord) }: Expr[JsonObject]) {
-                case (((label, tpe, enc), idx), elseExpr) =>
+              casesWithSubTrait.zipWithIndex.foldRight('{ throw new MatchError(ord) }: Expr[JsonObject]) {
+                case (((label, tpe, enc, isSub), idx), elseExpr) =>
                   val idxExpr = Expr(idx)
-                  val branch = buildBranch('a, label, tpe, enc)
+                  val branch = buildBranch('a, label, tpe, enc, isSub)
                   '{ if ord == $idxExpr then $branch else $elseExpr }
               }
             }

--- a/sanely/test/src/sanely/SanelyAutoSuite.scala
+++ b/sanely/test/src/sanely/SanelyAutoSuite.scala
@@ -70,6 +70,63 @@ case class NestedAdtExample(r: RecursiveAdtExample) extends RecursiveAdtExample
 
 case class RecursiveWithOptionExample(o: Option[RecursiveWithOptionExample])
 
+// Phase 7 types — large types & edge cases
+
+case class LongClass(
+  v1: String, v2: String, v3: String, v4: String, v5: String,
+  v6: String, v7: String, v8: String, v9: String, v10: String,
+  v11: String, v12: String, v13: String, v14: String, v15: String,
+  v16: String, v17: String, v18: String, v19: String, v20: String,
+  v21: String, v22: String, v23: String, v24: String, v25: String,
+  v26: String, v27: String, v28: String, v29: String, v30: String,
+  v31: String, v32: String, v33: String
+)
+
+enum LongSum:
+  case V1(str: String)
+  case V2(str: String)
+  case V3(str: String)
+  case V4(str: String)
+  case V5(str: String)
+  case V6(str: String)
+  case V7(str: String)
+  case V8(str: String)
+  case V9(str: String)
+  case V10(str: String)
+  case V11(str: String)
+  case V12(str: String)
+  case V13(str: String)
+  case V14(str: String)
+  case V15(str: String)
+  case V16(str: String)
+  case V17(str: String)
+  case V18(str: String)
+  case V19(str: String)
+  case V20(str: String)
+  case V21(str: String)
+  case V22(str: String)
+  case V23(str: String)
+  case V24(str: String)
+  case V25(str: String)
+  case V26(str: String)
+  case V27(str: String)
+  case V28(str: String)
+  case V29(str: String)
+  case V30(str: String)
+  case V31(str: String)
+  case V32(str: String)
+  case V33(str: String)
+
+enum LongEnum:
+  case V1, V2, V3, V4, V5, V6, V7, V8, V9, V10,
+    V11, V12, V13, V14, V15, V16, V17, V18, V19, V20,
+    V21, V22, V23, V24, V25, V26, V27, V28, V29, V30,
+    V31, V32, V33
+
+sealed trait ADTWithSubTraitExample
+sealed trait SubTrait extends ADTWithSubTraitExample
+case class TheClass(a: Int) extends SubTrait
+
 object SanelyAutoSuite extends TestSuite:
   val tests = Tests {
     test("Simple product round-trip") {
@@ -366,6 +423,70 @@ object SanelyAutoSuite extends TestSuite:
       val json = v.asJson
       val decoded = decode[RecursiveWithOptionExample](json.noSpaces)
       assert(decoded == Right(v))
+    }
+
+    // --- Phase 7: Large Types & Edge Cases ---
+
+    test("Large product round-trip (LongClass with 33 fields)") {
+      val v = LongClass(
+        "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10",
+        "a11", "a12", "a13", "a14", "a15", "a16", "a17", "a18", "a19", "a20",
+        "a21", "a22", "a23", "a24", "a25", "a26", "a27", "a28", "a29", "a30",
+        "a31", "a32", "a33"
+      )
+      val json = v.asJson
+      // Spot-check a few fields
+      assert(json.hcursor.downField("v1").as[String] == Right("a1"))
+      assert(json.hcursor.downField("v33").as[String] == Right("a33"))
+      val decoded = decode[LongClass](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Large sum round-trip (LongSum with 33 variants)") {
+      val v1: LongSum = LongSum.V1("hello")
+      val json1 = v1.asJson
+      assert(json1 == Json.obj("V1" -> Json.obj("str" -> Json.fromString("hello"))))
+      val decoded1 = decode[LongSum](json1.noSpaces)
+      assert(decoded1 == Right(v1))
+
+      val v33: LongSum = LongSum.V33("last")
+      val json33 = v33.asJson
+      assert(json33 == Json.obj("V33" -> Json.obj("str" -> Json.fromString("last"))))
+      val decoded33 = decode[LongSum](json33.noSpaces)
+      assert(decoded33 == Right(v33))
+    }
+
+    test("Large enum round-trip (LongEnum with 33 nullary cases)") {
+      val v1: LongEnum = LongEnum.V1
+      val json1 = v1.asJson
+      assert(json1 == Json.obj("V1" -> Json.obj()))
+      val decoded1 = decode[LongEnum](json1.noSpaces)
+      assert(decoded1 == Right(v1))
+
+      val v33: LongEnum = LongEnum.V33
+      val json33 = v33.asJson
+      assert(json33 == Json.obj("V33" -> Json.obj()))
+      val decoded33 = decode[LongEnum](json33.noSpaces)
+      assert(decoded33 == Right(v33))
+    }
+
+    test("Sub-trait flattening (ADTWithSubTraitExample)") {
+      // TheClass extends SubTrait extends ADTWithSubTraitExample
+      // Should encode as {"TheClass":{"a":0}}, NOT {"SubTrait":{"TheClass":{"a":0}}}
+      val v: ADTWithSubTraitExample = TheClass(0)
+      val json = v.asJson
+      val expected = Json.obj("TheClass" -> Json.obj("a" -> Json.fromInt(0)))
+      assert(json == expected)
+      val decoded = decode[ADTWithSubTraitExample](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Decoder ignores superfluous JSON keys") {
+      val expected = Right(Adt1Class1(3): Adt1)
+      assert(decode[Adt1]("""{"Adt1Class1":{"int":3}}""") == expected)
+      assert(decode[Adt1]("""{"extraField":true,"Adt1Class1":{"int":3}}""") == expected)
+      assert(decode[Adt1]("""{"extraField":true,"extraField2":15,"Adt1Class1":{"int":3}}""") == expected)
+      assert(decode[Adt1]("""{"Adt1Class1":{"int":3},"extraField":true}""") == expected)
     }
 
     // --- Phase 1 extras ---


### PR DESCRIPTION
## Summary
- Add LongClass (33 String fields), LongSum (33 case variants), LongEnum (33 nullary cases), sub-trait flattening (ADTWithSubTraitExample), and superfluous JSON keys tests
- Encoder: detect sub-trait variants via `Mirror.SumOf` and skip label wrapping for proper flattening
- Decoder: iterate all JSON keys (not just `keys.head`) to find matching variant, enabling superfluous key tolerance
- Decoder: sub-trait variants try their decoder directly on the cursor

## Test plan
- [x] All 34 tests pass (`./mill sanely.test`)
- [x] LongClass (33 fields) roundtrips correctly
- [x] LongSum first and last variants roundtrip
- [x] LongEnum first and last cases roundtrip
- [x] `TheClass(0)` as `ADTWithSubTraitExample` encodes as `{"TheClass":{"a":0}}` (not double-wrapped)
- [x] Decoder ignores extra JSON keys in ADT objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)