### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -8,7 +8,7 @@ val scala3Version = "3.8.2"
 object sanely extends ScalaModule with SonatypeCentralPublishModule {
   def scalaVersion = scala3Version
   def artifactName = "circe-sanely-auto"
-  def publishVersion = "0.1.0"
+  def publishVersion = "0.2.0"
 
   def pomSettings = PomSettings(
     description = "Drop-in replacement for circe's auto-derivation using sanely-automatic Scala 3 macros",


### PR DESCRIPTION
## Summary
- Bump publishVersion from 0.1.0 to 0.2.0
- Already published to Maven Central via `publishSonatypeCentral`

🤖 Generated with [Claude Code](https://claude.com/claude-code)