### PR TITLE
test: add missing circe configured derivation compat tests

### DIFF
--- a/sanely/src/sanely/SanelyConfiguredDecoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredDecoder.scala
@@ -185,9 +185,13 @@ object SanelyConfiguredDecoder:
                 // External tagging mode
                 c.keys match
                   case Some(keys) =>
-                    val transformedLabels = $directLabelsExpr.map(l => $conf.transformConstructorNames(l))
-                    val key = keys.find(transformedLabels.toSet.contains).getOrElse("")
-                    ${ buildMatchExternal('c, 'key) }
+                    val keysList = keys.toList
+                    if $conf.strictDecoding && keysList.size > 1 then
+                      Left(DecodingFailure("Expected single-key JSON object for sum type", c.history))
+                    else
+                      val transformedLabels = $directLabelsExpr.map(l => $conf.transformConstructorNames(l))
+                      val key = keysList.find(transformedLabels.toSet.contains).getOrElse("")
+                      ${ buildMatchExternal('c, 'key) }
                   case None =>
                     Left(DecodingFailure("Expected JSON object for sum type", c.history))
       }
@@ -219,16 +223,24 @@ object SanelyConfiguredDecoder:
         case Some(companion) =>
           // Get the number of fields from the primary constructor
           val primaryCtor = sym.primaryConstructor
-          val paramCount = primaryCtor.paramSymss.headOption.map(_.size).getOrElse(0)
+          // Skip type parameter lists, only count value parameters
+          val paramCount = primaryCtor.paramSymss
+            .find(_.headOption.exists(s => !s.isTypeParam))
+            .map(_.size)
+            .getOrElse(0)
           (1 to paramCount).toList.map { idx =>
             val methodName = s"$$lessinit$$greater$$default$$$idx"
-            companion.declaredMethod(methodName).headOption.map { method =>
+            val found = companion.declaredMethod(methodName).headOption
+            found.map { method =>
               val select = Ref(companion).select(method)
-              // Apply type args if needed
-              val applied = tpe match
-                case AppliedType(_, args) if args.nonEmpty =>
-                  select.appliedToTypes(args)
-                case _ => select
+              // Apply type args if the method has type parameters
+              val applied =
+                if method.paramSymss.exists(_.exists(_.isTypeParam)) then
+                  tpe match
+                    case AppliedType(_, args) if args.nonEmpty =>
+                      select.appliedToTypes(args)
+                    case _ => select
+                else select
               applied.asExpr
             }
           }

--- a/sanely/test/src/sanely/SanelyConfiguredSuite.scala
+++ b/sanely/test/src/sanely/SanelyConfiguredSuite.scala
@@ -81,6 +81,13 @@ object HierarchicalEnum:
   case object C extends NestedB
   case object D extends NestedA with NestedB // diamond
 
+// Generic class with defaults (mirrors circe's GenericFoo)
+case class GenericFoo[T](a: List[T] = List.empty, b: String = "b")
+
+object GenericFooHelper:
+  given Configuration = Configuration.default.withDefaults
+  val genericFooIntDecoder: Decoder[GenericFoo[Int]] = SanelyConfiguredDecoder.derived
+
 object SanelyConfiguredSuite extends TestSuite:
   val tests = Tests {
 
@@ -699,6 +706,47 @@ object SanelyConfiguredSuite extends TestSuite:
       // Diamond case
       assert(enc(HierarchicalEnum.D) == Json.fromString("D"))
       assert(dec.decodeJson(Json.fromString("D")) == Right(HierarchicalEnum.D))
+    }
+
+    // === strictDecoding on sum types ===
+
+    test("strictDecoding - rejects multiple keys on sum type") {
+      given Configuration = Configuration.default.withStrictDecoding
+      given Decoder[ConfigExampleBase] = SanelyConfiguredDecoder.derived
+
+      val json = Json.obj(
+        "ConfigExampleFoo" -> Json.obj(
+          "thisIsAField" -> Json.fromString("x"),
+          "a" -> Json.fromInt(0),
+          "b" -> Json.fromDoubleOrNull(2.5)
+        ),
+        "anotherField" -> Json.fromString("some value")
+      )
+      assert(json.as[ConfigExampleBase].isLeft)
+    }
+
+    test("strictDecoding - rejects unexpected fields inside product variant of sum type") {
+      given Configuration = Configuration.default.withStrictDecoding
+      given Decoder[ConfigExampleBase] = SanelyConfiguredDecoder.derived
+
+      val json = Json.obj(
+        "ConfigExampleFoo" -> Json.obj(
+          "thisIsAField" -> Json.fromString("x"),
+          "a" -> Json.fromInt(0),
+          "b" -> Json.fromDoubleOrNull(2.5),
+          "anotherField" -> Json.fromString("some value")
+        )
+      )
+      assert(json.as[ConfigExampleBase].isLeft)
+    }
+
+    // === useDefaults with generic classes ===
+
+    test("useDefaults - generic class with defaults") {
+      val dec = GenericFooHelper.genericFooIntDecoder
+
+      val json = Json.obj()
+      assert(dec.decodeJson(json) == Right(GenericFoo(List.empty[Int], "b")))
     }
 
     // === SanelyConfiguredCodec ===


### PR DESCRIPTION
## Summary
- Add 3 missing tests from circe's `ConfiguredDerivesSuite`:
  - `strictDecoding` rejects multiple keys on sum types (external tagging)
  - `strictDecoding` rejects unexpected fields inside product variants of sum types
  - `useDefaults` works with generic classes (`GenericFoo[T]`)
- Fix `SanelyConfiguredDecoder` to reject multi-key JSON objects in strict sum type decoding
- Fix default value lookup for generic classes: skip type param lists when counting constructor params, and only apply type args to default methods that actually have type params

## Test plan
- [x] `./mill sanely.jvm.test` — 109/109 pass
- [x] `./mill sanely.js.test` — 109/109 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)