### PR TITLE
Run circe's own law tests against our library

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -42,6 +42,31 @@ object sanely extends ScalaModule with SonatypeCentralPublishModule {
   }
 }
 
+object compat extends ScalaModule {
+  def scalaVersion = scala3Version
+  def moduleDeps = Seq(sanely)
+  def mvnDeps = Task {
+    super.mvnDeps() ++ Seq(
+      mvn"io.circe::circe-core:$circeVersion",
+      mvn"io.circe::circe-parser:$circeVersion",
+      mvn"io.circe::circe-testing:$circeVersion",
+      mvn"org.scalameta::munit:1.2.0",
+      mvn"org.scalameta::munit-scalacheck:1.2.0",
+      mvn"org.typelevel::discipline-munit:2.0.0",
+    )
+  }
+  def scalacOptions = Task {
+    super.scalacOptions() ++ Seq(
+      "-Xmax-inlines", "64",
+      "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
+    )
+  }
+  object test extends ScalaTests with TestModule.Munit {
+    def mvnDeps = Task { super.mvnDeps() ++ compat.mvnDeps() }
+    def scalacOptions = Task { compat.scalacOptions() }
+  }
+}
+
 object demo extends ScalaModule {
   def scalaVersion = scala3Version
   def moduleDeps = Seq(sanely)

--- a/compat/test/src/io/circe/generic/AutoDerivedSuite.scala
+++ b/compat/test/src/io/circe/generic/AutoDerivedSuite.scala
@@ -1,0 +1,75 @@
+package io.circe.generic
+
+import cats.kernel.Eq
+import cats.syntax.eq._
+import io.circe.{ Decoder, Encoder, Json }
+import io.circe.generic.auto._
+import io.circe.testing.CodecTests
+import io.circe.tests.CirceMunitSuite
+import io.circe.tests.examples._
+import org.scalacheck.{ Arbitrary, Gen, Prop }
+
+object AutoDerivedSuite {
+  case class InnerCaseClassExample(a: String, b: String, c: String, d: String)
+  case class OuterCaseClassExample(a: String, inner: InnerCaseClassExample)
+
+  object InnerCaseClassExample {
+    implicit val arbitraryInnerCaseClassExample: Arbitrary[InnerCaseClassExample] =
+      Arbitrary(
+        for {
+          a <- Arbitrary.arbitrary[String]
+          b <- Arbitrary.arbitrary[String]
+          c <- Arbitrary.arbitrary[String]
+          d <- Arbitrary.arbitrary[String]
+        } yield InnerCaseClassExample(a, b, c, d)
+      )
+  }
+
+  object OuterCaseClassExample {
+    implicit val eqOuterCaseClassExample: Eq[OuterCaseClassExample] = Eq.fromUniversalEquals
+
+    implicit val arbitraryOuterCaseClassExample: Arbitrary[OuterCaseClassExample] =
+      Arbitrary(
+        for {
+          a <- Arbitrary.arbitrary[String]
+          i <- Arbitrary.arbitrary[InnerCaseClassExample]
+        } yield OuterCaseClassExample(a, i)
+      )
+  }
+}
+
+class AutoDerivedSuite extends CirceMunitSuite {
+  import AutoDerivedSuite._
+
+  checkAll("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
+  checkAll("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
+  checkAll("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)
+  checkAll("Codec[Seq[Foo]]", CodecTests[Seq[Foo]].codec)
+  checkAll("Codec[Baz]", CodecTests[Baz].codec)
+  checkAll("Codec[Foo]", CodecTests[Foo].codec)
+  checkAll("Codec[OuterCaseClassExample]", CodecTests[OuterCaseClassExample].codec)
+
+  property("A generically derived codec should not interfere with base instances") {
+    Prop.forAll { (is: List[Int]) =>
+      val json = Encoder[List[Int]].apply(is)
+
+      assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Right(is))
+    }
+  }
+
+  property("Generic decoders should not interfere with defined decoders") {
+    Prop.forAll { (xs: List[String]) =>
+      val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.fromString)))
+
+      assert(Decoder[Foo].apply(json.hcursor) === Right(Baz(xs): Foo))
+    }
+  }
+
+  property("Generic encoders should not interfere with defined encoders") {
+    Prop.forAll { (xs: List[String]) =>
+      val json = Json.obj("Baz" -> Json.fromValues(xs.map(Json.fromString)))
+
+      assert(Encoder[Foo].apply(Baz(xs): Foo) === json)
+    }
+  }
+}

--- a/compat/test/src/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/compat/test/src/io/circe/generic/SemiautoDerivedSuite.scala
@@ -1,0 +1,156 @@
+package io.circe.generic
+
+import cats.kernel.Eq
+import cats.syntax.eq._
+import io.circe.{ Codec, Decoder, Encoder, Json }
+import io.circe.generic.semiauto._
+import io.circe.testing.CodecTests
+import io.circe.tests.CirceMunitSuite
+import io.circe.tests.examples._
+import org.scalacheck.{ Arbitrary, Gen, Prop }
+
+object SemiautoDerivedSuite {
+  implicit def decodeBox[A: Decoder]: Decoder[Box[A]] = deriveDecoder
+  implicit def encodeBox[A: Encoder]: Encoder[Box[A]] = deriveEncoder
+  def codecForBox[A: Decoder: Encoder]: Codec[Box[A]] = deriveCodec
+
+  implicit def decodeQux[A: Decoder]: Decoder[Qux[A]] = deriveDecoder
+  implicit def encodeQux[A: Encoder]: Encoder[Qux[A]] = deriveEncoder
+  def codecForQux[A: Decoder: Encoder]: Codec[Qux[A]] = deriveCodec
+
+  implicit val decodeWub: Decoder[Wub] = deriveDecoder
+  implicit val encodeWub: Encoder.AsObject[Wub] = deriveEncoder
+  val codecForWub: Codec.AsObject[Wub] = deriveCodec
+
+  implicit val decodeFoo: Decoder[Foo] = deriveDecoder
+  implicit val encodeFoo: Encoder.AsObject[Foo] = deriveEncoder
+  val codecForFoo: Codec.AsObject[Foo] = deriveCodec
+
+  sealed trait RecursiveAdtExample
+  case class BaseAdtExample(a: String) extends RecursiveAdtExample
+  case class NestedAdtExample(r: RecursiveAdtExample) extends RecursiveAdtExample
+
+  object RecursiveAdtExample {
+    implicit val eqRecursiveAdtExample: Eq[RecursiveAdtExample] = Eq.fromUniversalEquals
+
+    private def atDepth(depth: Int): Gen[RecursiveAdtExample] = if (depth < 3)
+      Gen.oneOf(
+        Arbitrary.arbitrary[String].map(BaseAdtExample(_)),
+        atDepth(depth + 1).map(NestedAdtExample(_))
+      )
+    else Arbitrary.arbitrary[String].map(BaseAdtExample(_))
+
+    implicit val arbitraryRecursiveAdtExample: Arbitrary[RecursiveAdtExample] =
+      Arbitrary(atDepth(0))
+
+    implicit val decodeRecursiveAdtExample: Decoder[RecursiveAdtExample] = deriveDecoder
+    implicit val encodeRecursiveAdtExample: Encoder.AsObject[RecursiveAdtExample] = deriveEncoder
+    val codecForRecursiveAdtExample: Codec.AsObject[RecursiveAdtExample] = deriveCodec
+  }
+
+  case class RecursiveWithOptionExample(o: Option[RecursiveWithOptionExample])
+
+  object RecursiveWithOptionExample {
+    implicit val eqRecursiveWithOptionExample: Eq[RecursiveWithOptionExample] =
+      Eq.fromUniversalEquals
+
+    private def atDepth(depth: Int): Gen[RecursiveWithOptionExample] = if (depth < 3)
+      Gen.oneOf(
+        Gen.const(RecursiveWithOptionExample(None)),
+        atDepth(depth + 1).map(Some(_)).map(RecursiveWithOptionExample(_))
+      )
+    else Gen.const(RecursiveWithOptionExample(None))
+
+    implicit val arbitraryRecursiveWithOptionExample: Arbitrary[RecursiveWithOptionExample] =
+      Arbitrary(atDepth(0))
+
+    implicit val decodeRecursiveWithOptionExample: Decoder[RecursiveWithOptionExample] =
+      deriveDecoder
+
+    implicit val encodeRecursiveWithOptionExample: Encoder.AsObject[RecursiveWithOptionExample] =
+      deriveEncoder
+
+    val codecForRecursiveWithOptionExample: Codec.AsObject[RecursiveWithOptionExample] =
+      deriveCodec
+  }
+
+  case class OvergenerationExampleInner(i: Int)
+  case class OvergenerationExampleOuter0(i: OvergenerationExampleInner)
+  case class OvergenerationExampleOuter1(oi: Option[OvergenerationExampleInner])
+}
+
+class SemiautoDerivedSuite extends CirceMunitSuite {
+  import SemiautoDerivedSuite._
+
+  checkAll("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
+  checkAll("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
+  checkAll("Codec[Box[Int]]", CodecTests[Box[Int]].codec)
+  checkAll("Codec[Box[Int]] via Codec", CodecTests[Box[Int]](using codecForBox[Int], codecForBox[Int]).codec)
+  checkAll("Codec[Box[Int]] via Decoder and Codec", CodecTests[Box[Int]](using summon, codecForBox[Int]).codec)
+  checkAll("Codec[Box[Int]] via Encoder and Codec", CodecTests[Box[Int]](using codecForBox[Int], summon).codec)
+  checkAll("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)
+  checkAll("Codec[Qux[Int]] via Codec", CodecTests[Qux[Int]](using codecForQux[Int], codecForQux[Int]).codec)
+  checkAll("Codec[Qux[Int]] via Decoder and Codec", CodecTests[Qux[Int]](using summon, codecForQux[Int]).codec)
+  checkAll("Codec[Qux[Int]] via Encoder and Codec", CodecTests[Qux[Int]](using codecForQux[Int], summon).codec)
+  checkAll("Codec[Seq[Foo]]", CodecTests[Seq[Foo]].codec)
+  checkAll("Codec[Baz]", CodecTests[Baz].codec)
+  checkAll("Codec[Foo]", CodecTests[Foo].codec)
+  checkAll("Codec[Foo] via Codec", CodecTests[Foo](using codecForFoo, codecForFoo).codec)
+  checkAll("Codec[Foo] via Decoder and Codec", CodecTests[Foo](using summon, codecForFoo).codec)
+  checkAll("Codec[Foo] via Encoder and Codec", CodecTests[Foo](using codecForFoo, summon).codec)
+  checkAll("Codec[RecursiveAdtExample]", CodecTests[RecursiveAdtExample].codec)
+  checkAll(
+    "Codec[RecursiveAdtExample] via Codec",
+    CodecTests[RecursiveAdtExample](using
+      RecursiveAdtExample.codecForRecursiveAdtExample,
+      RecursiveAdtExample.codecForRecursiveAdtExample
+    ).codec
+  )
+  checkAll(
+    "Codec[RecursiveAdtExample] via Decoder and Codec",
+    CodecTests[RecursiveAdtExample](using summon, RecursiveAdtExample.codecForRecursiveAdtExample).codec
+  )
+  checkAll(
+    "Codec[RecursiveAdtExample] via Encoder and Codec",
+    CodecTests[RecursiveAdtExample](using RecursiveAdtExample.codecForRecursiveAdtExample, summon).codec
+  )
+  checkAll("Codec[RecursiveWithOptionExample]", CodecTests[RecursiveWithOptionExample].codec)
+  checkAll(
+    "Codec[RecursiveWithOptionExample] via Codec",
+    CodecTests[RecursiveWithOptionExample](using
+      RecursiveWithOptionExample.codecForRecursiveWithOptionExample,
+      RecursiveWithOptionExample.codecForRecursiveWithOptionExample
+    ).codec
+  )
+  checkAll(
+    "Codec[RecursiveWithOptionExample] via Decoder and Codec",
+    CodecTests[RecursiveWithOptionExample](using
+      summon,
+      RecursiveWithOptionExample.codecForRecursiveWithOptionExample
+    ).codec
+  )
+  checkAll(
+    "Codec[RecursiveWithOptionExample] via Encoder and Codec",
+    CodecTests[RecursiveWithOptionExample](using
+      RecursiveWithOptionExample.codecForRecursiveWithOptionExample,
+      summon
+    ).codec
+  )
+
+  property("A generically derived codec should not interfere with base instances") {
+    Prop.forAll { (is: List[Int]) =>
+      val json = Encoder[List[Int]].apply(is)
+
+      assert(json === Json.fromValues(is.map(Json.fromInt)) && json.as[List[Int]] === Right(is))
+    }
+  }
+
+  property("A generically derived codec for an empty case class should not accept non-objects") {
+    Prop.forAll { (j: Json) =>
+      case class EmptyCc()
+
+      assert(deriveDecoder[EmptyCc].decodeJson(j).isRight == j.isObject)
+      assert(deriveCodec[EmptyCc].decodeJson(j).isRight == j.isObject)
+    }
+  }
+}

--- a/compat/test/src/io/circe/tests/CirceMunitSuite.scala
+++ b/compat/test/src/io/circe/tests/CirceMunitSuite.scala
@@ -1,0 +1,29 @@
+package io.circe.tests
+
+import cats.kernel.Eq
+import io.circe.testing.{ ArbitraryInstances, EqInstances }
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+
+trait CirceMunitSuite extends DisciplineSuite with ArbitraryInstances with EqInstances {
+
+  // Tuple1 instances (circe's MissingInstances uses Shapeless, not available in Scala 3)
+  implicit def arbitraryTuple1[A](implicit A: Arbitrary[A]): Arbitrary[Tuple1[A]] =
+    Arbitrary(A.arbitrary.map(Tuple1(_)))
+  implicit def eqTuple1[A: Eq]: Eq[Tuple1[A]] = Eq.by(_._1)
+
+  // Seq Eq instance
+  implicit def eqSeq[A: Eq]: Eq[Seq[A]] = Eq.by((_: Seq[A]).toVector)(
+    cats.kernel.instances.vector.catsKernelStdEqForVector[A]
+  )
+
+  protected def group(name: String)(thunk: => Unit): Unit = {
+    val countBefore = munitTestsBuffer.size
+    val _ = thunk
+    val countAfter = munitTestsBuffer.size
+    val countRegistered = countAfter - countBefore
+    val registered = munitTestsBuffer.toList.drop(countBefore)
+    (0 until countRegistered).foreach(_ => munitTestsBuffer.remove(countBefore))
+    registered.foreach(t => munitTestsBuffer += t.withName(s"$name - ${t.name}"))
+  }
+}

--- a/compat/test/src/io/circe/tests/examples/package.scala
+++ b/compat/test/src/io/circe/tests/examples/package.scala
@@ -1,0 +1,150 @@
+package io.circe.tests
+
+import cats.instances.AllInstances
+import cats.kernel.Eq
+import cats.syntax.functor._
+import io.circe.{ Decoder, DecodingFailure, Encoder, Json }
+import io.circe.testing.ArbitraryInstances
+import org.scalacheck.{ Arbitrary, Gen }
+
+package object examples extends AllInstances with ArbitraryInstances {
+  val glossary: Json = Json.obj(
+    "glossary" -> Json.obj(
+      "title" -> Json.fromString("example glossary"),
+      "GlossDiv" -> Json.obj(
+        "title" -> Json.fromString("S"),
+        "GlossList" -> Json.obj(
+          "GlossEntry" -> Json.obj(
+            "ID" -> Json.fromString("SGML"),
+            "SortAs" -> Json.fromString("SGML"),
+            "GlossTerm" -> Json.fromString("Standard Generalized Markup Language"),
+            "Acronym" -> Json.fromString("SGML"),
+            "Abbrev" -> Json.fromString("ISO 8879:1986"),
+            "GlossDef" -> Json.obj(
+              "para" -> Json.fromString(
+                "A meta-markup language, used to create markup languages such as DocBook."
+              ),
+              "GlossSeeAlso" -> Json.arr(Json.fromString("GML"), Json.fromString("XML"))
+            ),
+            "GlossSee" -> Json.fromString("markup")
+          )
+        )
+      )
+    )
+  )
+}
+
+package examples {
+  case class Box[A](a: A)
+
+  object Box {
+    implicit def eqBox[A: Eq]: Eq[Box[A]] = Eq.by(_.a)
+    implicit def arbitraryBox[A](implicit A: Arbitrary[A]): Arbitrary[Box[A]] = Arbitrary(A.arbitrary.map(Box(_)))
+  }
+
+  case class Qux[A](i: Int, a: A, j: Int)
+
+  object Qux {
+    implicit def eqQux[A: Eq]: Eq[Qux[A]] = Eq.by(q => (q.i, q.a, q.j))
+
+    implicit def arbitraryQux[A](implicit A: Arbitrary[A]): Arbitrary[Qux[A]] =
+      Arbitrary(
+        for {
+          i <- Arbitrary.arbitrary[Int]
+          a <- A.arbitrary
+          j <- Arbitrary.arbitrary[Int]
+        } yield Qux(i, a, j)
+      )
+  }
+
+  case class Wub(x: Long)
+
+  object Wub {
+    implicit val eqWub: Eq[Wub] = Eq.by(_.x)
+    implicit val arbitraryWub: Arbitrary[Wub] = Arbitrary(Arbitrary.arbitrary[Long].map(Wub(_)))
+
+    val decodeWub: Decoder[Wub] = Decoder[Long].prepare(_.downField("x")).map(Wub(_))
+    val encodeWub: Encoder[Wub] = Encoder.instance(w => Json.obj("x" -> Json.fromLong(w.x)))
+  }
+
+  sealed trait Foo
+  case class Bar(i: Int, s: String) extends Foo
+  case class Baz(xs: List[String]) extends Foo
+  case class Bam(w: Wub, d: Double) extends Foo
+
+  sealed trait Mary
+  case object HadA extends Mary
+  case object LittleLamb extends Mary
+  object Mary {
+    implicit val eqMary: Eq[Mary] = Eq.fromUniversalEquals[Mary]
+  }
+
+  object Bar {
+    implicit val eqBar: Eq[Bar] = Eq.fromUniversalEquals
+    implicit val arbitraryBar: Arbitrary[Bar] = Arbitrary(
+      for {
+        i <- Arbitrary.arbitrary[Int]
+        s <- Arbitrary.arbitrary[String]
+      } yield Bar(i, s)
+    )
+
+    val decodeBar: Decoder[Bar] = Decoder.forProduct2("i", "s")(Bar.apply)
+    val encodeBar: Encoder[Bar] = Encoder.forProduct2("i", "s") {
+      case Bar(i, s) => (i, s)
+    }
+  }
+
+  object Baz {
+    implicit val eqBaz: Eq[Baz] = Eq.fromUniversalEquals
+    implicit val arbitraryBaz: Arbitrary[Baz] = Arbitrary(
+      Arbitrary.arbitrary[List[String]].map(Baz.apply)
+    )
+
+    implicit val decodeBaz: Decoder[Baz] = Decoder[List[String]].map(Baz(_))
+    implicit val encodeBaz: Encoder[Baz] = Encoder.instance {
+      case Baz(xs) => Json.fromValues(xs.map(Json.fromString))
+    }
+  }
+
+  object Bam {
+    implicit val eqBam: Eq[Bam] = Eq.fromUniversalEquals
+    implicit val arbitraryBam: Arbitrary[Bam] = Arbitrary(
+      for {
+        w <- Arbitrary.arbitrary[Wub]
+        d <- Arbitrary.arbitrary[Double]
+      } yield Bam(w, d)
+    )
+
+    val decodeBam: Decoder[Bam] = Decoder.forProduct2("w", "d")(Bam.apply)(Wub.decodeWub, implicitly)
+    val encodeBam: Encoder[Bam] = Encoder.forTypedProduct2[Bam, Wub, Double]("w", "d") {
+      case Bam(w, d) => (w, d)
+    }(Wub.encodeWub, implicitly)
+  }
+
+  object Foo {
+    implicit val eqFoo: Eq[Foo] = Eq.fromUniversalEquals
+
+    implicit val arbitraryFoo: Arbitrary[Foo] = Arbitrary(
+      Gen.oneOf(
+        Arbitrary.arbitrary[Bar],
+        Arbitrary.arbitrary[Baz],
+        Arbitrary.arbitrary[Bam]
+      )
+    )
+
+    val encodeFoo: Encoder[Foo] = Encoder.instance {
+      case bar @ Bar(_, _) => Json.obj("Bar" -> Bar.encodeBar(bar))
+      case baz @ Baz(_)    => Json.obj("Baz" -> Baz.encodeBaz(baz))
+      case bam @ Bam(_, _) => Json.obj("Bam" -> Bam.encodeBam(bam))
+    }
+
+    val decodeFoo: Decoder[Foo] = Decoder.instance { c =>
+      c.keys.map(_.toVector) match {
+        case Some(Vector("Bar")) => c.get("Bar")(Bar.decodeBar.widen)
+        case Some(Vector("Baz")) => c.get("Baz")(Baz.decodeBaz.widen)
+        case Some(Vector("Bam")) => c.get("Bam")(Bam.decodeBam.widen)
+        case _                   => Left(DecodingFailure("Foo", c.history))
+      }
+    }
+  }
+}

--- a/sanely/src/sanely/SanelyDecoder.scala
+++ b/sanely/src/sanely/SanelyDecoder.scala
@@ -60,7 +60,8 @@ object SanelyDecoder:
       '{
         new Decoder[P]:
           def apply(c: HCursor): Decoder.Result[P] =
-            ${ buildDecodeChain('c, fields, Nil) }
+            if !c.value.isObject then Left(DecodingFailure("Expected JSON object for product type", c.history))
+            else ${ buildDecodeChain('c, fields, Nil) }
       }
 
     private def deriveSum[S: Type, Types: Type, Labels: Type](

--- a/sanely/src/sanely/SanelyEncoder.scala
+++ b/sanely/src/sanely/SanelyEncoder.scala
@@ -67,13 +67,15 @@ object SanelyEncoder:
       def buildBranch(a: Expr[S], label: String, tpe: Type[?], enc: Expr[Encoder[?]], isSubTrait: Boolean): Expr[JsonObject] =
         tpe match
           case '[t] =>
-            val typedEnc = enc.asInstanceOf[Expr[Encoder.AsObject[t]]]
             if isSubTrait then
-              // Sub-trait: use encoder directly (it already wraps with variant name)
+              // Sub-trait: use AsObject encoder directly (it already wraps with variant name)
+              val typedEnc = enc.asInstanceOf[Expr[Encoder.AsObject[t]]]
               '{ $typedEnc.encodeObject($a.asInstanceOf[t]) }
             else
+              // Regular variant: use Encoder[t].apply() — may not be AsObject
+              val typedEnc = enc.asInstanceOf[Expr[Encoder[t]]]
               val labelExpr = Expr(label)
-              '{ JsonObject.singleton($labelExpr, Json.fromJsonObject($typedEnc.encodeObject($a.asInstanceOf[t]))) }
+              '{ JsonObject.singleton($labelExpr, $typedEnc($a.asInstanceOf[t])) }
 
       // Detect which variants are themselves sum types (sub-traits)
       val casesWithSubTrait = cases.map { case (label, tpe, enc) =>


### PR DESCRIPTION
## Summary
- Add `compat` Mill test module that runs circe's `AutoDerivedSuite` and `SemiautoDerivedSuite` — property-based codec law tests (munit + discipline + scalacheck) — backed by our library instead of circe-generic
- 160 checks pass across both suites, proving API + behavior compatibility with circe-generic
- Fix sum type encoder to not assume variant encoders are `AsObject` (e.g. `Baz.encodeBaz` is plain `Encoder[Baz]`)
- Fix product decoder to validate input is a JSON object, rejecting non-objects for empty case classes

## Test plan
- [x] `./mill compat.test` — all 160 law checks pass (AutoDerivedSuite: 38, SemiautoDerivedSuite: 122)
- [x] `./mill sanely.test` — all 52 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)