### PR TITLE
feat: add compile-time benchmark comparing sanely vs circe-generic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,17 +19,22 @@ Mill 1.1.2 build. Run from repo root:
 ./mill sanely.test              # run tests (utest)
 ./mill demo.run                 # run demo (product + sum round-trips)
 ./mill sanely.test.compile      # compile tests only
+./mill benchmark.sanely.compile # compile benchmark (our library)
+./mill benchmark.generic.compile # compile benchmark (circe-generic)
+bash bench.sh 5                 # run timed compile comparison (N iterations)
 ```
 
 **Do NOT run** `./mill __.compile` or bare `./mill` — use targeted module commands to avoid cache invalidation.
 
 ## Architecture
 
-Three Mill modules:
+Five Mill modules:
 
 - **`sanely/`** — Core library. Macro-based Encoder.AsObject and Decoder derivation.
 - **`sanely/test/`** — utest suite. Import `sanely.auto.given` to get instances.
 - **`demo/`** — Runnable examples. Depends on `sanely`.
+- **`benchmark/sanely`** — Compile-time benchmark using our library.
+- **`benchmark/generic`** — Compile-time benchmark using circe-generic (same source).
 
 ### Core source files (`sanely/src/sanely/`)
 
@@ -81,6 +86,13 @@ Circe test sources live at:
 - `circe/modules/tests/shared/src/main/scala/io/circe/tests/examples/package.scala` — shared test data types
 
 See `README.md` "Test Porting Plan" for the full 9-phase breakdown with expected challenges.
+
+## Mill: Shared Sources via `package.mill`
+
+`benchmark/package.mill` defines two modules sharing `benchmark/shared/src/` via `override def moduleDir = super.moduleDir / os.up / "shared"`. Key gotchas:
+- Mill 1.x: override `moduleDir` (public API), not `millSourcePath` (internal, will error)
+- `Task.Sources` can't use computed paths — sandbox restriction blocks `PathRef` creation
+- Nested modules inside plain `object` don't register; parent must `extends Module` or use `package.mill`
 
 ## Reference Repositories
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,32 @@ object MyType:
 - **No Shapeless dependency** — uses Scala 3 `Mirror` + `Expr.summonIgnoring`
 - **`derives` keyword** — works as-is via circe-core (no migration needed); `Encoder.AsObject.derived`/`Decoder.derived` are defined in circe-core itself, independent of circe-generic
 
+## Compile-Time Benchmark
+
+The whole point of this library is faster compile times. The benchmark compiles the same source code (~300 types across 9 files) against both `circe-sanely-auto` and `circe-generic`:
+
+```bash
+bash bench.sh 5   # 5 iterations per module, reports median
+```
+
+Results on an M3 Max MacBook Pro (Mill 1.1.2, Scala 3.8.2):
+
+| | Median compile time | |
+|---|---|---|
+| **circe-sanely-auto** | **3.77s** | |
+| **circe-generic** | **6.07s** | 1.6× slower |
+
+The benchmark includes: nested products, sealed trait hierarchies, generic type instantiations, wide case classes (22 fields × 8), and cross-domain compositions — representative of a real-world codebase. Times include Mill/JVM overhead.
+
+You can also compile and run each module individually:
+
+```bash
+./mill benchmark.sanely.compile   # compile with our library
+./mill benchmark.generic.compile  # compile with circe-generic
+./mill benchmark.sanely.run       # verify round-trips pass
+./mill benchmark.generic.run      # verify round-trips pass
+```
+
 ## Building
 
 Requires [Mill](https://mill-build.org/) (bootstrapped via `./mill` wrapper).
@@ -212,7 +238,6 @@ All circe auto-derivation roundtrip tests are ported and passing (52/52). The li
 
 ### Out of scope
 
-- ~~**Publish under `io.github.nguyenyou`**~~ — infrastructure task, not a code port
 - ~~**`derives` keyword support**~~ — works out of the box via circe-core; no action needed from this library
 - ~~**`Either[E, Self]` recursive container**~~ — circe doesn't test this; `disjunctionCodecs` requires explicit import and string keys
 - ~~**Compile error message quality**~~ — not testable in utest (compile errors can't be asserted at runtime)

--- a/bench.sh
+++ b/bench.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+N=${1:-5}
+echo "Compile-time benchmark: circe-sanely-auto vs circe-generic (N=$N)"
+echo "================================================================"
+
+for module in sanely generic; do
+  times=()
+  for i in $(seq 1 "$N"); do
+    rm -rf out/benchmark/$module
+    start=$(python3 -c 'import time; print(time.time())')
+    ./mill benchmark.$module.compile 2>/dev/null 1>/dev/null
+    end=$(python3 -c 'import time; print(time.time())')
+    elapsed=$(python3 -c "print(f'{$end - $start:.2f}')")
+    times+=("$elapsed")
+    echo "  benchmark.$module run $i: ${elapsed}s"
+  done
+
+  # compute median
+  median=$(printf '%s\n' "${times[@]}" | sort -n | awk -v n="$N" 'NR==int((n+1)/2){print}')
+  echo "benchmark.$module median: ${median}s (of ${times[*]})"
+  echo ""
+done

--- a/benchmark/package.mill
+++ b/benchmark/package.mill
@@ -1,0 +1,35 @@
+package build.benchmark
+
+import mill.*, scalalib.*
+
+object `package` extends mill.Module {
+
+  object sanely extends ScalaModule {
+    def scalaVersion = build.scala3Version
+    override def moduleDir = super.moduleDir / os.up / "shared"
+    def scalacOptions = Task {
+      super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
+    }
+    def moduleDeps = Seq(build.sanely)
+    def mvnDeps = Task {
+      super.mvnDeps() ++ Seq(
+        mvn"io.circe::circe-core:${build.circeVersion}",
+        mvn"io.circe::circe-parser:${build.circeVersion}",
+      )
+    }
+  }
+
+  object generic extends ScalaModule {
+    def scalaVersion = build.scala3Version
+    override def moduleDir = super.moduleDir / os.up / "shared"
+    def scalacOptions = Task {
+      super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
+    }
+    def mvnDeps = Task {
+      super.mvnDeps() ++ Seq(
+        mvn"io.circe::circe-generic:${build.circeVersion}",
+        mvn"io.circe::circe-parser:${build.circeVersion}",
+      )
+    }
+  }
+}

--- a/benchmark/shared/src/benchmark/CompileTimeBenchmark.scala
+++ b/benchmark/shared/src/benchmark/CompileTimeBenchmark.scala
@@ -1,0 +1,181 @@
+package benchmark
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+// ═══════════════════════════════════════════════════════════════════════
+// Wide case classes (stress field count × derivation)
+// ═══════════════════════════════════════════════════════════════════════
+case class Wide22A(f1: String, f2: Int, f3: Double, f4: Boolean, f5: String, f6: Int, f7: Double, f8: Boolean, f9: String, f10: Int, f11: String, f12: Int, f13: Double, f14: Boolean, f15: String, f16: Int, f17: Double, f18: Boolean, f19: String, f20: Int, f21: Double, f22: Boolean)
+case class Wide22B(g1: String, g2: Int, g3: Double, g4: Boolean, g5: String, g6: Int, g7: Double, g8: Boolean, g9: String, g10: Int, g11: String, g12: Int, g13: Double, g14: Boolean, g15: String, g16: Int, g17: Double, g18: Boolean, g19: String, g20: Int, g21: Double, g22: Boolean)
+case class Wide22C(h1: String, h2: Int, h3: Double, h4: Boolean, h5: String, h6: Int, h7: Double, h8: Boolean, h9: String, h10: Int, h11: String, h12: Int, h13: Double, h14: Boolean, h15: String, h16: Int, h17: Double, h18: Boolean, h19: String, h20: Int, h21: Double, h22: Boolean)
+case class Wide22D(i1: String, i2: Int, i3: Double, i4: Boolean, i5: String, i6: Int, i7: Double, i8: Boolean, i9: String, i10: Int, i11: String, i12: Int, i13: Double, i14: Boolean, i15: String, i16: Int, i17: Double, i18: Boolean, i19: String, i20: Int, i21: Double, i22: Boolean)
+case class Wide22E(j1: String, j2: Int, j3: Double, j4: Boolean, j5: String, j6: Int, j7: Double, j8: Boolean, j9: String, j10: Int, j11: String, j12: Int, j13: Double, j14: Boolean, j15: String, j16: Int, j17: Double, j18: Boolean, j19: String, j20: Int, j21: Double, j22: Boolean)
+case class Wide22F(k1: String, k2: Int, k3: Double, k4: Boolean, k5: String, k6: Int, k7: Double, k8: Boolean, k9: String, k10: Int, k11: String, k12: Int, k13: Double, k14: Boolean, k15: String, k16: Int, k17: Double, k18: Boolean, k19: String, k20: Int, k21: Double, k22: Boolean)
+case class Wide22G(l1: String, l2: Int, l3: Double, l4: Boolean, l5: String, l6: Int, l7: Double, l8: Boolean, l9: String, l10: Int, l11: String, l12: Int, l13: Double, l14: Boolean, l15: String, l16: Int, l17: Double, l18: Boolean, l19: String, l20: Int, l21: Double, l22: Boolean)
+case class Wide22H(m1: String, m2: Int, m3: Double, m4: Boolean, m5: String, m6: Int, m7: Double, m8: Boolean, m9: String, m10: Int, m11: String, m12: Int, m13: Double, m14: Boolean, m15: String, m16: Int, m17: Double, m18: Boolean, m19: String, m20: Int, m21: Double, m22: Boolean)
+
+object WideTypes:
+  private val w = ("a",1,1.0,true,"b",2,2.0,false,"c",3,"d",4,4.0,true,"e",5,5.0,false,"f",6,6.0,true)
+  def run(): Unit =
+    val a = Wide22A(w._1,w._2,w._3,w._4,w._5,w._6,w._7,w._8,w._9,w._10,w._11,w._12,w._13,w._14,w._15,w._16,w._17,w._18,w._19,w._20,w._21,w._22)
+    assert(decode[Wide22A](a.asJson.noSpaces) == Right(a))
+    val b = Wide22B(w._1,w._2,w._3,w._4,w._5,w._6,w._7,w._8,w._9,w._10,w._11,w._12,w._13,w._14,w._15,w._16,w._17,w._18,w._19,w._20,w._21,w._22)
+    assert(decode[Wide22B](b.asJson.noSpaces) == Right(b))
+    val c = Wide22C(w._1,w._2,w._3,w._4,w._5,w._6,w._7,w._8,w._9,w._10,w._11,w._12,w._13,w._14,w._15,w._16,w._17,w._18,w._19,w._20,w._21,w._22)
+    assert(decode[Wide22C](c.asJson.noSpaces) == Right(c))
+    val d = Wide22D(w._1,w._2,w._3,w._4,w._5,w._6,w._7,w._8,w._9,w._10,w._11,w._12,w._13,w._14,w._15,w._16,w._17,w._18,w._19,w._20,w._21,w._22)
+    assert(decode[Wide22D](d.asJson.noSpaces) == Right(d))
+    val e = Wide22E(w._1,w._2,w._3,w._4,w._5,w._6,w._7,w._8,w._9,w._10,w._11,w._12,w._13,w._14,w._15,w._16,w._17,w._18,w._19,w._20,w._21,w._22)
+    assert(decode[Wide22E](e.asJson.noSpaces) == Right(e))
+    val f = Wide22F(w._1,w._2,w._3,w._4,w._5,w._6,w._7,w._8,w._9,w._10,w._11,w._12,w._13,w._14,w._15,w._16,w._17,w._18,w._19,w._20,w._21,w._22)
+    assert(decode[Wide22F](f.asJson.noSpaces) == Right(f))
+    val g = Wide22G(w._1,w._2,w._3,w._4,w._5,w._6,w._7,w._8,w._9,w._10,w._11,w._12,w._13,w._14,w._15,w._16,w._17,w._18,w._19,w._20,w._21,w._22)
+    assert(decode[Wide22G](g.asJson.noSpaces) == Right(g))
+    val h = Wide22H(w._1,w._2,w._3,w._4,w._5,w._6,w._7,w._8,w._9,w._10,w._11,w._12,w._13,w._14,w._15,w._16,w._17,w._18,w._19,w._20,w._21,w._22)
+    assert(decode[Wide22H](h.asJson.noSpaces) == Right(h))
+
+// ═══════════════════════════════════════════════════════════════════════
+// Sum type variety (many distinct sealed hierarchies)
+// ═══════════════════════════════════════════════════════════════════════
+sealed trait HttpMethod
+case class GetMethod(cached: Boolean) extends HttpMethod
+case class PostMethod(idempotent: Boolean) extends HttpMethod
+case class PutMethod(upsert: Boolean) extends HttpMethod
+case class DeleteMethod(soft: Boolean) extends HttpMethod
+case class PatchMethod(partial: Boolean) extends HttpMethod
+
+sealed trait LogLevel
+case class TraceLevel(verbose: Boolean) extends LogLevel
+case class DebugLevel(module: String) extends LogLevel
+case class InfoLevel(source: String) extends LogLevel
+case class WarnLevel(stackTrace: Boolean) extends LogLevel
+case class ErrorLevel(fatal: Boolean) extends LogLevel
+
+sealed trait Shape
+case class CircleShape(radius: Double) extends Shape
+case class RectShape(width: Double, height: Double) extends Shape
+case class TriShape(a: Double, b: Double, c: Double) extends Shape
+case class EllipseShape(rx: Double, ry: Double) extends Shape
+case class PolygonShape(sides: Int, radius: Double) extends Shape
+
+sealed trait CurrencyType
+case class UsdCurrency(cents: Int) extends CurrencyType
+case class EurCurrency(cents: Int) extends CurrencyType
+case class GbpCurrency(pence: Int) extends CurrencyType
+case class JpyCurrency(yen: Int) extends CurrencyType
+case class ChfCurrency(rappen: Int) extends CurrencyType
+
+sealed trait Permission
+case class ReadPerm(resource: String) extends Permission
+case class WritePerm(resource: String) extends Permission
+case class AdminPerm(scope: String) extends Permission
+case class DeletePerm(resource: String, soft: Boolean) extends Permission
+case class ExecutePerm(action: String) extends Permission
+
+sealed trait NotifChannel
+case class EmailChan(to: String, subject: String) extends NotifChannel
+case class SmsChan(to: String) extends NotifChannel
+case class PushChan(token: String, badge: Int) extends NotifChannel
+case class SlackChan(channel: String, emoji: String) extends NotifChannel
+case class WebhookChan(url: String, secret: String) extends NotifChannel
+
+sealed trait CacheStrategy
+case class NoCache(reason: String) extends CacheStrategy
+case class TtlCache(seconds: Int) extends CacheStrategy
+case class LruCache(maxEntries: Int) extends CacheStrategy
+case class WriteThrough(batchSize: Int) extends CacheStrategy
+case class WriteBehind(delayMs: Int) extends CacheStrategy
+
+sealed trait ValidationError
+case class RequiredField(field: String) extends ValidationError
+case class InvalidFormat(field: String, expected: String) extends ValidationError
+case class OutOfRange(field: String, min: Double, max: Double) extends ValidationError
+case class TooLong(field: String, maxLen: Int) extends ValidationError
+case class CustomError(field: String, message: String) extends ValidationError
+
+object SumTypes:
+  def run(): Unit =
+    val m: HttpMethod = PostMethod(true); assert(decode[HttpMethod](m.asJson.noSpaces) == Right(m))
+    val l: LogLevel = WarnLevel(true); assert(decode[LogLevel](l.asJson.noSpaces) == Right(l))
+    val s: Shape = PolygonShape(6, 10.0); assert(decode[Shape](s.asJson.noSpaces) == Right(s))
+    val c: CurrencyType = EurCurrency(1599); assert(decode[CurrencyType](c.asJson.noSpaces) == Right(c))
+    val p: Permission = DeletePerm("users", true); assert(decode[Permission](p.asJson.noSpaces) == Right(p))
+    val n: NotifChannel = SlackChan("#alerts", ":warning:"); assert(decode[NotifChannel](n.asJson.noSpaces) == Right(n))
+    val cs: CacheStrategy = LruCache(1000); assert(decode[CacheStrategy](cs.asJson.noSpaces) == Right(cs))
+    val v: ValidationError = OutOfRange("age", 0, 200); assert(decode[ValidationError](v.asJson.noSpaces) == Right(v))
+
+// ═══════════════════════════════════════════════════════════════════════
+// More flat products
+// ═══════════════════════════════════════════════════════════════════════
+case class Rgb(r: Int, g: Int, b: Int)
+case class Hsl(h: Double, s: Double, l: Double)
+case class Rgba(r: Int, g: Int, b: Int, a: Double)
+case class Vec2(x: Double, y: Double)
+case class Vec3(x: Double, y: Double, z: Double)
+case class Vec4(x: Double, y: Double, z: Double, w: Double)
+case class Matrix2x2(m00: Double, m01: Double, m10: Double, m11: Double)
+case class Rect2(x: Double, y: Double, width: Double, height: Double)
+case class Range2(min: Double, max: Double, step: Double)
+case class DateRange3(start: String, end: String)
+case class TimeSlot(day: String, startHour: Int, endHour: Int)
+case class Interval2(from: Long, to: Long, unit: String)
+case class Locale4(language: String, country: String, variant: String)
+case class Version3(major: Int, minor: Int, patch: Int, preRelease: String)
+case class Semver(version: Version3, buildMeta: String)
+case class FeatureFlag2(name: String, enabled: Boolean, rolloutPct: Double, description: String)
+case class Experiment2(id: String, name: String, variants: List[String], trafficPct: Double)
+case class ABTest(experiment: Experiment2, winner: String, confidence: Double, sampleSize: Int)
+case class ConnectionPool(minSize: Int, maxSize: Int, idleTimeoutMs: Int, acquireTimeoutMs: Int, validationQuery: String)
+case class DatabaseConfig(host: String, port: Int, database: String, username: String, ssl: Boolean, pool: ConnectionPool)
+case class RedisConfig(host: String, port: Int, database: Int, maxRetries: Int, timeoutMs: Int)
+case class KafkaConfig(brokers: List[String], groupId: String, autoCommit: Boolean, maxPollRecords: Int)
+case class S3Config(bucket: String, region: String, prefix: String, encryption: Boolean)
+case class SmtpConfig(host: String, port: Int, username: String, tls: Boolean, fromAddress: String, fromName: String)
+
+object FlatProducts:
+  def run(): Unit =
+    val rgb = Rgb(255, 128, 0); assert(decode[Rgb](rgb.asJson.noSpaces) == Right(rgb))
+    val hsl = Hsl(180.0, 0.5, 0.6); assert(decode[Hsl](hsl.asJson.noSpaces) == Right(hsl))
+    val rgba = Rgba(0, 0, 0, 0.5); assert(decode[Rgba](rgba.asJson.noSpaces) == Right(rgba))
+    val v2 = Vec2(1, 2); assert(decode[Vec2](v2.asJson.noSpaces) == Right(v2))
+    val v3 = Vec3(1, 2, 3); assert(decode[Vec3](v3.asJson.noSpaces) == Right(v3))
+    val v4 = Vec4(1, 2, 3, 4); assert(decode[Vec4](v4.asJson.noSpaces) == Right(v4))
+    val mat = Matrix2x2(1, 0, 0, 1); assert(decode[Matrix2x2](mat.asJson.noSpaces) == Right(mat))
+    val rect = Rect2(0, 0, 100, 50); assert(decode[Rect2](rect.asJson.noSpaces) == Right(rect))
+    val rng = Range2(0, 100, 5); assert(decode[Range2](rng.asJson.noSpaces) == Right(rng))
+    val dr = DateRange3("2024-01", "2024-12"); assert(decode[DateRange3](dr.asJson.noSpaces) == Right(dr))
+    val ts = TimeSlot("Mon", 9, 17); assert(decode[TimeSlot](ts.asJson.noSpaces) == Right(ts))
+    val iv = Interval2(0, 3600, "s"); assert(decode[Interval2](iv.asJson.noSpaces) == Right(iv))
+    val loc = Locale4("en", "US", ""); assert(decode[Locale4](loc.asJson.noSpaces) == Right(loc))
+    val ver = Version3(1, 2, 3, "beta"); assert(decode[Version3](ver.asJson.noSpaces) == Right(ver))
+    val sv = Semver(ver, "abc123"); assert(decode[Semver](sv.asJson.noSpaces) == Right(sv))
+    val feat = FeatureFlag2("dark", true, 50.0, "Dark theme"); assert(decode[FeatureFlag2](feat.asJson.noSpaces) == Right(feat))
+    val exp = Experiment2("e1", "btn", List("red", "blue"), 10.0); assert(decode[Experiment2](exp.asJson.noSpaces) == Right(exp))
+    val ab = ABTest(exp, "blue", 0.95, 10000); assert(decode[ABTest](ab.asJson.noSpaces) == Right(ab))
+    val pool = ConnectionPool(5, 20, 60000, 5000, "SELECT 1")
+    val db = DatabaseConfig("localhost", 5432, "mydb", "admin", true, pool); assert(decode[DatabaseConfig](db.asJson.noSpaces) == Right(db))
+    val redis = RedisConfig("localhost", 6379, 0, 3, 5000); assert(decode[RedisConfig](redis.asJson.noSpaces) == Right(redis))
+    val kafka = KafkaConfig(List("broker1:9092", "broker2:9092"), "my-group", false, 500); assert(decode[KafkaConfig](kafka.asJson.noSpaces) == Right(kafka))
+    val s3 = S3Config("my-bucket", "us-east-1", "data/", true); assert(decode[S3Config](s3.asJson.noSpaces) == Right(s3))
+    val smtp = SmtpConfig("smtp.example.com", 587, "noreply", true, "noreply@example.com", "My App"); assert(decode[SmtpConfig](smtp.asJson.noSpaces) == Right(smtp))
+
+// ═══════════════════════════════════════════════════════════════════════
+// Main
+// ═══════════════════════════════════════════════════════════════════════
+object Main:
+  def main(args: Array[String]): Unit =
+    benchmark.domain1.Domain1.run()
+    benchmark.domain2.Domain2.run()
+    benchmark.domain3.Domain3.run()
+    benchmark.domain4.Domain4.run()
+    benchmark.domain5.Domain5.run()
+    benchmark.domain6.Domain6.run()
+    benchmark.domain7.Domain7.run()
+    benchmark.domain8.Domain8.run()
+    WideTypes.run()
+    SumTypes.run()
+    FlatProducts.run()
+    println("All domains passed!")

--- a/benchmark/shared/src/benchmark/domain1_users.scala
+++ b/benchmark/shared/src/benchmark/domain1_users.scala
@@ -1,0 +1,62 @@
+package benchmark.domain1
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+case class UserId(value: String)
+case class Email(address: String)
+case class PhoneNumber(countryCode: String, number: String)
+case class UserName(first: String, middle: String, last: String)
+case class StreetAddress(line1: String, line2: String, city: String, state: String, zip: String, country: String)
+case class GeoCoord(lat: Double, lng: Double)
+case class UserBio(summary: String, website: String, company: String)
+case class UserProfile(name: UserName, email: Email, phone: PhoneNumber, bio: UserBio)
+case class NotifPrefs(email: Boolean, sms: Boolean, push: Boolean, digest: String)
+case class DisplayPrefs(theme: String, language: String, timezone: String, fontSize: Int)
+case class PrivacyPrefs(profilePublic: Boolean, showEmail: Boolean, showPhone: Boolean)
+case class Preferences(notif: NotifPrefs, display: DisplayPrefs, privacy: PrivacyPrefs)
+case class UserAccount(id: UserId, profile: UserProfile, preferences: Preferences, createdAt: String, updatedAt: String)
+
+sealed trait UserRole
+case class AdminRole(level: Int, permissions: List[String]) extends UserRole
+case class EditorRole(sections: List[String], canPublish: Boolean) extends UserRole
+case class ViewerRole(restricted: Boolean) extends UserRole
+case class GuestRole(expiresAt: String) extends UserRole
+case class SuperAdminRole(region: String, canDelegate: Boolean) extends UserRole
+case class ModeratorRole(forums: List[String], canBan: Boolean) extends UserRole
+
+sealed trait AccountStatus
+case class ActiveAccount(since: String) extends AccountStatus
+case class SuspendedAccount(reason: String, until: String) extends AccountStatus
+case class DeactivatedAccount(deactivatedAt: String) extends AccountStatus
+case class PendingVerification(token: String, expiresAt: String) extends AccountStatus
+case class LockedAccount(failedAttempts: Int, lockedAt: String) extends AccountStatus
+
+case class Session(id: String, userId: UserId, startedAt: String, lastActiveAt: String, ipAddress: String, userAgent: String)
+case class LoginAttempt(userId: UserId, success: Boolean, timestamp: String, ipAddress: String, method: String)
+case class AuditEntry(action: String, userId: UserId, targetId: String, timestamp: String, details: String)
+
+object Domain1:
+  def run(): Unit =
+    val name = UserName("Alice", "M", "Smith")
+    val profile = UserProfile(name, Email("a@b.com"), PhoneNumber("+1", "5551234"), UserBio("dev", "x.com", "Acme"))
+    val prefs = Preferences(NotifPrefs(true, false, true, "weekly"), DisplayPrefs("dark", "en", "UTC", 14), PrivacyPrefs(true, false, false))
+    val account = UserAccount(UserId("u1"), profile, prefs, "2024-01-01", "2024-06-01")
+    assert(decode[UserAccount](account.asJson.noSpaces) == Right(account))
+
+    val role: UserRole = ModeratorRole(List("general", "help"), true)
+    assert(decode[UserRole](role.asJson.noSpaces) == Right(role))
+
+    val status: AccountStatus = SuspendedAccount("spam", "2024-12-01")
+    assert(decode[AccountStatus](status.asJson.noSpaces) == Right(status))
+
+    val session = Session("s1", UserId("u1"), "2024-03-01T10:00:00Z", "2024-03-01T11:30:00Z", "1.2.3.4", "Chrome/120")
+    assert(decode[Session](session.asJson.noSpaces) == Right(session))
+
+    val login = LoginAttempt(UserId("u1"), true, "2024-03-01T10:00:00Z", "1.2.3.4", "password")
+    assert(decode[LoginAttempt](login.asJson.noSpaces) == Right(login))
+
+    val audit = AuditEntry("login", UserId("u1"), "u1", "2024-03-01T10:00:00Z", "successful login")
+    assert(decode[AuditEntry](audit.asJson.noSpaces) == Right(audit))

--- a/benchmark/shared/src/benchmark/domain2_ecommerce.scala
+++ b/benchmark/shared/src/benchmark/domain2_ecommerce.scala
@@ -1,0 +1,68 @@
+package benchmark.domain2
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+case class Money(amount: Double, currency: String)
+case class ProductId(value: String)
+case class Sku(code: String)
+case class Barcode(format: String, value: String)
+case class Dimensions(width: Double, height: Double, depth: Double, unit: String)
+case class Weight(value: Double, unit: String)
+case class ProductImage(url: String, alt: String, width: Int, height: Int, isPrimary: Boolean)
+case class ProductVariant(sku: Sku, barcode: Barcode, color: String, size: String, price: Money, compareAtPrice: Money, stock: Int)
+case class ProductMeta(brand: String, manufacturer: String, countryOfOrigin: String, material: String)
+case class ProductInfo(id: ProductId, name: String, description: String, meta: ProductMeta, dimensions: Dimensions, weight: Weight, images: List[ProductImage], variants: List[ProductVariant], tags: List[String])
+
+case class CartItem(productId: ProductId, variantSku: Sku, quantity: Int, unitPrice: Money)
+case class Discount(code: String, description: String, amount: Money, percentage: Double)
+case class Cart(items: List[CartItem], discounts: List[Discount], subtotal: Money, tax: Money, shipping: Money, total: Money)
+
+sealed trait PaymentMethod
+case class CreditCardPay(last4: String, brand: String, expMonth: Int, expYear: Int) extends PaymentMethod
+case class BankTransferPay(bankName: String, accountLast4: String, routingLast4: String) extends PaymentMethod
+case class DigitalWalletPay(provider: String, email: String) extends PaymentMethod
+case class GiftCardPay(code: String, pin: String, balance: Money) extends PaymentMethod
+case class CryptoPay(wallet: String, network: String, txHash: String) extends PaymentMethod
+case class BuyNowPayLater(provider: String, installments: Int, monthlyAmount: Money) extends PaymentMethod
+
+sealed trait OrderStatus
+case class OrderPending(estimatedShip: String) extends OrderStatus
+case class OrderConfirmed(confirmedAt: String, estimatedDelivery: String) extends OrderStatus
+case class OrderProcessing(startedAt: String, warehouseId: String) extends OrderStatus
+case class OrderShipped(carrier: String, tracking: String, shippedAt: String) extends OrderStatus
+case class OrderOutForDelivery(estimatedArrival: String, driverName: String) extends OrderStatus
+case class OrderDelivered(deliveredAt: String, signature: String, photoUrl: String) extends OrderStatus
+case class OrderCancelled(reason: String, cancelledAt: String, refundAmount: Double) extends OrderStatus
+case class OrderReturned(returnReason: String, returnedAt: String, refundStatus: String) extends OrderStatus
+
+case class ShippingInfo(recipientName: String, street: String, city: String, state: String, zip: String, phone: String, instructions: String)
+case class OrderSummary(id: String, itemCount: Int, total: Money, payment: PaymentMethod, status: OrderStatus, shipping: ShippingInfo)
+
+case class Review(productId: ProductId, userId: String, rating: Int, title: String, body: String, helpful: Int, verified: Boolean, createdAt: String)
+case class Wishlist(id: String, name: String, items: List[ProductId], isPublic: Boolean, createdAt: String)
+
+object Domain2:
+  def run(): Unit =
+    val img = ProductImage("http://x.com/img.jpg", "widget", 800, 600, true)
+    val variant = ProductVariant(Sku("SKU-001"), Barcode("EAN13", "5901234123457"), "red", "L", Money(29.99, "USD"), Money(39.99, "USD"), 42)
+    val product = ProductInfo(ProductId("p1"), "Widget", "A fine widget", ProductMeta("Acme", "Acme Corp", "US", "steel"),
+      Dimensions(10, 5, 3, "cm"), Weight(0.5, "kg"), List(img), List(variant), List("tools", "sale"))
+    assert(decode[ProductInfo](product.asJson.noSpaces) == Right(product))
+
+    val discount = Discount("SAVE10", "10% off", Money(6.00, "USD"), 10.0)
+    val cart = Cart(List(CartItem(ProductId("p1"), Sku("SKU-001"), 2, Money(29.99, "USD"))),
+      List(discount), Money(59.98, "USD"), Money(5.40, "USD"), Money(5.00, "USD"), Money(64.38, "USD"))
+    assert(decode[Cart](cart.asJson.noSpaces) == Right(cart))
+
+    val order = OrderSummary("ord-1", 3, Money(65.38, "USD"), CreditCardPay("4242", "visa", 12, 2026),
+      OrderShipped("UPS", "1Z999", "2024-03-01"), ShippingInfo("Bob", "456 Oak", "LA", "CA", "90001", "555-0123", "Leave at door"))
+    assert(decode[OrderSummary](order.asJson.noSpaces) == Right(order))
+
+    val review = Review(ProductId("p1"), "u1", 5, "Great!", "Love it", 12, true, "2024-03-15")
+    assert(decode[Review](review.asJson.noSpaces) == Right(review))
+
+    val wishlist = Wishlist("w1", "Birthday", List(ProductId("p1"), ProductId("p2")), false, "2024-01-01")
+    assert(decode[Wishlist](wishlist.asJson.noSpaces) == Right(wishlist))

--- a/benchmark/shared/src/benchmark/domain3_cms.scala
+++ b/benchmark/shared/src/benchmark/domain3_cms.scala
@@ -1,0 +1,72 @@
+package benchmark.domain3
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+case class ContentId(value: String)
+case class Slug(value: String)
+case class TagInfo(name: String, slug: Slug, color: String)
+case class CategoryInfo(name: String, slug: Slug, parentSlug: String, description: String)
+case class AuthorInfo(name: String, email: String, avatar: String, bio: String, socialLinks: List[String])
+case class SeoMeta(title: String, description: String, keywords: List[String], canonical: String, ogImage: String)
+case class MediaAsset(url: String, mimeType: String, sizeBytes: Int, alt: String, width: Int, height: Int)
+
+sealed trait ContentBlock
+case class TextBlock(markdown: String) extends ContentBlock
+case class HeadingBlock(level: Int, text: String, anchor: String) extends ContentBlock
+case class ImageBlock(url: String, caption: String, width: Int, height: Int, alignment: String) extends ContentBlock
+case class CodeBlock(language: String, source: String, filename: String, highlighted: Boolean) extends ContentBlock
+case class QuoteBlock(text: String, attribution: String, source: String) extends ContentBlock
+case class EmbedBlock(provider: String, url: String, width: Int, height: Int) extends ContentBlock
+case class TableBlock(headers: List[String], rowCount: Int, caption: String) extends ContentBlock
+case class CalloutBlock(style: String, title: String, body: String) extends ContentBlock
+
+sealed trait PublishState
+case class DraftState(lastEditedAt: String, wordCount: Int) extends PublishState
+case class InReviewState(reviewer: String, submittedAt: String, notes: String) extends PublishState
+case class ScheduledState(publishAt: String, timezone: String) extends PublishState
+case class PublishedState(publishedAt: String, url: String, views: Int) extends PublishState
+case class ArchivedState(archivedAt: String, reason: String) extends PublishState
+case class UnpublishedState(unpublishedAt: String, previousUrl: String) extends PublishState
+
+case class Article(id: ContentId, slug: Slug, title: String, subtitle: String, author: AuthorInfo,
+  blocks: List[ContentBlock], tags: List[TagInfo], category: CategoryInfo, seo: SeoMeta,
+  state: PublishState, readTimeMin: Int, featured: Boolean)
+
+case class Comment2(id: String, author: String, body: String, createdAt: String, likes: Int, parentId: String)
+case class Newsletter(id: String, subject: String, preheader: String, blocks: List[ContentBlock], sentAt: String, recipientCount: Int)
+case class Redirect(fromPath: String, toPath: String, statusCode: Int, createdAt: String)
+case class SiteConfig(name: String, domain: String, defaultLocale: String, supportedLocales: List[String], analyticsId: String)
+
+object Domain3:
+  def run(): Unit =
+    val blocks: List[ContentBlock] = List(
+      HeadingBlock(1, "Introduction", "intro"),
+      TextBlock("# Hello world"),
+      ImageBlock("img.png", "A photo", 800, 600, "center"),
+      CodeBlock("scala", "val x = 1", "Main.scala", true),
+      QuoteBlock("Be kind", "Unknown", "Twitter"),
+      EmbedBlock("youtube", "https://youtube.com/watch?v=x", 560, 315),
+      TableBlock(List("Name", "Age"), 10, "Users"),
+      CalloutBlock("info", "Note", "This is important"))
+    val author = AuthorInfo("Jane", "j@b.com", "av.png", "Writer", List("https://twitter.com/jane"))
+    val article = Article(ContentId("a1"), Slug("hello"), "Hello", "World", author, blocks,
+      List(TagInfo("scala", Slug("scala"), "#ff0000")),
+      CategoryInfo("Tech", Slug("tech"), "", "Technology articles"),
+      SeoMeta("Hello", "An intro", List("scala"), "https://blog.com/hello", "https://blog.com/og.png"),
+      PublishedState("2024-03-01", "https://blog.com/hello", 1500), 5, true)
+    assert(decode[Article](article.asJson.noSpaces) == Right(article))
+
+    val comment = Comment2("c1", "reader", "Great article!", "2024-03-02", 5, "")
+    assert(decode[Comment2](comment.asJson.noSpaces) == Right(comment))
+
+    val newsletter = Newsletter("n1", "Weekly Digest", "Top stories this week", List(TextBlock("hello")), "2024-03-07", 5000)
+    assert(decode[Newsletter](newsletter.asJson.noSpaces) == Right(newsletter))
+
+    val redirect = Redirect("/old-path", "/new-path", 301, "2024-01-15")
+    assert(decode[Redirect](redirect.asJson.noSpaces) == Right(redirect))
+
+    val config = SiteConfig("My Blog", "blog.com", "en-US", List("en-US", "es", "fr"), "GA-12345")
+    assert(decode[SiteConfig](config.asJson.noSpaces) == Right(config))

--- a/benchmark/shared/src/benchmark/domain4_monitoring.scala
+++ b/benchmark/shared/src/benchmark/domain4_monitoring.scala
@@ -1,0 +1,73 @@
+package benchmark.domain4
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+case class MetricName(value: String)
+case class LabelPair(key: String, value: String)
+case class Timestamp(epochMs: Long)
+case class DataPoint(timestamp: Timestamp, value: Double)
+case class Histogram(buckets: List[Double], counts: List[Int], sum: Double, count: Int)
+case class Summary(quantiles: List[Double], values: List[Double], sum: Double, count: Int)
+case class TimeSeries(name: MetricName, labels: List[LabelPair], points: List[DataPoint])
+
+sealed trait MetricType
+case class CounterMetric(total: Double, created: Timestamp) extends MetricType
+case class GaugeMetric(value: Double) extends MetricType
+case class HistogramMetric(histogram: Histogram) extends MetricType
+case class SummaryMetric(summary: Summary) extends MetricType
+
+sealed trait AlertSeverity
+case class CriticalSev(escalateAfterMin: Int, pageOnCall: Boolean) extends AlertSeverity
+case class WarningSev(autoResolveAfterMin: Int) extends AlertSeverity
+case class InfoSev(logOnly: Boolean) extends AlertSeverity
+
+sealed trait AlertCondition
+case class ThresholdAbove(metric: MetricName, threshold: Double, durationSec: Int) extends AlertCondition
+case class ThresholdBelow(metric: MetricName, threshold: Double, durationSec: Int) extends AlertCondition
+case class RateOfChange(metric: MetricName, maxDelta: Double, windowSec: Int) extends AlertCondition
+case class Absence(metric: MetricName, timeoutSec: Int) extends AlertCondition
+case class AnomalyDetection(metric: MetricName, sensitivity: Double, seasonality: String) extends AlertCondition
+
+sealed trait AlertState
+case class AlertFiring(since: Timestamp, value: Double) extends AlertState
+case class AlertPending(since: Timestamp, value: Double) extends AlertState
+case class AlertResolved(resolvedAt: Timestamp, duration: Long) extends AlertState
+case class AlertSilenced(silencedBy: String, until: Timestamp, reason: String) extends AlertState
+case class AlertAcked(ackedBy: String, ackedAt: Timestamp, note: String) extends AlertState
+
+case class AlertRule(name: String, condition: AlertCondition, severity: AlertSeverity, notifyChannels: List[String], cooldownMin: Int)
+case class AlertInstance(rule: AlertRule, state: AlertState, labels: List[LabelPair])
+
+case class ServiceHealth(name: String, version: String, healthy: Boolean, uptime: Double, latencyP50: Double, latencyP95: Double, latencyP99: Double, errorRate: Double, requestRate: Double)
+case class DependencyHealth(name: String, healthy: Boolean, latencyMs: Double, errorRate: Double)
+case class HealthReport(service: ServiceHealth, dependencies: List[DependencyHealth], checkedAt: Timestamp)
+
+case class LogEntry(timestamp: Timestamp, level: String, logger: String, message: String, traceId: String, spanId: String)
+case class SpanInfo(traceId: String, spanId: String, parentId: String, operation: String, service: String, durationMs: Double, status: String, tags: List[LabelPair])
+
+object Domain4:
+  def run(): Unit =
+    val ts = Timestamp(1709251200000L)
+    val series = TimeSeries(MetricName("cpu"), List(LabelPair("host", "n1")), List(DataPoint(ts, 42.0), DataPoint(Timestamp(ts.epochMs + 60000), 43.5)))
+    assert(decode[TimeSeries](series.asJson.noSpaces) == Right(series))
+
+    val mt: MetricType = HistogramMetric(Histogram(List(0.1, 0.5, 1.0), List(10, 25, 50), 75.5, 50))
+    assert(decode[MetricType](mt.asJson.noSpaces) == Right(mt))
+
+    val rule = AlertRule("high-cpu", ThresholdAbove(MetricName("cpu"), 90.0, 300), CriticalSev(15, true), List("slack", "pagerduty"), 60)
+    val alert = AlertInstance(rule, AlertFiring(ts, 95.0), List(LabelPair("host", "n1")))
+    assert(decode[AlertInstance](alert.asJson.noSpaces) == Right(alert))
+
+    val health = ServiceHealth("api", "2.1.0", true, 99.99, 12.5, 45.0, 150.0, 0.01, 1500.0)
+    val depHealth = DependencyHealth("postgres", true, 2.5, 0.001)
+    val report = HealthReport(health, List(depHealth), ts)
+    assert(decode[HealthReport](report.asJson.noSpaces) == Right(report))
+
+    val log = LogEntry(ts, "ERROR", "com.app.Api", "Connection refused", "trace-123", "span-456")
+    assert(decode[LogEntry](log.asJson.noSpaces) == Right(log))
+
+    val span = SpanInfo("trace-123", "span-456", "span-000", "GET /api/users", "api-gateway", 45.2, "OK", List(LabelPair("http.method", "GET")))
+    assert(decode[SpanInfo](span.asJson.noSpaces) == Right(span))

--- a/benchmark/shared/src/benchmark/domain5_infra.scala
+++ b/benchmark/shared/src/benchmark/domain5_infra.scala
@@ -1,0 +1,84 @@
+package benchmark.domain5
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+// API Gateway
+case class RateLimit(requestsPerSecond: Int, burstSize: Int, windowMs: Int)
+case class Timeout(connectMs: Int, readMs: Int, writeMs: Int, idleMs: Int)
+case class RetryPolicy(maxRetries: Int, backoffMs: Int, backoffMultiplier: Double, retryOn: List[Int])
+case class CircuitBreaker(failureThreshold: Int, resetTimeoutMs: Int, halfOpenRequests: Int, failureRatePct: Double)
+case class HealthCheck(path: String, intervalMs: Int, timeoutMs: Int, healthyThreshold: Int, unhealthyThreshold: Int)
+
+sealed trait AuthScheme
+case class ApiKeyAuth(headerName: String, required: Boolean) extends AuthScheme
+case class BearerTokenAuth(issuer: String, audience: String, algorithms: List[String]) extends AuthScheme
+case class BasicAuth(realm: String) extends AuthScheme
+case class OAuth2Auth(provider: String, scopes: List[String], callbackUrl: String, pkce: Boolean) extends AuthScheme
+case class MtlsAuth(caBundle: String, requireClientCert: Boolean) extends AuthScheme
+
+case class CorsConfig(allowedOrigins: List[String], allowedMethods: List[String], allowedHeaders: List[String], maxAgeSec: Int, credentials: Boolean)
+case class RouteConfig(path: String, methods: List[String], auth: AuthScheme, rateLimit: RateLimit,
+  timeout: Timeout, retry: RetryPolicy, circuitBreaker: CircuitBreaker, cors: CorsConfig)
+
+// Deployment
+sealed trait DeployStrategy
+case class RollingDeploy(maxUnavailable: Int, maxSurge: Int) extends DeployStrategy
+case class BlueGreenDeploy(activeColor: String, testEndpoint: String) extends DeployStrategy
+case class CanaryDeploy(initialPct: Int, stepPct: Int, intervalSec: Int, maxPct: Int) extends DeployStrategy
+case class RecreateDeploy(drainTimeoutSec: Int) extends DeployStrategy
+
+case class ResourceLimits(cpuMillis: Int, memoryMb: Int, diskMb: Int)
+case class ContainerPort(name: String, port: Int, protocol: String)
+case class EnvVar(name: String, value: String, secret: Boolean)
+case class VolumeMount(name: String, mountPath: String, readOnly: Boolean)
+case class ContainerSpec(image: String, tag: String, ports: List[ContainerPort], env: List[EnvVar], resources: ResourceLimits, volumes: List[VolumeMount], command: List[String])
+case class DeploymentSpec(name: String, replicas: Int, strategy: DeployStrategy, container: ContainerSpec, healthCheck: HealthCheck)
+
+// DNS & Networking
+case class DnsRecord(name: String, recordType: String, value: String, ttl: Int, priority: Int)
+case class LoadBalancerConfig(algorithm: String, healthCheckPath: String, stickySession: Boolean, drainTimeout: Int)
+case class TlsCert(domain: String, issuer: String, expiresAt: String, autoRenew: Boolean)
+case class IngressRule(host: String, path: String, serviceName: String, servicePort: Int, tls: TlsCert)
+
+// Service mesh
+case class ServiceEndpoint(host: String, port: Int, weight: Int, zone: String)
+case class ServiceRegistry(name: String, version: String, endpoints: List[ServiceEndpoint], tags: List[String])
+case class TrafficPolicy(connectionPool: Int, outlierDetection: Boolean, loadBalancer: String, retries: Int)
+
+object Domain5:
+  def run(): Unit =
+    val route = RouteConfig("/api/v1/users", List("GET", "POST"),
+      BearerTokenAuth("auth.example.com", "api", List("RS256")),
+      RateLimit(100, 200, 60000), Timeout(5000, 30000, 30000, 120000),
+      RetryPolicy(3, 1000, 2.0, List(502, 503)),
+      CircuitBreaker(5, 60000, 2, 50.0),
+      CorsConfig(List("https://app.example.com"), List("GET", "POST"), List("Authorization"), 86400, true))
+    assert(decode[RouteConfig](route.asJson.noSpaces) == Right(route))
+
+    val container = ContainerSpec("myapp", "v2.1.0",
+      List(ContainerPort("http", 8080, "TCP")),
+      List(EnvVar("DB_URL", "postgres://...", false), EnvVar("API_KEY", "***", true)),
+      ResourceLimits(1000, 512, 1024),
+      List(VolumeMount("data", "/data", false)),
+      List("java", "-jar", "app.jar"))
+    val deploy = DeploymentSpec("myapp", 3, CanaryDeploy(10, 10, 300, 100), container,
+      HealthCheck("/health", 10000, 3000, 3, 2))
+    assert(decode[DeploymentSpec](deploy.asJson.noSpaces) == Right(deploy))
+
+    val dns = DnsRecord("api.example.com", "A", "1.2.3.4", 300, 0)
+    assert(decode[DnsRecord](dns.asJson.noSpaces) == Right(dns))
+
+    val ingress = IngressRule("api.example.com", "/", "api-svc", 8080,
+      TlsCert("*.example.com", "LetsEncrypt", "2025-06-01", true))
+    assert(decode[IngressRule](ingress.asJson.noSpaces) == Right(ingress))
+
+    val registry = ServiceRegistry("user-service", "3.0.0",
+      List(ServiceEndpoint("10.0.0.1", 8080, 100, "us-east-1a"), ServiceEndpoint("10.0.0.2", 8080, 100, "us-east-1b")),
+      List("production", "critical"))
+    assert(decode[ServiceRegistry](registry.asJson.noSpaces) == Right(registry))
+
+    val policy = TrafficPolicy(100, true, "round-robin", 3)
+    assert(decode[TrafficPolicy](policy.asJson.noSpaces) == Right(policy))

--- a/benchmark/shared/src/benchmark/domain6_analytics.scala
+++ b/benchmark/shared/src/benchmark/domain6_analytics.scala
@@ -1,0 +1,76 @@
+package benchmark.domain6
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+case class SessionId(value: String)
+case class EventId(value: String)
+case class DeviceInfo(deviceType: String, os: String, osVersion: String, browser: String, browserVersion: String, screenWidth: Int, screenHeight: Int, touchEnabled: Boolean)
+case class GeoInfo(country: String, region: String, city: String, postalCode: String, lat: Double, lng: Double, isp: String)
+case class UTMParams(source: String, medium: String, campaign: String, term: String, content: String)
+case class ReferrerInfo(url: String, domain: String, medium: String, campaign: String)
+case class UserSegment(id: String, name: String, rules: List[String])
+
+sealed trait AnalyticsEvent
+case class PageView(url: String, referrer: String, title: String, durationMs: Int) extends AnalyticsEvent
+case class ButtonClick(elementId: String, label: String, page: String, x: Int, y: Int) extends AnalyticsEvent
+case class FormSubmit(formId: String, fieldCount: Int, success: Boolean, errorFields: List[String]) extends AnalyticsEvent
+case class SearchQuery(query: String, resultCount: Int, clickedResult: Boolean, position: Int) extends AnalyticsEvent
+case class PurchaseEvent(orderId: String, amount: Double, itemCount: Int, currency: String) extends AnalyticsEvent
+case class SignupEvent(method: String, referralCode: String, step: Int) extends AnalyticsEvent
+case class ErrorEvent(errorType: String, message: String, stackTrace: String, page: String) extends AnalyticsEvent
+case class VideoEvent(videoId: String, action: String, positionSec: Double, durationSec: Double) extends AnalyticsEvent
+
+case class EventEnvelope(id: EventId, sessionId: SessionId, userId: String, timestamp: Long,
+  device: DeviceInfo, geo: GeoInfo, utm: UTMParams, referrer: ReferrerInfo, event: AnalyticsEvent)
+
+// Aggregation types
+case class MetricAgg(name: String, value: Double, count: Int, min: Double, max: Double, avg: Double)
+case class FunnelStep(name: String, count: Int, conversionRate: Double, dropoffRate: Double)
+case class CohortBucket(period: String, size: Int, retained: List[Double])
+case class SegmentBreakdown(segment: UserSegment, metrics: List[MetricAgg])
+case class DailyStats(date: String, pageViews: Int, uniqueVisitors: Int, sessions: Int, bounceRate: Double, avgSessionDuration: Double)
+case class PagePerformance(url: String, views: Int, avgDuration: Double, bounceRate: Double, exitRate: Double)
+case class ConversionFunnel(name: String, steps: List[FunnelStep], overallRate: Double)
+case class RetentionCohort(startDate: String, buckets: List[CohortBucket])
+
+sealed trait ReportFormat
+case class TableReport(columns: List[String], sortBy: String, limit: Int) extends ReportFormat
+case class ChartReport(chartType: String, xAxis: String, yAxis: String, groupBy: String) extends ReportFormat
+case class SummaryReport(metrics: List[String], comparison: String) extends ReportFormat
+
+case class ReportConfig(name: String, dateRange: String, format: ReportFormat, segments: List[UserSegment], filters: List[String])
+
+object Domain6:
+  def run(): Unit =
+    val device = DeviceInfo("desktop", "macOS", "14.0", "Chrome", "120.0", 1920, 1080, false)
+    val geo = GeoInfo("US", "CA", "SF", "94102", 37.78, -122.41, "Comcast")
+    val utm = UTMParams("google", "cpc", "q4_sale", "widgets", "banner_v2")
+    val ref = ReferrerInfo("https://google.com/search?q=widgets", "google.com", "organic", "")
+    val env = EventEnvelope(EventId("e1"), SessionId("s1"), "u1", 1709251200000L,
+      device, geo, utm, ref, PageView("https://shop.com", "https://google.com", "Home", 5000))
+    assert(decode[EventEnvelope](env.asJson.noSpaces) == Right(env))
+
+    val env2 = env.copy(event = ErrorEvent("TypeError", "null is not an object", "at line 42", "/checkout"))
+    assert(decode[EventEnvelope](env2.asJson.noSpaces) == Right(env2))
+
+    val daily = DailyStats("2024-03-01", 15000, 8000, 10000, 35.5, 180.0)
+    assert(decode[DailyStats](daily.asJson.noSpaces) == Right(daily))
+
+    val funnel = ConversionFunnel("Purchase", List(
+      FunnelStep("View Product", 1000, 100.0, 0.0),
+      FunnelStep("Add to Cart", 400, 40.0, 60.0),
+      FunnelStep("Checkout", 200, 50.0, 50.0),
+      FunnelStep("Purchase", 150, 75.0, 25.0)), 15.0)
+    assert(decode[ConversionFunnel](funnel.asJson.noSpaces) == Right(funnel))
+
+    val segment = UserSegment("s1", "Power Users", List("sessions > 10", "purchases > 3"))
+    val breakdown = SegmentBreakdown(segment, List(MetricAgg("revenue", 50000, 100, 50, 2000, 500)))
+    assert(decode[SegmentBreakdown](breakdown.asJson.noSpaces) == Right(breakdown))
+
+    val report = ReportConfig("Weekly KPIs", "2024-W10",
+      ChartReport("line", "date", "pageViews", "segment"),
+      List(segment), List("country:US"))
+    assert(decode[ReportConfig](report.asJson.noSpaces) == Right(report))

--- a/benchmark/shared/src/benchmark/domain7_projects.scala
+++ b/benchmark/shared/src/benchmark/domain7_projects.scala
@@ -1,0 +1,75 @@
+package benchmark.domain7
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+case class Milestone(name: String, dueDate: String, completed: Boolean, description: String)
+case class Label(name: String, color: String, description: String)
+
+sealed trait Priority
+case class UrgentPri(deadline: String, escalated: Boolean) extends Priority
+case class HighPri(reason: String) extends Priority
+case class MediumPri(notes: String) extends Priority
+case class LowPri(deferUntil: String) extends Priority
+case class TrivialPri(autoClose: Boolean) extends Priority
+
+sealed trait TicketType
+case class BugTicket(severity: String, stepsToReproduce: List[String], environment: String) extends TicketType
+case class FeatureTicket(businessValue: String, effort: Int, requester: String) extends TicketType
+case class ChoreTicket(category: String, recurring: Boolean) extends TicketType
+case class SpikeTicket(question: String, timebox: Int, findings: String) extends TicketType
+case class EpicTicket(description: String, childCount: Int) extends TicketType
+case class SubtaskTicket(parentId: String, description: String) extends TicketType
+
+sealed trait TicketState
+case class Backlog(addedAt: String) extends TicketState
+case class Todo(orderedAt: String) extends TicketState
+case class InProgress(startedAt: String, assignee: String) extends TicketState
+case class InReview(reviewerId: String, submittedAt: String) extends TicketState
+case class Testing(testerId: String, startedAt: String) extends TicketState
+case class Done(completedAt: String, resolution: String) extends TicketState
+case class Wontfix(reason: String, closedAt: String) extends TicketState
+
+case class TicketComment(id: String, author: String, body: String, createdAt: String, editedAt: String)
+case class TimeEntry(id: String, userId: String, hours: Double, date: String, note: String)
+case class Attachment(id: String, filename: String, url: String, sizeBytes: Int, mimeType: String)
+case class TicketRelation(relationType: String, targetId: String)
+case class Ticket(id: String, title: String, ticketType: TicketType, priority: Priority, state: TicketState,
+  labels: List[Label], comments: List[TicketComment], timeEntries: List[TimeEntry],
+  attachments: List[Attachment], relations: List[TicketRelation], milestone: Milestone)
+
+case class Sprint(name: String, goal: String, startDate: String, endDate: String, tickets: List[Ticket], velocity: Int)
+case class Retrospective(sprintName: String, wentWell: List[String], needsImprovement: List[String], actionItems: List[String])
+case class TeamMember(name: String, role: String, capacity: Double, skills: List[String])
+case class Team(name: String, members: List[TeamMember], lead: String)
+case class RoadmapItem(title: String, quarter: String, status: String, milestones: List[Milestone], teams: List[String])
+
+object Domain7:
+  def run(): Unit =
+    val comment = TicketComment("c1", "Dev", "Fixed in branch feat/fix", "2024-03-01", "")
+    val time = TimeEntry("t1", "u1", 2.5, "2024-03-01", "debugging")
+    val attach = Attachment("a1", "screenshot.png", "https://s3/screenshot.png", 524288, "image/png")
+    val ticket = Ticket("T-1", "Fix login timeout",
+      BugTicket("critical", List("Go to /login", "Wait 30s", "See timeout"), "production"),
+      UrgentPri("2024-03-05", true), InProgress("2024-03-02", "dev1"),
+      List(Label("bug", "#ff0000", ""), Label("auth", "#00ff00", "")),
+      List(comment), List(time), List(attach),
+      List(TicketRelation("blocks", "T-2")),
+      Milestone("v1.0", "2024-04-01", false, "First release"))
+    assert(decode[Ticket](ticket.asJson.noSpaces) == Right(ticket))
+
+    val sprint = Sprint("Sprint 7", "Fix critical bugs", "2024-03-01", "2024-03-14", List(ticket), 21)
+    assert(decode[Sprint](sprint.asJson.noSpaces) == Right(sprint))
+
+    val retro = Retrospective("Sprint 7", List("Good collaboration"), List("Too many bugs"), List("Add more tests"))
+    assert(decode[Retrospective](retro.asJson.noSpaces) == Right(retro))
+
+    val team = Team("Backend", List(TeamMember("Alice", "Senior", 1.0, List("Scala", "Kafka")), TeamMember("Bob", "Junior", 0.8, List("Java"))), "Alice")
+    assert(decode[Team](team.asJson.noSpaces) == Right(team))
+
+    val roadmap = RoadmapItem("Auth Rewrite", "Q2 2024", "in-progress",
+      List(Milestone("Design", "2024-04-01", true, ""), Milestone("Impl", "2024-05-15", false, "")),
+      List("Backend", "Security"))
+    assert(decode[RoadmapItem](roadmap.asJson.noSpaces) == Right(roadmap))

--- a/benchmark/shared/src/benchmark/domain8_generics.scala
+++ b/benchmark/shared/src/benchmark/domain8_generics.scala
@@ -1,0 +1,90 @@
+package benchmark.domain8
+
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import io.circe.generic.auto._
+
+// Generic wrapper types
+case class Box[A](value: A)
+case class Pair[A, B](first: A, second: B)
+case class Triple[A, B, C](first: A, second: B, third: C)
+case class Tagged[A](tag: String, payload: A)
+case class Validated[A](result: A, errors: List[String], warnings: List[String])
+case class Versioned[A](data: A, version: Int, updatedAt: String, updatedBy: String)
+case class Paginated[A](items: List[A], page: Int, pageSize: Int, totalItems: Int, totalPages: Int)
+case class Cached[A](value: A, cachedAt: Long, ttlMs: Long, stale: Boolean)
+
+// Value types used across instantiations
+case class Email2(address: String)
+case class UserId2(value: String)
+case class Money2(amount: Double, currency: String)
+case class GeoCoord2(lat: Double, lng: Double)
+case class DateRange2(start: String, end: String)
+case class Sku2(code: String)
+case class Slug2(value: String)
+case class MetricVal(name: String, value: Double, timestamp: Long)
+case class StatusMsg(code: Int, message: String, details: String)
+case class ConfigEntry(key: String, value: String, description: String, secret: Boolean)
+case class FeatureFlag(name: String, enabled: Boolean, rolloutPct: Double)
+case class RateLimit2(limit: Int, remaining: Int, resetAt: Long)
+case class Locale3(lang: String, country: String)
+case class Version2(major: Int, minor: Int, patch: Int)
+case class Dimensions2(width: Double, height: Double, depth: Double)
+
+object Domain8:
+  def run(): Unit =
+    // Box instantiations
+    val b1 = Box(42); assert(decode[Box[Int]](b1.asJson.noSpaces) == Right(b1))
+    val b2 = Box("hi"); assert(decode[Box[String]](b2.asJson.noSpaces) == Right(b2))
+    val b3 = Box(true); assert(decode[Box[Boolean]](b3.asJson.noSpaces) == Right(b3))
+    val b4 = Box(3.14); assert(decode[Box[Double]](b4.asJson.noSpaces) == Right(b4))
+    val b5 = Box(Money2(9.99, "USD")); assert(decode[Box[Money2]](b5.asJson.noSpaces) == Right(b5))
+    val b6 = Box(Email2("a@b")); assert(decode[Box[Email2]](b6.asJson.noSpaces) == Right(b6))
+    val b7 = Box(GeoCoord2(0, 0)); assert(decode[Box[GeoCoord2]](b7.asJson.noSpaces) == Right(b7))
+    val b8 = Box(Version2(1, 2, 3)); assert(decode[Box[Version2]](b8.asJson.noSpaces) == Right(b8))
+
+    // Pair instantiations
+    val p1 = Pair("x", 1); assert(decode[Pair[String, Int]](p1.asJson.noSpaces) == Right(p1))
+    val p2 = Pair(Money2(1.0, "EUR"), GeoCoord2(0, 0)); assert(decode[Pair[Money2, GeoCoord2]](p2.asJson.noSpaces) == Right(p2))
+    val p3 = Pair(true, 3.14); assert(decode[Pair[Boolean, Double]](p3.asJson.noSpaces) == Right(p3))
+    val p4 = Pair(Email2("x"), UserId2("u")); assert(decode[Pair[Email2, UserId2]](p4.asJson.noSpaces) == Right(p4))
+    val p5 = Pair(Sku2("s"), Money2(5, "GBP")); assert(decode[Pair[Sku2, Money2]](p5.asJson.noSpaces) == Right(p5))
+    val p6 = Pair(Version2(1,0,0), DateRange2("a","b")); assert(decode[Pair[Version2, DateRange2]](p6.asJson.noSpaces) == Right(p6))
+
+    // Triple instantiations
+    val t1 = Triple("a", 1, true); assert(decode[Triple[String, Int, Boolean]](t1.asJson.noSpaces) == Right(t1))
+    val t2 = Triple(Money2(1,"X"), Email2("e"), GeoCoord2(1,2)); assert(decode[Triple[Money2, Email2, GeoCoord2]](t2.asJson.noSpaces) == Right(t2))
+    val t3 = Triple(Sku2("s"), Slug2("x"), Version2(2,0,1)); assert(decode[Triple[Sku2, Slug2, Version2]](t3.asJson.noSpaces) == Right(t3))
+
+    // Tagged instantiations
+    val tg1 = Tagged("u", UserId2("u1")); assert(decode[Tagged[UserId2]](tg1.asJson.noSpaces) == Right(tg1))
+    val tg2 = Tagged("m", MetricVal("cpu", 42.0, 0L)); assert(decode[Tagged[MetricVal]](tg2.asJson.noSpaces) == Right(tg2))
+    val tg3 = Tagged("s", Sku2("S1")); assert(decode[Tagged[Sku2]](tg3.asJson.noSpaces) == Right(tg3))
+    val tg4 = Tagged("e", Email2("x@y")); assert(decode[Tagged[Email2]](tg4.asJson.noSpaces) == Right(tg4))
+    val tg5 = Tagged("c", ConfigEntry("k","v","d",false)); assert(decode[Tagged[ConfigEntry]](tg5.asJson.noSpaces) == Right(tg5))
+    val tg6 = Tagged("f", FeatureFlag("x", true, 50.0)); assert(decode[Tagged[FeatureFlag]](tg6.asJson.noSpaces) == Right(tg6))
+
+    // Validated instantiations
+    val v1 = Validated(Money2(100,"USD"), Nil, List("rounded")); assert(decode[Validated[Money2]](v1.asJson.noSpaces) == Right(v1))
+    val v2 = Validated(StatusMsg(200,"OK",""), Nil, Nil); assert(decode[Validated[StatusMsg]](v2.asJson.noSpaces) == Right(v2))
+    val v3 = Validated(Dimensions2(1,2,3), List("too small"), Nil); assert(decode[Validated[Dimensions2]](v3.asJson.noSpaces) == Right(v3))
+    val v4 = Validated(Locale3("en","US"), Nil, Nil); assert(decode[Validated[Locale3]](v4.asJson.noSpaces) == Right(v4))
+
+    // Versioned instantiations
+    val vr1 = Versioned(Email2("a@b"), 3, "2024-01", "admin"); assert(decode[Versioned[Email2]](vr1.asJson.noSpaces) == Right(vr1))
+    val vr2 = Versioned(RateLimit2(100, 50, 0L), 1, "2024-06", "system"); assert(decode[Versioned[RateLimit2]](vr2.asJson.noSpaces) == Right(vr2))
+    val vr3 = Versioned(ConfigEntry("k","v","d",false), 5, "2024-09", "ops"); assert(decode[Versioned[ConfigEntry]](vr3.asJson.noSpaces) == Right(vr3))
+    val vr4 = Versioned(FeatureFlag("dark", true, 100.0), 2, "2024-11", "pm"); assert(decode[Versioned[FeatureFlag]](vr4.asJson.noSpaces) == Right(vr4))
+
+    // Paginated instantiations
+    val pg1 = Paginated(List(Email2("a"), Email2("b")), 1, 10, 2, 1); assert(decode[Paginated[Email2]](pg1.asJson.noSpaces) == Right(pg1))
+    val pg2 = Paginated(List(Money2(1,"X")), 1, 20, 1, 1); assert(decode[Paginated[Money2]](pg2.asJson.noSpaces) == Right(pg2))
+    val pg3 = Paginated(List(MetricVal("x", 1.0, 0L)), 2, 50, 100, 2); assert(decode[Paginated[MetricVal]](pg3.asJson.noSpaces) == Right(pg3))
+    val pg4 = Paginated(List(StatusMsg(200,"OK","")), 1, 10, 1, 1); assert(decode[Paginated[StatusMsg]](pg4.asJson.noSpaces) == Right(pg4))
+
+    // Cached instantiations
+    val c1 = Cached(GeoCoord2(37.7, -122.4), 1709251200000L, 60000, false); assert(decode[Cached[GeoCoord2]](c1.asJson.noSpaces) == Right(c1))
+    val c2 = Cached(Version2(1,0,0), 0L, 3600000, true); assert(decode[Cached[Version2]](c2.asJson.noSpaces) == Right(c2))
+    val c3 = Cached(Slug2("hello"), 0L, 300000, false); assert(decode[Cached[Slug2]](c3.asJson.noSpaces) == Right(c3))
+    val c4 = Cached(Dimensions2(10,20,30), 0L, 600000, false); assert(decode[Cached[Dimensions2]](c4.asJson.noSpaces) == Right(c4))


### PR DESCRIPTION
## Summary
- Adds compile-time benchmark with ~300 types across 9 source files (users, e-commerce, CMS, monitoring, infra, analytics, project management, generics, wide case classes)
- Both `benchmark.sanely` and `benchmark.generic` modules compile the same shared source — only the dependency differs
- `bench.sh` script runs N iterations per module and reports median compile time
- Results on M3 Max: **3.77s** (sanely) vs **6.07s** (circe-generic) — **1.6× faster**
- Documents benchmark in README.md and updates CLAUDE.md with Mill shared-sources pattern

## Test plan
- [x] `./mill benchmark.sanely.compile` — compiles successfully
- [x] `./mill benchmark.generic.compile` — compiles successfully
- [x] `./mill benchmark.sanely.run` — all round-trip assertions pass
- [x] `./mill benchmark.generic.run` — all round-trip assertions pass
- [x] `bash bench.sh 5` — produces consistent timing results

🤖 Generated with [Claude Code](https://claude.com/claude-code)