### PR TITLE
feat: add Scala.js cross-platform support

### DIFF
--- a/benchmark/package.mill
+++ b/benchmark/package.mill
@@ -10,7 +10,7 @@ object `package` extends mill.Module {
     def scalacOptions = Task {
       super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
     }
-    def moduleDeps = Seq(build.sanely)
+    def moduleDeps = Seq(build.sanely.jvm)
     def mvnDeps = Task {
       super.mvnDeps() ++ Seq(
         mvn"io.circe::circe-core:${build.circeVersion}",

--- a/build.mill
+++ b/build.mill
@@ -5,46 +5,9 @@ import mill._, scalalib._, publish._
 val circeVersion = "0.14.13"
 val scala3Version = "3.8.2"
 
-object sanely extends ScalaModule with SonatypeCentralPublishModule {
-  def scalaVersion = scala3Version
-  def artifactName = "circe-sanely-auto"
-  def publishVersion = "0.2.0"
-
-  def pomSettings = PomSettings(
-    description = "Drop-in replacement for circe's auto-derivation using sanely-automatic Scala 3 macros",
-    organization = "io.github.nguyenyou",
-    url = "https://github.com/nguyenyou/circe-sanely-auto",
-    licenses = Seq(License.MIT),
-    versionControl = VersionControl.github("nguyenyou", "circe-sanely-auto"),
-    developers = Seq(Developer("nguyenyou", "Tu Nguyen", "https://github.com/nguyenyou")),
-  )
-
-  def mvnDeps = Task {
-    super.mvnDeps() ++ Seq(
-      mvn"io.circe::circe-core:$circeVersion"
-    )
-  }
-  def scalacOptions = Task {
-    super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
-  }
-
-  object test extends ScalaTests with TestModule.Utest {
-    def mvnDeps = Task {
-      super.mvnDeps() ++ Seq(
-        mvn"io.circe::circe-core:$circeVersion",
-        mvn"io.circe::circe-parser:$circeVersion",
-        mvn"com.lihaoyi::utest:0.10.0-RC1"
-      )
-    }
-    def scalacOptions = Task {
-      super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
-    }
-  }
-}
-
 object compat extends ScalaModule {
   def scalaVersion = scala3Version
-  def moduleDeps = Seq(sanely)
+  def moduleDeps = Seq(sanely.jvm)
   def mvnDeps = Task {
     super.mvnDeps() ++ Seq(
       mvn"io.circe::circe-core:$circeVersion",
@@ -69,7 +32,7 @@ object compat extends ScalaModule {
 
 object demo extends ScalaModule {
   def scalaVersion = scala3Version
-  def moduleDeps = Seq(sanely)
+  def moduleDeps = Seq(sanely.jvm)
   def mvnDeps = Task {
     super.mvnDeps() ++ Seq(
       mvn"io.circe::circe-core:$circeVersion",

--- a/sanely/package.mill
+++ b/sanely/package.mill
@@ -1,0 +1,53 @@
+package build.sanely
+
+import mill.*, scalalib.*, scalajslib.*, publish.*
+
+object `package` extends mill.Module {
+
+  object jvm extends SharedModule {
+    object test extends ScalaTests with SharedTests
+  }
+
+  object js extends ScalaJSModule with SharedModule {
+    override def scalaJSVersion = "1.20.2"
+    object test extends ScalaJSTests with SharedTests
+  }
+
+  trait SharedModule extends PlatformScalaModule with SonatypeCentralPublishModule {
+    def artifactName = "circe-sanely-auto"
+    def scalaVersion = build.scala3Version
+    def publishVersion = "0.2.0"
+
+    def pomSettings = PomSettings(
+      description = "Drop-in replacement for circe's auto-derivation using sanely-automatic Scala 3 macros",
+      organization = "io.github.nguyenyou",
+      url = "https://github.com/nguyenyou/circe-sanely-auto",
+      licenses = Seq(License.MIT),
+      versionControl = VersionControl.github("nguyenyou", "circe-sanely-auto"),
+      developers = Seq(Developer("nguyenyou", "Tu Nguyen", "https://github.com/nguyenyou")),
+    )
+
+    def mvnDeps = Task {
+      super.mvnDeps() ++ Seq(
+        mvn"io.circe::circe-core::${build.circeVersion}"
+      )
+    }
+
+    def scalacOptions = Task {
+      super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
+    }
+
+    trait SharedTests extends ScalaTests with TestModule.Utest {
+      def mvnDeps = Task {
+        super.mvnDeps() ++ Seq(
+          mvn"io.circe::circe-core::${build.circeVersion}",
+          mvn"io.circe::circe-parser::${build.circeVersion}",
+          mvn"com.lihaoyi::utest::0.10.0-RC1"
+        )
+      }
+      def scalacOptions = Task {
+        super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Restructure `sanely` module from JVM-only `ScalaModule` to cross-platform with `.jvm` and `.js` sub-modules using Mill's `PlatformScalaModule` pattern
- Scala.js 1.20.2, existing source files unchanged (pure Scala 3 macros, no JVM-specific APIs)
- Update `compat`, `demo`, and `benchmark` module refs to `sanely.jvm`

## New commands
- `./mill sanely.jvm.compile` / `./mill sanely.js.compile`
- `./mill sanely.jvm.test` / `./mill sanely.js.test`
- `./mill sanely.jvm.publishLocal` / `./mill sanely.js.publishLocal`

## Test plan
- [x] `./mill sanely.jvm.compile` — passes
- [x] `./mill sanely.js.compile` — passes
- [x] `./mill sanely.jvm.test` — 52/52 pass
- [x] `./mill sanely.js.test` — 51/52 pass (1 expected failure: `Long.MaxValue` precision loss is a known Scala.js limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)