### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/sanely/src/sanely/SanelyConfiguredDecoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredDecoder.scala
@@ -209,6 +209,7 @@ object SanelyConfiguredDecoder:
               ).toString
           val dec = resolveOneDecoder[t](selfRef)
           (labelStr, Type.of[t], dec) :: resolveFields[ts, ls](selfRef)
+        case _ => report.errorAndAbort("Mismatched Types and Labels tuple lengths")
 
     private def resolveDefaults[P: Type]: List[Option[Expr[Any]]] =
       val tpe = TypeRepr.of[P]
@@ -338,5 +339,6 @@ object SanelyConfiguredDecoder:
                   '{ Decoder.decodeMap[k, v](using $keyDec, $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
                 case None =>
                   report.errorAndAbort(s"Cannot derive Decoder for Map: no KeyDecoder for ${Type.show[k]}")
+            case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive decoder")
         case _ =>
           report.errorAndAbort(s"Cannot derive Decoder for recursive type application: ${Type.show[T]}")

--- a/sanely/src/sanely/SanelyConfiguredEncoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredEncoder.scala
@@ -138,6 +138,7 @@ object SanelyConfiguredEncoder:
               ).toString
           val enc = resolveOneEncoder[t](selfRef)
           (labelStr, Type.of[t], enc) :: resolveFields[ts, ls](selfRef)
+        case _ => report.errorAndAbort("Mismatched Types and Labels tuple lengths")
 
     private def resolveOneEncoder[T: Type](
       selfRef: Expr[Encoder.AsObject[A]]
@@ -232,5 +233,6 @@ object SanelyConfiguredEncoder:
                   '{ Encoder.encodeMap[k, v](using $keyEnc, $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
                 case None =>
                   report.errorAndAbort(s"Cannot derive Encoder for Map: no KeyEncoder for ${Type.show[k]}")
+            case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive encoder")
         case _ =>
           report.errorAndAbort(s"Cannot derive Encoder for recursive type application: ${Type.show[T]}")

--- a/sanely/src/sanely/SanelyDecoder.scala
+++ b/sanely/src/sanely/SanelyDecoder.scala
@@ -125,6 +125,7 @@ object SanelyDecoder:
               ).toString
           val dec = resolveOneDecoder[t](selfRef)
           (labelStr, Type.of[t], dec) :: resolveFields[ts, ls](selfRef)
+        case _ => report.errorAndAbort("Mismatched Types and Labels tuple lengths")
 
     private def resolveOneDecoder[T: Type](
       selfRef: Expr[Decoder[A]]
@@ -224,5 +225,6 @@ object SanelyDecoder:
                   '{ Decoder.decodeMap[k, v](using $keyDec, $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
                 case None =>
                   report.errorAndAbort(s"Cannot derive Decoder for Map: no KeyDecoder for ${Type.show[k]}")
+            case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive decoder")
         case _ =>
           report.errorAndAbort(s"Cannot derive Decoder for recursive type application: ${Type.show[T]}")

--- a/sanely/src/sanely/SanelyEncoder.scala
+++ b/sanely/src/sanely/SanelyEncoder.scala
@@ -111,6 +111,7 @@ object SanelyEncoder:
               ).toString
           val enc = resolveOneEncoder[t](selfRef)
           (labelStr, Type.of[t], enc) :: resolveFields[ts, ls](selfRef)
+        case _ => report.errorAndAbort("Mismatched Types and Labels tuple lengths")
 
     private def resolveOneEncoder[T: Type](
       selfRef: Expr[Encoder.AsObject[A]]
@@ -211,5 +212,6 @@ object SanelyEncoder:
                   '{ Encoder.encodeMap[k, v](using $keyEnc, $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
                 case None =>
                   report.errorAndAbort(s"Cannot derive Encoder for Map: no KeyEncoder for ${Type.show[k]}")
+            case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive encoder")
         case _ =>
           report.errorAndAbort(s"Cannot derive Encoder for recursive type application: ${Type.show[T]}")

--- a/sanely/src/sanely/SanelyEnumCodec.scala
+++ b/sanely/src/sanely/SanelyEnumCodec.scala
@@ -35,6 +35,7 @@ object SanelyEnumCodec:
               Type.valueOfConstant[l].getOrElse(
                 report.errorAndAbort(s"Expected literal string type for enum label")
               ).toString
+
           val casesForThis: List[(String, Expr[S])] = Expr.summon[Mirror.ProductOf[t]] match
             case Some('{ $pm: Mirror.ProductOf[t] { type MirroredElemTypes = EmptyTuple } }) =>
               // Zero-field product = singleton
@@ -49,6 +50,7 @@ object SanelyEnumCodec:
                 case None =>
                   report.errorAndAbort(s"Enum case '${labelStr}' is not a singleton (has fields). SanelyEnumCodec only supports pure-value enums.")
           casesForThis ++ collectSingletonCases[S, ts, ls](mirror)
+        case _ => report.errorAndAbort("Mismatched Types and Labels tuple lengths")
 
     private def buildCodec[S: Type](
       mirror: Expr[Mirror.SumOf[S]],

--- a/sanely/test/src/sanely/SanelyAutoSuite.scala
+++ b/sanely/test/src/sanely/SanelyAutoSuite.scala
@@ -637,6 +637,7 @@ object SanelyAutoSuite extends TestSuite:
         val v2 = Wub(Long.MinValue)
         val decoded2 = decode[Wub](v2.asJson.noSpaces)
         assert(decoded2 == Right(v2))
+      else ()
 
       val v3 = Wub(0L)
       val decoded3 = decode[Wub](v3.asJson.noSpaces)


### PR DESCRIPTION
## Summary
- Add exhaustive match wildcard cases for `(Type.of[Types], Type.of[Labels]) match` and `(keyArg.asType, valArg.asType) match` in all 5 macro derivation files (9 warnings)
- Add `else ()` branch to `if !Platform.isJS` check in test suite to suppress dead code warning on Scala.js (1 warning)
- All 269 tests pass, zero warnings

## Test plan
- [x] `./mill sanely.jvm.test` — 57/57 passed, no warnings
- [x] `./mill sanely.js.test` — 109/109 passed, no warnings
- [x] `./mill compat.test` — 160 passed, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)