### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Supports hierarchical sealed traits with diamond inheritance.
 
 ```diff
 - mvn"io.circe::circe-generic:0.14.x"
-+ mvn"io.github.nguyenyou::circe-sanely-auto:0.2.0"
++ mvn"io.github.nguyenyou::circe-sanely-auto:0.3.0"
 ```
 
 ### Step 2: Update imports

--- a/sanely/package.mill
+++ b/sanely/package.mill
@@ -16,7 +16,7 @@ object `package` extends mill.Module {
   trait SharedModule extends PlatformScalaModule with SonatypeCentralPublishModule {
     def artifactName = "circe-sanely-auto"
     def scalaVersion = build.scala3Version
-    def publishVersion = "0.2.0"
+    def publishVersion = "0.3.0"
 
     def pomSettings = PomSettings(
       description = "Drop-in replacement for circe's auto-derivation using sanely-automatic Scala 3 macros",


### PR DESCRIPTION
## Summary
- Bump publishVersion to 0.3.0
- Update README dependency example to 0.3.0
- Published to Maven Central (JVM + Scala.js)

## Test plan
- [x] 269 tests pass before publish
- [x] `sanely.jvm.publishSonatypeCentral` succeeded
- [x] `sanely.js.publishSonatypeCentral` succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)