### PR TITLE
feat: drop-in replacement API surface and expanded type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ When a type already has an implicit `Encoder`/`Decoder`, our macro's `Expr.summo
 
 - [x] Custom `Encoder.AsObject` respected in nested type — `WrapsRenamed` uses `Renamed`'s custom field-renaming encoder
 - [x] `Outer(a: Option[Inner[String]])` — macro internally derives `Inner[String]` and uses it
-- [ ] Nested sums not encoded redundantly — `ADTWithSubTraitExample` → `TheClass(0)` becomes `{"TheClass":{"a":0}}` not `{"SubTrait":{"TheClass":{"a":0}}}`
+- [x] Nested sums not encoded redundantly — `ADTWithSubTraitExample` → `TheClass(0)` becomes `{"TheClass":{"a":0}}` *(tested in Phase 7 sub-trait flattening)*
 
 **What to test**: JSON shape matches circe's expected output exactly, custom encoders are not overridden.
 
@@ -144,16 +144,38 @@ Explicit `SanelyEncoder.derived[A]` / `SanelyDecoder.derived[A]` calls (already 
 - [x] Local case class derivation with strict `val` (no `StackOverflowError`)
 - [x] Local ADT derivation with strict `val`
 
-## Implementation Challenges by Phase
+## TODO — Toward Full Drop-in Replacement
 
-| Phase | Key Challenge |
-|-------|--------------|
-| 1 | None — already works |
-| 2 | None — already works for case-class-only sums |
-| 3 | Case objects: `Mirror.ProductOf` with `EmptyTuple`, singleton encoding |
-| 4 | `Expr.summonIgnoring` already skips auto-given; verify user instances are found |
-| 5 | Type params: macro must resolve `Encoder[A]` when `A` is abstract |
-| 6 | Recursion: break infinite macro expansion, likely needs lazy wrapper |
-| 7 | Inline budget for 33 fields/variants; sub-trait Mirror flattening |
-| 8 | Error messages matching circe's format |
-| 9 | API surface compatibility |
+The core derivation engine is solid (41/41 tests, Phases 1–9). The remaining work is API surface alignment, broader type support, and missing test coverage.
+
+### API Surface
+
+- [ ] **Publish under `io.github.nguyenyou`** — publish to Maven Central under `io.github.nguyenyou::circe-sanely-auto`
+- [ ] **Provide `io.circe.generic.auto` alias** — add an `io.circe.generic.auto` object that re-exports `sanely.auto.given`, so users keep `import io.circe.generic.auto.given`
+- [ ] **Wire into `Encoder.AsObject.derived` / `Decoder.derived`** — provide givens or extensions so `derives Encoder.AsObject, Decoder` works on case classes and sealed traits
+- [ ] **Add `Codec.AsObject` derivation** — compose existing encoder + decoder so `summon[Codec[A]]` works; trivial implementation: `Codec.from(decoder, encoder)`
+
+### Recursive Container Support
+
+Currently only `Option[Self]`, `List[Self]`, `Vector[Self]`, `Set[Self]` are handled in recursive positions (hardcoded in `constructRecursiveEncoder`/`constructRecursiveDecoder`). Non-recursive containers work fine via `summonIgnoring`.
+
+- [ ] **`Seq[Self]`** — add to hardcoded container list
+- [ ] **`Map[String, Self]`** — needs 2-type-param support in `constructRecursiveEncoder`/`constructRecursiveDecoder` (currently only matches `AppliedType(tycon, List(arg))` — single type param)
+- [ ] **`Either[E, Self]`** — same 2-type-param issue
+- [ ] **`NonEmptyList[Self]`** (cats) — optional, add if circe-core has the instance
+
+### Missing Test Coverage
+
+Items still unchecked from the test plan:
+
+- [ ] Nested generic `Bar(foo: Box[Foo])` (Phase 5) — likely works, needs test
+- [ ] Recursive enum `RecursiveEnumAdt` (Phase 6) — enum-specific Mirror may differ from sealed trait
+- [ ] Tagged type members `ProductWithTaggedMember(x: TaggedString)` (Phase 7) — opaque/tagged types common in circe codebases
+- [ ] Compile error message quality for missing instances (Phase 8) — `report.errorAndAbort` exists but untested
+
+### `containsType` Improvement
+
+`containsType` only checks `AppliedType` args. Won't detect recursive references buried in non-`AppliedType` wrappers (e.g., type aliases, match types). Low priority — rare in practice.
+
+- [ ] Handle type aliases by dealias before checking
+- [ ] Consider `TypeRepr.dealias` in recursive walk

--- a/sanely/src/io/circe/generic/auto.scala
+++ b/sanely/src/io/circe/generic/auto.scala
@@ -1,0 +1,13 @@
+package io.circe.generic
+
+import io.circe.{Decoder, Encoder}
+import io.circe.`export`.Exported
+import scala.deriving.Mirror
+
+trait AutoDerivation:
+  implicit inline final def deriveDecoder[A](using inline A: Mirror.Of[A]): Exported[Decoder[A]] =
+    Exported(sanely.SanelyDecoder.derived[A])
+  implicit inline final def deriveEncoder[A](using inline A: Mirror.Of[A]): Exported[Encoder.AsObject[A]] =
+    Exported(sanely.SanelyEncoder.derived[A])
+
+object auto extends AutoDerivation

--- a/sanely/src/io/circe/generic/semiauto.scala
+++ b/sanely/src/io/circe/generic/semiauto.scala
@@ -1,0 +1,12 @@
+package io.circe.generic
+
+import io.circe.{Codec, Decoder, Encoder}
+import scala.deriving.Mirror
+
+object semiauto:
+  inline def deriveDecoder[A](using inline A: Mirror.Of[A]): Decoder[A] =
+    sanely.SanelyDecoder.derived[A]
+  inline def deriveEncoder[A](using inline A: Mirror.Of[A]): Encoder.AsObject[A] =
+    sanely.SanelyEncoder.derived[A]
+  inline def deriveCodec[A](using inline A: Mirror.Of[A]): Codec.AsObject[A] =
+    sanely.SanelyCodec.derived[A]

--- a/sanely/src/sanely/SanelyCodec.scala
+++ b/sanely/src/sanely/SanelyCodec.scala
@@ -1,0 +1,9 @@
+package sanely
+
+import io.circe.{Codec, Decoder, Encoder}
+import scala.deriving.Mirror
+
+object SanelyCodec:
+
+  inline def derived[A](using inline m: Mirror.Of[A]): Codec.AsObject[A] =
+    Codec.AsObject.from(SanelyDecoder.derived[A], SanelyEncoder.derived[A])

--- a/sanely/src/sanely/SanelyDecoder.scala
+++ b/sanely/src/sanely/SanelyDecoder.scala
@@ -139,8 +139,8 @@ object SanelyDecoder:
         return constructRecursiveDecoder[T](tpe, selfRef)
 
       // Safe path: no recursion risk
-      val autoDecoderSymbol = Symbol.requiredModule("sanely.auto").methodMember("autoDecoder").head
-      Expr.summonIgnoring[Decoder[T]](autoDecoderSymbol) match
+      val ignoreSymbols = collectIgnoreSymbols("autoDecoder", "deriveDecoder", "importedDecoder")
+      Expr.summonIgnoring[Decoder[T]](ignoreSymbols*) match
         case Some(dec) => dec
         case None =>
           Expr.summon[Mirror.Of[T]] match
@@ -154,9 +154,33 @@ object SanelyDecoder:
               report.errorAndAbort(s"Cannot derive Decoder for ${Type.show[T]}: no implicit Decoder and no Mirror available")
 
     private def containsType(tpe: TypeRepr, target: TypeRepr): Boolean =
-      tpe match
-        case AppliedType(_, args) => args.exists(arg => (arg =:= target) || containsType(arg, target))
+      val dealiased = tpe.dealias
+      if dealiased =:= target then true
+      else dealiased match
+        case AppliedType(_, args) => args.exists(arg => containsType(arg, target))
+        case AndType(left, right) => containsType(left, target) || containsType(right, target)
+        case OrType(left, right) => containsType(left, target) || containsType(right, target)
         case _ => false
+
+    private def collectIgnoreSymbols(sanelyAutoMethod: String, genericAutoMethod: String, importedMethods: String*): List[Symbol] =
+      val buf = List.newBuilder[Symbol]
+      buf += Symbol.requiredModule("sanely.auto").methodMember(sanelyAutoMethod).head
+      // io.circe.generic.auto alias
+      try
+        val genericAuto = Symbol.requiredModule("io.circe.generic.auto")
+        genericAuto.methodMember(genericAutoMethod).foreach(buf += _)
+      catch case _: Exception => ()
+      // circe-core imported* unwrappers
+      for method <- importedMethods do
+        try
+          val decoderCompanion = Symbol.requiredModule("io.circe.Decoder")
+          decoderCompanion.methodMember(method).foreach(buf += _)
+        catch case _: Exception => ()
+        try
+          val encoderCompanion = Symbol.requiredModule("io.circe.Encoder")
+          encoderCompanion.methodMember(method).foreach(buf += _)
+        catch case _: Exception => ()
+      buf.result()
 
     private def constructRecursiveDecoder[T: Type](
       tpe: TypeRepr,
@@ -176,7 +200,28 @@ object SanelyDecoder:
                   '{ Decoder.decodeVector[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
                 case s if s.endsWith(".Set") =>
                   '{ Decoder.decodeSet[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case s if s.endsWith(".Seq") =>
+                  '{ Decoder.decodeSeq[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case "cats.data.Chain" =>
+                  '{ Decoder.decodeChain[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case "cats.data.NonEmptyList" =>
+                  '{ Decoder.decodeNonEmptyList[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case "cats.data.NonEmptyVector" =>
+                  '{ Decoder.decodeNonEmptyVector[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case "cats.data.NonEmptySeq" =>
+                  '{ Decoder.decodeNonEmptySeq[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case "cats.data.NonEmptyChain" =>
+                  '{ Decoder.decodeNonEmptyChain[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
                 case other =>
                   report.errorAndAbort(s"Cannot derive Decoder for recursive type in container ${other}[${Type.show[a]}]")
+        case AppliedType(tycon, List(keyArg, valArg)) if valArg =:= selfType =>
+          (keyArg.asType, valArg.asType) match
+            case ('[k], '[v]) =>
+              val innerDec = selfRef.asInstanceOf[Expr[Decoder[v]]]
+              Expr.summon[io.circe.KeyDecoder[k]] match
+                case Some(keyDec) =>
+                  '{ Decoder.decodeMap[k, v](using $keyDec, $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case None =>
+                  report.errorAndAbort(s"Cannot derive Decoder for Map: no KeyDecoder for ${Type.show[k]}")
         case _ =>
           report.errorAndAbort(s"Cannot derive Decoder for recursive type application: ${Type.show[T]}")

--- a/sanely/src/sanely/SanelyEncoder.scala
+++ b/sanely/src/sanely/SanelyEncoder.scala
@@ -125,8 +125,8 @@ object SanelyEncoder:
         return constructRecursiveEncoder[T](tpe, selfRef)
 
       // Safe path: no recursion risk
-      val autoEncoderSymbol = Symbol.requiredModule("sanely.auto").methodMember("autoEncoder").head
-      Expr.summonIgnoring[Encoder[T]](autoEncoderSymbol) match
+      val ignoreSymbols = collectIgnoreSymbols("autoEncoder", "deriveEncoder", "importedEncoder", "importedAsObjectEncoder")
+      Expr.summonIgnoring[Encoder[T]](ignoreSymbols*) match
         case Some(enc) => enc
         case None =>
           Expr.summon[Mirror.Of[T]] match
@@ -140,9 +140,33 @@ object SanelyEncoder:
               report.errorAndAbort(s"Cannot derive Encoder for ${Type.show[T]}: no implicit Encoder and no Mirror available")
 
     private def containsType(tpe: TypeRepr, target: TypeRepr): Boolean =
-      tpe match
-        case AppliedType(_, args) => args.exists(arg => (arg =:= target) || containsType(arg, target))
+      val dealiased = tpe.dealias
+      if dealiased =:= target then true
+      else dealiased match
+        case AppliedType(_, args) => args.exists(arg => containsType(arg, target))
+        case AndType(left, right) => containsType(left, target) || containsType(right, target)
+        case OrType(left, right) => containsType(left, target) || containsType(right, target)
         case _ => false
+
+    private def collectIgnoreSymbols(sanelyAutoMethod: String, genericAutoMethod: String, importedMethods: String*): List[Symbol] =
+      val buf = List.newBuilder[Symbol]
+      buf += Symbol.requiredModule("sanely.auto").methodMember(sanelyAutoMethod).head
+      // io.circe.generic.auto alias
+      try
+        val genericAuto = Symbol.requiredModule("io.circe.generic.auto")
+        genericAuto.methodMember(genericAutoMethod).foreach(buf += _)
+      catch case _: Exception => ()
+      // circe-core imported* unwrappers
+      for method <- importedMethods do
+        try
+          val encoderCompanion = Symbol.requiredModule("io.circe.Encoder")
+          encoderCompanion.methodMember(method).foreach(buf += _)
+        catch case _: Exception => ()
+        try
+          val decoderCompanion = Symbol.requiredModule("io.circe.Decoder")
+          decoderCompanion.methodMember(method).foreach(buf += _)
+        catch case _: Exception => ()
+      buf.result()
 
     private def constructRecursiveEncoder[T: Type](
       tpe: TypeRepr,
@@ -162,7 +186,28 @@ object SanelyEncoder:
                   '{ Encoder.encodeVector[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
                 case s if s.endsWith(".Set") =>
                   '{ Encoder.encodeSet[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case s if s.endsWith(".Seq") =>
+                  '{ Encoder.encodeSeq[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case "cats.data.Chain" =>
+                  '{ Encoder.encodeChain[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case "cats.data.NonEmptyList" =>
+                  '{ Encoder.encodeNonEmptyList[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case "cats.data.NonEmptyVector" =>
+                  '{ Encoder.encodeNonEmptyVector[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case "cats.data.NonEmptySeq" =>
+                  '{ Encoder.encodeNonEmptySeq[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case "cats.data.NonEmptyChain" =>
+                  '{ Encoder.encodeNonEmptyChain[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
                 case other =>
                   report.errorAndAbort(s"Cannot derive Encoder for recursive type in container ${other}[${Type.show[a]}]")
+        case AppliedType(tycon, List(keyArg, valArg)) if valArg =:= selfType =>
+          (keyArg.asType, valArg.asType) match
+            case ('[k], '[v]) =>
+              val innerEnc = selfRef.asInstanceOf[Expr[Encoder[v]]]
+              Expr.summon[io.circe.KeyEncoder[k]] match
+                case Some(keyEnc) =>
+                  '{ Encoder.encodeMap[k, v](using $keyEnc, $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case None =>
+                  report.errorAndAbort(s"Cannot derive Encoder for Map: no KeyEncoder for ${Type.show[k]}")
         case _ =>
           report.errorAndAbort(s"Cannot derive Encoder for recursive type application: ${Type.show[T]}")

--- a/sanely/test/src/sanely/SanelyAutoSuite.scala
+++ b/sanely/test/src/sanely/SanelyAutoSuite.scala
@@ -127,6 +127,41 @@ sealed trait ADTWithSubTraitExample
 sealed trait SubTrait extends ADTWithSubTraitExample
 case class TheClass(a: Int) extends SubTrait
 
+// Nested generic type
+case class BarBoxFoo(foo: Box[Foo])
+
+// Recursive enum
+enum RecursiveEnumAdt:
+  case Base(a: String)
+  case Nested(r: RecursiveEnumAdt)
+
+// Recursive with Seq
+case class RecursiveWithSeq(children: Seq[RecursiveWithSeq], value: String)
+
+// Recursive with Map
+case class RecursiveWithMap(children: Map[String, RecursiveWithMap], value: String)
+
+// Tagged type member
+case class ProductWithTaggedMember(x: ProductWithTaggedMember.TaggedString)
+object ProductWithTaggedMember:
+  sealed trait Tag
+  type TaggedString = String & Tag
+  given Codec[TaggedString] = Codec.from(
+    summon[Decoder[String]].map(_.asInstanceOf[TaggedString]),
+    summon[Encoder[String]].contramap(x => x: String)
+  )
+
+// Codec derivation test type
+case class CodecTestProduct(a: Int, b: String)
+object CodecTestProduct:
+  given Codec.AsObject[CodecTestProduct] = SanelyCodec.derived
+
+sealed trait CodecTestAdt
+case class CodecCase(i: Int) extends CodecTestAdt
+case object CodecObj extends CodecTestAdt
+object CodecTestAdt:
+  given Codec.AsObject[CodecTestAdt] = SanelyCodec.derived
+
 // Phase 9 types — semiauto (explicit derived) in companion objects
 case class SemiAutoProduct(x: Int, y: String)
 object SemiAutoProduct:
@@ -604,5 +639,118 @@ object SanelyAutoSuite extends TestSuite:
       val v3 = Wub(0L)
       val decoded3 = decode[Wub](v3.asJson.noSpaces)
       assert(decoded3 == Right(v3))
+    }
+
+    // --- New coverage: nested generic ---
+
+    test("Nested generic Box[Foo] in product round-trip") {
+      val v = BarBoxFoo(Box[Foo](Bar(1, "x")))
+      val json = v.asJson
+      val expected = Json.obj("foo" -> Json.obj("a" -> Json.obj("Bar" -> Json.obj("i" -> Json.fromInt(1), "s" -> Json.fromString("x")))))
+      assert(json == expected)
+      val decoded = decode[BarBoxFoo](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    // --- Recursive enum ---
+
+    test("Recursive enum base case round-trip") {
+      val v: RecursiveEnumAdt = RecursiveEnumAdt.Base("hello")
+      val json = v.asJson
+      val expected = Json.obj("Base" -> Json.obj("a" -> Json.fromString("hello")))
+      assert(json == expected)
+      val decoded = decode[RecursiveEnumAdt](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Recursive enum nested depth 2 round-trip") {
+      val v: RecursiveEnumAdt = RecursiveEnumAdt.Nested(RecursiveEnumAdt.Nested(RecursiveEnumAdt.Base("deep")))
+      val json = v.asJson
+      val decoded = decode[RecursiveEnumAdt](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    // --- Recursive with Seq ---
+
+    test("Recursive with Seq round-trip") {
+      val v = RecursiveWithSeq(Seq(RecursiveWithSeq(Seq.empty, "child")), "parent")
+      val json = v.asJson
+      val decoded = decode[RecursiveWithSeq](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    // --- Recursive with Map ---
+
+    test("Recursive with Map round-trip") {
+      val v = RecursiveWithMap(Map("child" -> RecursiveWithMap(Map.empty, "leaf")), "root")
+      val json = v.asJson
+      val decoded = decode[RecursiveWithMap](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    // --- Tagged type member ---
+
+    test("Tagged type member round-trip") {
+      val v = ProductWithTaggedMember("hello".asInstanceOf[ProductWithTaggedMember.TaggedString])
+      val json = v.asJson
+      assert(json == Json.obj("x" -> Json.fromString("hello")))
+      val decoded = decode[ProductWithTaggedMember](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    // --- Codec derivation ---
+
+    test("Codec.AsObject derivation product round-trip") {
+      val v = CodecTestProduct(42, "hello")
+      val json = v.asJson(using CodecTestProduct.given_AsObject_CodecTestProduct)
+      val expected = Json.obj("a" -> Json.fromInt(42), "b" -> Json.fromString("hello"))
+      assert(json == expected)
+      val decoded = json.as[CodecTestProduct](using CodecTestProduct.given_AsObject_CodecTestProduct)
+      assert(decoded == Right(v))
+    }
+
+    test("Codec.AsObject derivation ADT round-trip") {
+      val v1: CodecTestAdt = CodecCase(7)
+      val json1 = v1.asJson(using CodecTestAdt.given_AsObject_CodecTestAdt)
+      assert(json1 == Json.obj("CodecCase" -> Json.obj("i" -> Json.fromInt(7))))
+      val decoded1 = json1.as[CodecTestAdt](using CodecTestAdt.given_AsObject_CodecTestAdt)
+      assert(decoded1 == Right(v1))
+    }
+
+    // --- io.circe.generic.auto alias ---
+
+    test("io.circe.generic.auto alias works") {
+      import io.circe.generic.auto.given
+      case class AutoAlias(x: Int, y: String)
+      val v = AutoAlias(1, "hi")
+      val json = v.asJson
+      assert(json == Json.obj("x" -> Json.fromInt(1), "y" -> Json.fromString("hi")))
+      val decoded = decode[AutoAlias](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    // --- io.circe.generic.semiauto alias ---
+
+    test("io.circe.generic.semiauto alias works") {
+      case class SemiAlias(a: Int, b: String)
+      given Encoder.AsObject[SemiAlias] = io.circe.generic.semiauto.deriveEncoder
+      given Decoder[SemiAlias] = io.circe.generic.semiauto.deriveDecoder
+
+      val v = SemiAlias(1, "hi")
+      val json = v.asJson
+      assert(json == Json.obj("a" -> Json.fromInt(1), "b" -> Json.fromString("hi")))
+      val decoded = decode[SemiAlias](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("io.circe.generic.semiauto.deriveCodec works") {
+      case class SemiCodecAlias(x: Int, y: String)
+      given Codec.AsObject[SemiCodecAlias] = io.circe.generic.semiauto.deriveCodec
+
+      val v = SemiCodecAlias(1, "hi")
+      val json = v.asJson
+      assert(json == Json.obj("x" -> Json.fromInt(1), "y" -> Json.fromString("hi")))
+      val decoded = decode[SemiCodecAlias](json.noSpaces)
+      assert(decoded == Right(v))
     }
   }


### PR DESCRIPTION
## Summary
- Add `io.circe.generic.auto` alias with `Exported` wrapper pattern matching circe's API
- Add `io.circe.generic.semiauto` alias with `deriveEncoder`/`deriveDecoder`/`deriveCodec`
- Add `SanelyCodec.derived[A]` for `Codec.AsObject` derivation
- Expand recursive container support: `Seq`, `Chain`, `NonEmptyList`, `NonEmptyVector`, `NonEmptySeq`, `NonEmptyChain`, `Map[K, Self]`
- Improve `containsType` with `dealias`, `AndType`, `OrType` handling
- Update `summonIgnoring` to also ignore `io.circe.generic.auto` and circe-core `imported*` unwrappers
- 11 new tests (52 total): nested generic, recursive enum, recursive Seq/Map, tagged types, Codec derivation, auto/semiauto alias tests

## Test plan
- [x] `./mill sanely.test` — 52/52 pass
- [x] `./mill demo.run` — demo works

🤖 Generated with [Claude Code](https://claude.com/claude-code)