### PR TITLE
test: complete Phase 8 — error cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ Stress tests and unusual patterns.
 
 ### Phase 8 — Error Cases
 
-- [ ] Wrong JSON shape → `Left(DecodingFailure(...))`
-- [ ] Unknown variant → `Left(DecodingFailure(...))`
-- [ ] Non-object for sum type → `Left(DecodingFailure(...))`
+- [x] Wrong JSON shape → `Left(DecodingFailure(...))`
+- [x] Unknown variant → `Left(DecodingFailure(...))`
+- [x] Non-object for sum type → `Left(DecodingFailure(...))`
 - [ ] Compile error when nested type has no `Encoder`/`Decoder` and no `Mirror`
 
 ### Phase 9 — Semiauto API *(optional)*

--- a/sanely/test/src/sanely/SanelyAutoSuite.scala
+++ b/sanely/test/src/sanely/SanelyAutoSuite.scala
@@ -491,6 +491,37 @@ object SanelyAutoSuite extends TestSuite:
 
     // --- Phase 1 extras ---
 
+    // --- Phase 8: Error Cases ---
+
+    test("Wrong JSON shape for product returns DecodingFailure") {
+      // Missing required field "s"
+      val result = decode[Simple]("""{"i":42}""")
+      assert(result.isLeft)
+
+      // Wrong type for field
+      val result2 = decode[Simple]("""{"i":"not_an_int","s":"hello"}""")
+      assert(result2.isLeft)
+    }
+
+    test("Unknown variant for sum type returns DecodingFailure") {
+      val result = decode[Foo]("""{"UnknownVariant":{"x":1}}""")
+      assert(result.isLeft)
+    }
+
+    test("Non-object for sum type returns DecodingFailure") {
+      // Array instead of object
+      val result = decode[Foo]("""[1,2,3]""")
+      assert(result.isLeft)
+
+      // String instead of object
+      val result2 = decode[Foo](""""hello"""")
+      assert(result2.isLeft)
+
+      // Number instead of object
+      val result3 = decode[Foo]("""42""")
+      assert(result3.isLeft)
+    }
+
     test("Single-field product with extreme values") {
       val v = Wub(Long.MaxValue)
       val decoded = decode[Wub](v.asJson.noSpaces)


### PR DESCRIPTION
## Summary
- Add 3 error case tests: wrong JSON shape, unknown variant, non-object for sum type
- All produce `Left(DecodingFailure(...))` as expected — no implementation changes needed

## Test plan
- [x] All 37 tests pass (`./mill sanely.test`)
- [x] Missing/wrong-type fields return DecodingFailure
- [x] Unknown variant returns DecodingFailure  
- [x] Array, string, number inputs for sum type return DecodingFailure

🤖 Generated with [Claude Code](https://claude.com/claude-code)