### PR TITLE
test: port all circe configured derivation tests

### DIFF
--- a/sanely/src/sanely/SanelyConfiguredDecoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredDecoder.scala
@@ -55,18 +55,36 @@ object SanelyConfiguredDecoder:
                 defaultOpt match
                   case Some(defaultExpr) =>
                     val typedDefault = defaultExpr.asInstanceOf[Expr[t]]
-                    '{
-                      val fieldName = $conf.transformMemberNames($labelExpr)
-                      val cursor = $c.downField(fieldName)
-                      val result: Decoder.Result[t] =
-                        if $conf.useDefaults && (cursor.failed || cursor.focus.exists(_.isNull)) then
-                          Right($typedDefault)
-                        else
-                          $typedDec.tryDecode(cursor)
-                      result match
-                        case Right(v) => ${ buildDecodeChain(c, rest, fieldIdx + 1, 'v :: acc) }
-                        case Left(e)  => Left(e)
-                    }
+                    // For Option types, null should decode normally as None, not trigger default
+                    val isOptionType = TypeRepr.of[t].dealias match
+                      case AppliedType(tycon, _) => tycon.typeSymbol.fullName == "scala.Option"
+                      case _ => false
+                    if isOptionType then
+                      '{
+                        val fieldName = $conf.transformMemberNames($labelExpr)
+                        val cursor = $c.downField(fieldName)
+                        val result: Decoder.Result[t] =
+                          if $conf.useDefaults && cursor.failed then
+                            Right($typedDefault)
+                          else
+                            $typedDec.tryDecode(cursor)
+                        result match
+                          case Right(v) => ${ buildDecodeChain(c, rest, fieldIdx + 1, 'v :: acc) }
+                          case Left(e)  => Left(e)
+                      }
+                    else
+                      '{
+                        val fieldName = $conf.transformMemberNames($labelExpr)
+                        val cursor = $c.downField(fieldName)
+                        val result: Decoder.Result[t] =
+                          if $conf.useDefaults && (cursor.failed || cursor.focus.exists(_.isNull)) then
+                            Right($typedDefault)
+                          else
+                            $typedDec.tryDecode(cursor)
+                        result match
+                          case Right(v) => ${ buildDecodeChain(c, rest, fieldIdx + 1, 'v :: acc) }
+                          case Left(e)  => Left(e)
+                      }
                   case None =>
                     '{
                       $typedDec.tryDecode($c.downField($conf.transformMemberNames($labelExpr))) match

--- a/sanely/src/sanely/SanelyEnumCodec.scala
+++ b/sanely/src/sanely/SanelyEnumCodec.scala
@@ -35,14 +35,20 @@ object SanelyEnumCodec:
               Type.valueOfConstant[l].getOrElse(
                 report.errorAndAbort(s"Expected literal string type for enum label")
               ).toString
-          // Try to summon the singleton value
-          val singletonExpr: Expr[S] = Expr.summon[Mirror.ProductOf[t]] match
+          val casesForThis: List[(String, Expr[S])] = Expr.summon[Mirror.ProductOf[t]] match
             case Some('{ $pm: Mirror.ProductOf[t] { type MirroredElemTypes = EmptyTuple } }) =>
               // Zero-field product = singleton
-              '{ $pm.fromProduct(EmptyTuple).asInstanceOf[S] }
+              List((labelStr, '{ $pm.fromProduct(EmptyTuple).asInstanceOf[S] }))
             case _ =>
-              report.errorAndAbort(s"Enum case '${labelStr}' is not a singleton (has fields). SanelyEnumCodec only supports pure-value enums.")
-          (labelStr, singletonExpr) :: collectSingletonCases[S, ts, ls](mirror)
+              // Not a singleton — check if it's a sub-sum-type (nested sealed trait)
+              Expr.summon[Mirror.SumOf[t]] match
+                case Some(subMirror) =>
+                  subMirror match
+                    case '{ $sm: Mirror.SumOf[t] { type MirroredElemTypes = subTypes; type MirroredElemLabels = subLabels } } =>
+                      collectSingletonCases[S, subTypes, subLabels](mirror)
+                case None =>
+                  report.errorAndAbort(s"Enum case '${labelStr}' is not a singleton (has fields). SanelyEnumCodec only supports pure-value enums.")
+          casesForThis ++ collectSingletonCases[S, ts, ls](mirror)
 
     private def buildCodec[S: Type](
       mirror: Expr[Mirror.SumOf[S]],

--- a/sanely/test/src/sanely/SanelyConfiguredSuite.scala
+++ b/sanely/test/src/sanely/SanelyConfiguredSuite.scala
@@ -8,6 +8,11 @@ import io.circe.derivation.Configuration
 
 // --- Test types for configured derivation ---
 
+// Mirrors circe's ConfigExampleBase
+enum ConfigExampleBase:
+  case ConfigExampleFoo(thisIsAField: String, a: Int = 0, b: Double)
+  case ConfigExampleBar
+
 case class SnakeCaseProduct(firstName: String, lastName: String, zipCode: Int)
 
 sealed trait Animal
@@ -27,6 +32,10 @@ enum Color:
 enum Direction:
   case North, South, East, West
 
+// Mirrors circe's IntercardinalDirections
+enum IntercardinalDirections:
+  case NorthEast, SouthEast, SouthWest, NorthWest
+
 case class StrictProduct(a: Int, b: String)
 
 // Discriminator test type
@@ -41,12 +50,110 @@ sealed trait SnakeDiscAdt
 case class VariantOne(someValue: Int) extends SnakeDiscAdt
 case class VariantTwo(anotherValue: String) extends SnakeDiscAdt
 
+// Option defaults test types (mirrors circe's FooWithDefault/FooNoDefault)
+case class FooWithDefault(a: Option[Int] = Some(0), b: String = "b")
+case class FooNoDefault(a: Option[Int], b: String = "b")
+
+// Multi-level hierarchy with discriminator
+sealed trait GrandParent
+sealed trait Parent extends GrandParent
+case class Child(a: Int, b: String) extends Parent
+
+// 3-level hierarchy with name collision (mirrors circe test)
+sealed trait GreatGrandParent
+sealed trait GrandParent2 extends GreatGrandParent
+case class Uncle(Child: Int) extends GrandParent2 // field name matches case class name
+sealed trait Parent2 extends GrandParent2
+case class Child2(a: Int, b: String) extends Parent2
+
+// Recursive with discriminator
+sealed trait Tree
+case class Branch(l: Tree, r: Tree) extends Tree
+case object Leaf extends Tree
+
+// Hierarchical enum (mirrors circe's HierarchicalEnum with diamond)
+sealed trait HierarchicalEnum
+object HierarchicalEnum:
+  sealed trait NestedA extends HierarchicalEnum
+  sealed trait NestedB extends HierarchicalEnum
+  case object A extends HierarchicalEnum
+  case object B extends NestedA
+  case object C extends NestedB
+  case object D extends NestedA with NestedB // diamond
+
 object SanelyConfiguredSuite extends TestSuite:
   val tests = Tests {
 
     // === transformMemberNames ===
 
-    test("transformMemberNames - snake_case product") {
+    test("transformMemberNames - snake_case") {
+      given Configuration = Configuration.default.withSnakeCaseMemberNames
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = SanelyConfiguredCodec.derived
+
+      val foo: ConfigExampleBase.ConfigExampleFoo = ConfigExampleBase.ConfigExampleFoo("value", 42, 3.14)
+      val json = Json.obj(
+        "this_is_a_field" -> Json.fromString("value"),
+        "a" -> Json.fromInt(42),
+        "b" -> Json.fromDoubleOrNull(3.14)
+      )
+      assert(Encoder.AsObject[ConfigExampleBase.ConfigExampleFoo].encodeObject(foo) == json.asObject.get)
+      assert(json.as[ConfigExampleBase.ConfigExampleFoo] == Right(foo))
+    }
+
+    test("transformMemberNames - SCREAMING_SNAKE_CASE") {
+      given Configuration = Configuration.default.withScreamingSnakeCaseMemberNames
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = SanelyConfiguredCodec.derived
+
+      val foo: ConfigExampleBase.ConfigExampleFoo = ConfigExampleBase.ConfigExampleFoo("value", 42, 3.14)
+      val json = Json.obj(
+        "THIS_IS_A_FIELD" -> Json.fromString("value"),
+        "A" -> Json.fromInt(42),
+        "B" -> Json.fromDoubleOrNull(3.14)
+      )
+      assert(Encoder.AsObject[ConfigExampleBase.ConfigExampleFoo].encodeObject(foo) == json.asObject.get)
+      assert(json.as[ConfigExampleBase.ConfigExampleFoo] == Right(foo))
+    }
+
+    test("transformMemberNames - kebab-case") {
+      given Configuration = Configuration.default.withKebabCaseMemberNames
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = SanelyConfiguredCodec.derived
+
+      val foo: ConfigExampleBase.ConfigExampleFoo = ConfigExampleBase.ConfigExampleFoo("value", 42, 3.14)
+      val json = Json.obj(
+        "this-is-a-field" -> Json.fromString("value"),
+        "a" -> Json.fromInt(42),
+        "b" -> Json.fromDoubleOrNull(3.14)
+      )
+      assert(Encoder.AsObject[ConfigExampleBase.ConfigExampleFoo].encodeObject(foo) == json.asObject.get)
+      assert(json.as[ConfigExampleBase.ConfigExampleFoo] == Right(foo))
+    }
+
+    test("transformMemberNames - PascalCase") {
+      given Configuration = Configuration.default.withPascalCaseMemberNames
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = SanelyConfiguredCodec.derived
+
+      val foo: ConfigExampleBase.ConfigExampleFoo = ConfigExampleBase.ConfigExampleFoo("value", 42, 3.14)
+      val json = Json.obj(
+        "ThisIsAField" -> Json.fromString("value"),
+        "A" -> Json.fromInt(42),
+        "B" -> Json.fromDoubleOrNull(3.14)
+      )
+      assert(Encoder.AsObject[ConfigExampleBase.ConfigExampleFoo].encodeObject(foo) == json.asObject.get)
+      assert(json.as[ConfigExampleBase.ConfigExampleFoo] == Right(foo))
+    }
+
+    test("transformMemberNames - identity (default config)") {
+      given Configuration = Configuration.default
+      given Encoder.AsObject[SnakeCaseProduct] = SanelyConfiguredEncoder.derived
+      given Decoder[SnakeCaseProduct] = SanelyConfiguredDecoder.derived
+
+      val v = SnakeCaseProduct("Bob", "Jones", 99999)
+      val json = v.asJson
+      assert(json.hcursor.downField("firstName").as[String] == Right("Bob"))
+      assert(json.as[SnakeCaseProduct] == Right(v))
+    }
+
+    test("transformMemberNames - snake_case product roundtrip") {
       given Configuration = Configuration.default.withSnakeCaseMemberNames
       given Encoder.AsObject[SnakeCaseProduct] = SanelyConfiguredEncoder.derived
       given Decoder[SnakeCaseProduct] = SanelyConfiguredDecoder.derived
@@ -59,20 +166,7 @@ object SanelyConfiguredSuite extends TestSuite:
         "zip_code" -> Json.fromInt(12345)
       )
       assert(json == expected)
-      val decoded = json.as[SnakeCaseProduct]
-      assert(decoded == Right(v))
-    }
-
-    test("transformMemberNames - identity (default config)") {
-      given Configuration = Configuration.default
-      given Encoder.AsObject[SnakeCaseProduct] = SanelyConfiguredEncoder.derived
-      given Decoder[SnakeCaseProduct] = SanelyConfiguredDecoder.derived
-
-      val v = SnakeCaseProduct("Bob", "Jones", 99999)
-      val json = v.asJson
-      assert(json.hcursor.downField("firstName").as[String] == Right("Bob"))
-      val decoded = json.as[SnakeCaseProduct]
-      assert(decoded == Right(v))
+      assert(json.as[SnakeCaseProduct] == Right(v))
     }
 
     // === transformConstructorNames ===
@@ -88,8 +182,7 @@ object SanelyConfiguredSuite extends TestSuite:
         "domestic_cat" -> Json.obj("whiskerLength" -> Json.fromDoubleOrNull(3.5))
       )
       assert(json == expected)
-      val decoded = json.as[Animal]
-      assert(decoded == Right(v))
+      assert(json.as[Animal] == Right(v))
     }
 
     test("transformConstructorNames + transformMemberNames combined") {
@@ -105,8 +198,7 @@ object SanelyConfiguredSuite extends TestSuite:
         "wild_dog" -> Json.obj("pack_size" -> Json.fromInt(5))
       )
       assert(json == expected)
-      val decoded = json.as[Animal]
-      assert(decoded == Right(v))
+      assert(json.as[Animal] == Right(v))
     }
 
     // === discriminator ===
@@ -124,8 +216,7 @@ object SanelyConfiguredSuite extends TestSuite:
         "type" -> Json.fromString("Car")
       )
       assert(json == expected)
-      val decoded = json.as[Vehicle]
-      assert(decoded == Right(v))
+      assert(json.as[Vehicle] == Right(v))
     }
 
     test("discriminator - flat encoding Truck variant") {
@@ -140,11 +231,60 @@ object SanelyConfiguredSuite extends TestSuite:
         "type" -> Json.fromString("Truck")
       )
       assert(json == expected)
-      val decoded = json.as[Vehicle]
-      assert(decoded == Right(v))
+      assert(json.as[Vehicle] == Right(v))
     }
 
-    test("discriminator + transformConstructorNames") {
+    test("discriminator - singleton variant (ConfigExampleBar)") {
+      given Configuration = Configuration.default.withDiscriminator("type")
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      val v: ConfigExampleBase = ConfigExampleBase.ConfigExampleBar
+      val json = v.asJson
+      assert(json.hcursor.downField("type").as[String] == Right("ConfigExampleBar"))
+      assert(json.as[ConfigExampleBase] == Right(v))
+    }
+
+    test("discriminator + snake_case constructor names") {
+      given Configuration = Configuration.default.withDiscriminator("type").withSnakeCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      val foo = ConfigExampleBase.ConfigExampleFoo("x", 1, 2.0)
+      val json = foo.asJson
+      assert(json.hcursor.downField("type").as[String] == Right("config_example_foo"))
+      assert(json.as[ConfigExampleBase] == Right(foo))
+    }
+
+    test("discriminator + SCREAMING_SNAKE_CASE constructor names") {
+      given Configuration = Configuration.default.withDiscriminator("type").withScreamingSnakeCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      val foo = ConfigExampleBase.ConfigExampleFoo("x", 1, 2.0)
+      val json = foo.asJson
+      assert(json.hcursor.downField("type").as[String] == Right("CONFIG_EXAMPLE_FOO"))
+      assert(json.as[ConfigExampleBase] == Right(foo))
+    }
+
+    test("discriminator + kebab-case constructor names") {
+      given Configuration = Configuration.default.withDiscriminator("type").withKebabCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      val foo = ConfigExampleBase.ConfigExampleFoo("x", 1, 2.0)
+      val json = foo.asJson
+      assert(json.hcursor.downField("type").as[String] == Right("config-example-foo"))
+      assert(json.as[ConfigExampleBase] == Right(foo))
+    }
+
+    test("discriminator + PascalCase constructor names") {
+      given Configuration = Configuration.default.withDiscriminator("type").withPascalCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      val foo = ConfigExampleBase.ConfigExampleFoo("x", 1, 2.0)
+      val json = foo.asJson
+      assert(json.hcursor.downField("type").as[String] == Right("ConfigExampleFoo"))
+      assert(json.as[ConfigExampleBase] == Right(foo))
+    }
+
+    test("discriminator + transformConstructorNames (custom field name)") {
       given Configuration = Configuration.default
         .withDiscriminator("__typename__")
         .withSnakeCaseConstructorNames
@@ -155,8 +295,7 @@ object SanelyConfiguredSuite extends TestSuite:
       val json = v.asJson
       assert(json.hcursor.downField("__typename__").as[String] == Right("car"))
       assert(json.hcursor.downField("brand").as[String] == Right("Honda"))
-      val decoded = json.as[Vehicle]
-      assert(decoded == Right(v))
+      assert(json.as[Vehicle] == Right(v))
     }
 
     test("discriminator + transformMemberNames + transformConstructorNames") {
@@ -174,8 +313,70 @@ object SanelyConfiguredSuite extends TestSuite:
         "type" -> Json.fromString("variant_one")
       )
       assert(json == expected)
-      val decoded = json.as[SnakeDiscAdt]
-      assert(decoded == Right(v))
+      assert(json.as[SnakeDiscAdt] == Right(v))
+    }
+
+    test("discriminator missing field fails") {
+      given Configuration = Configuration.default.withDiscriminator("type")
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      val json = Json.obj(
+        "_notType" -> Json.fromString("ConfigExampleFoo"),
+        "thisIsAField" -> Json.fromString("x"),
+        "a" -> Json.fromInt(0),
+        "b" -> Json.fromDoubleOrNull(2.5)
+      )
+      assert(json.as[ConfigExampleBase].isLeft)
+    }
+
+    test("discriminator null value fails") {
+      given Configuration = Configuration.default.withDiscriminator("type")
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      val json = Json.obj(
+        "type" -> Json.Null,
+        "thisIsAField" -> Json.fromString("x"),
+        "a" -> Json.fromInt(0),
+        "b" -> Json.fromDoubleOrNull(2.5)
+      )
+      assert(json.as[ConfigExampleBase].isLeft)
+    }
+
+    // === Multi-level hierarchy with discriminator ===
+
+    test("multi-level hierarchy with discriminator encodes and decodes") {
+      given Configuration = Configuration.default.withDiscriminator("type")
+      given Encoder.AsObject[GrandParent] = SanelyConfiguredEncoder.derived
+      given Decoder[GrandParent] = SanelyConfiguredDecoder.derived
+
+      val child: GrandParent = Child(1, "a")
+      val json = child.asJson
+      assert(json.hcursor.downField("type").as[String] == Right("Child"))
+      assert(json.as[GrandParent] == Right(child))
+    }
+
+    test("3-level hierarchy with discriminator and name collision") {
+      given Configuration = Configuration.default.withDiscriminator("type")
+      given Encoder.AsObject[GreatGrandParent] = SanelyConfiguredEncoder.derived
+      given Decoder[GreatGrandParent] = SanelyConfiguredDecoder.derived
+
+      val child: GreatGrandParent = Child2(1, "a")
+      val json = child.asJson
+      val result = json.as[GreatGrandParent]
+      assert(result == Right(child))
+    }
+
+    // === Recursive with discriminator ===
+
+    test("recursive type with discriminator encodes and decodes") {
+      given Configuration = Configuration.default.withDiscriminator("type")
+      given Encoder.AsObject[Tree] = SanelyConfiguredEncoder.derived
+      given Decoder[Tree] = SanelyConfiguredDecoder.derived
+
+      val tree: Tree = Branch(Branch(Leaf, Leaf), Leaf)
+      val json = tree.asJson
+      val result = json.as[Tree]
+      assert(result == Right(tree))
     }
 
     // === useDefaults ===
@@ -185,8 +386,7 @@ object SanelyConfiguredSuite extends TestSuite:
       given Decoder[WithDefaults] = SanelyConfiguredDecoder.derived
 
       val json = Json.obj("x" -> Json.fromInt(42))
-      val decoded = json.as[WithDefaults]
-      assert(decoded == Right(WithDefaults(42, "default_y", true)))
+      assert(json.as[WithDefaults] == Right(WithDefaults(42, "default_y", true)))
     }
 
     test("useDefaults - provided fields override defaults") {
@@ -198,8 +398,7 @@ object SanelyConfiguredSuite extends TestSuite:
         "y" -> Json.fromString("custom"),
         "z" -> Json.fromBoolean(false)
       )
-      val decoded = json.as[WithDefaults]
-      assert(decoded == Right(WithDefaults(1, "custom", false)))
+      assert(json.as[WithDefaults] == Right(WithDefaults(1, "custom", false)))
     }
 
     test("useDefaults - null field uses default value") {
@@ -207,26 +406,21 @@ object SanelyConfiguredSuite extends TestSuite:
       given Decoder[WithDefaults] = SanelyConfiguredDecoder.derived
 
       val json = Json.obj("x" -> Json.fromInt(10), "y" -> Json.Null, "z" -> Json.Null)
-      val decoded = json.as[WithDefaults]
-      assert(decoded == Right(WithDefaults(10, "default_y", true)))
+      assert(json.as[WithDefaults] == Right(WithDefaults(10, "default_y", true)))
     }
 
     test("useDefaults - all defaults") {
       given Configuration = Configuration.default.withDefaults
       given Decoder[AllDefaults] = SanelyConfiguredDecoder.derived
 
-      val json = Json.obj()
-      val decoded = json.as[AllDefaults]
-      assert(decoded == Right(AllDefaults(1, "hello")))
+      assert(Json.obj().as[AllDefaults] == Right(AllDefaults(1, "hello")))
     }
 
     test("useDefaults=false - missing field fails") {
       given Configuration = Configuration.default
       given Decoder[WithDefaults] = SanelyConfiguredDecoder.derived
 
-      val json = Json.obj("x" -> Json.fromInt(42))
-      val decoded = json.as[WithDefaults]
-      assert(decoded.isLeft)
+      assert(Json.obj("x" -> Json.fromInt(42)).as[WithDefaults].isLeft)
     }
 
     test("useDefaults + snake_case") {
@@ -234,14 +428,118 @@ object SanelyConfiguredSuite extends TestSuite:
       given Encoder.AsObject[WithDefaults] = SanelyConfiguredEncoder.derived
       given Decoder[WithDefaults] = SanelyConfiguredDecoder.derived
 
-      val json = Json.obj("x" -> Json.fromInt(5))
-      val decoded = json.as[WithDefaults]
-      assert(decoded == Right(WithDefaults(5, "default_y", true)))
+      assert(Json.obj("x" -> Json.fromInt(5)).as[WithDefaults] == Right(WithDefaults(5, "default_y", true)))
+    }
+
+    test("useDefaults - ConfigExampleFoo missing 'a' uses default 0") {
+      given Configuration = Configuration.default.withDefaults
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = SanelyConfiguredCodec.derived
+
+      val foo: ConfigExampleBase.ConfigExampleFoo = ConfigExampleBase.ConfigExampleFoo("hello", 0, 2.5)
+      val json = Json.obj(
+        "thisIsAField" -> Json.fromString("hello"),
+        "b" -> Json.fromDoubleOrNull(2.5)
+      )
+      val expected = Json.obj(
+        "thisIsAField" -> Json.fromString("hello"),
+        "a" -> Json.fromInt(0),
+        "b" -> Json.fromDoubleOrNull(2.5)
+      )
+      assert(Encoder.AsObject[ConfigExampleBase.ConfigExampleFoo].encodeObject(foo) == expected.asObject.get)
+      assert(json.as[ConfigExampleBase.ConfigExampleFoo] == Right(foo))
+    }
+
+    // Option[T] without default
+
+    test("Option[T] without default should be None if null decoded") {
+      given Configuration = Configuration.default.withDefaults
+      given Decoder[FooNoDefault] = SanelyConfiguredDecoder.derived
+
+      val json = Json.obj("a" -> Json.Null)
+      assert(json.as[FooNoDefault] == Right(FooNoDefault(None, "b")))
+    }
+
+    test("Option[T] without default should be None if missing key decoded") {
+      given Configuration = Configuration.default.withDefaults
+      given Decoder[FooNoDefault] = SanelyConfiguredDecoder.derived
+
+      val json = Json.obj()
+      assert(json.as[FooNoDefault] == Right(FooNoDefault(None, "b")))
+    }
+
+    // Option[T] with default
+
+    test("Option[T] with default should be None if null decoded") {
+      given Configuration = Configuration.default.withDefaults
+      given Decoder[FooWithDefault] = SanelyConfiguredDecoder.derived
+
+      val json = Json.obj("a" -> Json.Null)
+      assert(json.as[FooWithDefault] == Right(FooWithDefault(None, "b")))
+    }
+
+    test("Option[T] with default should be default value if missing key decoded") {
+      given Configuration = Configuration.default.withDefaults
+      given Decoder[FooWithDefault] = SanelyConfiguredDecoder.derived
+
+      val json = Json.obj()
+      assert(json.as[FooWithDefault] == Right(FooWithDefault(Some(0), "b")))
+    }
+
+    test("Value with default should be default value if value is null") {
+      given Configuration = Configuration.default.withDefaults
+      given Decoder[FooWithDefault] = SanelyConfiguredDecoder.derived
+
+      val json = Json.obj("b" -> Json.Null)
+      assert(json.as[FooWithDefault] == Right(FooWithDefault(Some(0), "b")))
+    }
+
+    // Wrong type should still fail even with defaults
+
+    test("Option[T] with default should fail to decode if type is wrong") {
+      given Configuration = Configuration.default.withDefaults
+      given Decoder[FooWithDefault] = SanelyConfiguredDecoder.derived
+
+      val json = Json.obj("a" -> Json.fromString("NotAnInt"))
+      assert(json.as[FooWithDefault].isLeft)
+    }
+
+    test("Field with default should fail to decode if type is wrong") {
+      given Configuration = Configuration.default.withDefaults
+      given Decoder[FooWithDefault] = SanelyConfiguredDecoder.derived
+
+      val json = Json.obj("b" -> Json.fromInt(25))
+      assert(json.as[FooWithDefault].isLeft)
+    }
+
+    // === All options combined ===
+
+    test("all options combined - snake members + defaults + discriminator + kebab constructors") {
+      given Configuration = Configuration.default
+        .withSnakeCaseMemberNames
+        .withDefaults
+        .withDiscriminator("type")
+        .withKebabCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      val foo: ConfigExampleBase = ConfigExampleBase.ConfigExampleFoo("hello", 0, 2.5)
+      val json = Json.obj(
+        "type" -> Json.fromString("config-example-foo"),
+        "this_is_a_field" -> Json.fromString("hello"),
+        "b" -> Json.fromDoubleOrNull(2.5)
+      )
+      val expected = Json.obj(
+        "this_is_a_field" -> Json.fromString("hello"),
+        "a" -> Json.fromInt(0),
+        "b" -> Json.fromDoubleOrNull(2.5),
+        "type" -> Json.fromString("config-example-foo")
+      )
+      assert(Encoder.AsObject[ConfigExampleBase].encodeObject(foo) == expected.asObject.get)
+      assert(json.as[ConfigExampleBase] == Right(foo))
     }
 
     // === strictDecoding ===
 
-    test("strictDecoding - rejects unexpected fields") {
+    test("strictDecoding - rejects unexpected fields on product") {
       given Configuration = Configuration.default.withStrictDecoding
       given Decoder[StrictProduct] = SanelyConfiguredDecoder.derived
 
@@ -250,8 +548,7 @@ object SanelyConfiguredSuite extends TestSuite:
         "b" -> Json.fromString("hi"),
         "extra" -> Json.fromBoolean(true)
       )
-      val decoded = json.as[StrictProduct]
-      assert(decoded.isLeft)
+      assert(json.as[StrictProduct].isLeft)
     }
 
     test("strictDecoding - accepts exact fields") {
@@ -262,31 +559,69 @@ object SanelyConfiguredSuite extends TestSuite:
         "a" -> Json.fromInt(1),
         "b" -> Json.fromString("hi")
       )
-      val decoded = json.as[StrictProduct]
-      assert(decoded == Right(StrictProduct(1, "hi")))
+      assert(json.as[StrictProduct] == Right(StrictProduct(1, "hi")))
     }
 
     test("strictDecoding + transformMemberNames") {
       given Configuration = Configuration.default.withStrictDecoding.withSnakeCaseMemberNames
       given Decoder[SnakeCaseProduct] = SanelyConfiguredDecoder.derived
 
-      // Using camelCase keys should fail (strict checks transformed names)
+      // camelCase keys should fail
       val json = Json.obj(
         "firstName" -> Json.fromString("Alice"),
         "lastName" -> Json.fromString("Smith"),
         "zipCode" -> Json.fromInt(12345)
       )
-      val decoded = json.as[SnakeCaseProduct]
-      assert(decoded.isLeft)
+      assert(json.as[SnakeCaseProduct].isLeft)
 
-      // Using snake_case keys should succeed
+      // snake_case keys should succeed
       val json2 = Json.obj(
         "first_name" -> Json.fromString("Alice"),
         "last_name" -> Json.fromString("Smith"),
         "zip_code" -> Json.fromInt(12345)
       )
-      val decoded2 = json2.as[SnakeCaseProduct]
-      assert(decoded2 == Right(SnakeCaseProduct("Alice", "Smith", 12345)))
+      assert(json2.as[SnakeCaseProduct] == Right(SnakeCaseProduct("Alice", "Smith", 12345)))
+    }
+
+    // === Fail to decode unknown variant ===
+
+    test("fail to decode if case name does not exist") {
+      given Configuration = Configuration.default
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      val json = Json.obj(
+        "invalid-name" -> Json.obj(
+          "thisIsAField" -> Json.fromString("x"),
+          "a" -> Json.fromInt(0),
+          "b" -> Json.fromDoubleOrNull(2.5)
+        )
+      )
+      assert(json.as[ConfigExampleBase].isLeft)
+    }
+
+    test("fail to decode if case name does not exist when constructor names are transformed") {
+      given Configuration = Configuration.default.withSnakeCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+
+      // Using untransformed name should fail
+      val json = Json.obj(
+        "ConfigExampleFoo" -> Json.obj(
+          "thisIsAField" -> Json.fromString("x"),
+          "a" -> Json.fromInt(0),
+          "b" -> Json.fromDoubleOrNull(2.5)
+        )
+      )
+      assert(json.as[ConfigExampleBase].isLeft)
+    }
+
+    test("fail when json to decode is not a Json object") {
+      given Configuration = Configuration.default
+      given Codec.AsObject[ConfigExampleBase] = SanelyConfiguredCodec.derived
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = SanelyConfiguredCodec.derived
+
+      val json = Json.fromString("a string")
+      assert(json.as[ConfigExampleBase].isLeft) // sum type
+      assert(json.as[ConfigExampleBase.ConfigExampleFoo].isLeft) // product type
     }
 
     // === SanelyEnumCodec ===
@@ -308,11 +643,37 @@ object SanelyConfiguredSuite extends TestSuite:
       given Configuration = Configuration.default
       given Codec[Color] = SanelyEnumCodec.derived
 
-      val result = Json.fromString("Purple").as[Color]
-      assert(result.isLeft)
+      assert(Json.fromString("Purple").as[Color].isLeft)
     }
 
-    test("enum codec - transformConstructorNames") {
+    test("enum codec - snake_case") {
+      given Configuration = Configuration.default.withSnakeCaseConstructorNames
+      given Codec[IntercardinalDirections] = SanelyEnumCodec.derived
+
+      val ne = IntercardinalDirections.NorthEast
+      assert(ne.asJson == Json.fromString("north_east"))
+      assert(Json.fromString("north_east").as[IntercardinalDirections] == Right(ne))
+    }
+
+    test("enum codec - SCREAMING_SNAKE_CASE") {
+      given Configuration = Configuration.default.withScreamingSnakeCaseConstructorNames
+      given Codec[IntercardinalDirections] = SanelyEnumCodec.derived
+
+      val se = IntercardinalDirections.SouthEast
+      assert(se.asJson == Json.fromString("SOUTH_EAST"))
+      assert(Json.fromString("SOUTH_EAST").as[IntercardinalDirections] == Right(se))
+    }
+
+    test("enum codec - kebab-case") {
+      given Configuration = Configuration.default.withKebabCaseConstructorNames
+      given Codec[IntercardinalDirections] = SanelyEnumCodec.derived
+
+      val sw = IntercardinalDirections.SouthWest
+      assert(sw.asJson == Json.fromString("south-west"))
+      assert(Json.fromString("south-west").as[IntercardinalDirections] == Right(sw))
+    }
+
+    test("enum codec - transformConstructorNames (Direction)") {
       given Configuration = Configuration.default.withSnakeCaseConstructorNames
       given Codec[Direction] = SanelyEnumCodec.derived
 
@@ -320,6 +681,24 @@ object SanelyConfiguredSuite extends TestSuite:
       assert(Direction.South.asJson == Json.fromString("south"))
       assert(Json.fromString("north").as[Direction] == Right(Direction.North))
       assert(Json.fromString("east").as[Direction] == Right(Direction.East))
+    }
+
+    test("enum codec - hierarchical sealed trait") {
+      given Configuration = Configuration.default
+      given Codec[HierarchicalEnum] = SanelyEnumCodec.derived
+
+      val enc = summon[Encoder[HierarchicalEnum]]
+      val dec = summon[Decoder[HierarchicalEnum]]
+
+      assert(enc(HierarchicalEnum.A) == Json.fromString("A"))
+      assert(dec.decodeJson(Json.fromString("A")) == Right(HierarchicalEnum.A))
+
+      assert(enc(HierarchicalEnum.C) == Json.fromString("C"))
+      assert(dec.decodeJson(Json.fromString("C")) == Right(HierarchicalEnum.C))
+
+      // Diamond case
+      assert(enc(HierarchicalEnum.D) == Json.fromString("D"))
+      assert(dec.decodeJson(Json.fromString("D")) == Right(HierarchicalEnum.D))
     }
 
     // === SanelyConfiguredCodec ===
@@ -331,8 +710,7 @@ object SanelyConfiguredSuite extends TestSuite:
       val v = SnakeCaseProduct("Test", "User", 55555)
       val json = v.asJson
       assert(json.hcursor.downField("first_name").as[String] == Right("Test"))
-      val decoded = json.as[SnakeCaseProduct]
-      assert(decoded == Right(v))
+      assert(json.as[SnakeCaseProduct] == Right(v))
     }
 
     // === semiauto API ===


### PR DESCRIPTION
## Summary
- Port all remaining tests from circe's `ConfiguredDerivesSuite` and `ConfiguredEnumDerivesSuites` for full compatibility coverage (54 configured tests)
- Fix `SanelyEnumCodec` to support hierarchical sealed traits (nested `sealed trait` with case objects) by recursing into `Mirror.SumOf` sub-types
- Fix `SanelyConfiguredDecoder` so `Option` fields with `null` JSON values decode as `None` instead of using the default value (null triggers default only for non-Option types)

## Test plan
- [x] 106 tests pass on JVM (52 auto + 54 configured)
- [x] 105/106 pass on JS (pre-existing Long precision issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)