### PR TITLE
chore: release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.1] - 2026-03-04
+
+### Added
+- GitHub Actions CI workflow (JVM unit tests, Scala.js unit tests, compat tests)
+- CI status badge in README
+
+### Fixed
+- Resolved all 10 compiler warnings:
+  - 9 non-exhaustive match warnings in macro derivation files (added wildcard cases for tuple type pattern matching)
+  - 1 dead code warning on Scala.js for `Platform.isJS` check (added `else` branch)
+
 ## [0.3.0] - 2026-03-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Supports hierarchical sealed traits with diamond inheritance.
 
 ```diff
 - mvn"io.circe::circe-generic:0.14.x"
-+ mvn"io.github.nguyenyou::circe-sanely-auto:0.3.0"
++ mvn"io.github.nguyenyou::circe-sanely-auto:0.3.1"
 ```
 
 ### Step 2: Update imports

--- a/sanely/package.mill
+++ b/sanely/package.mill
@@ -16,7 +16,7 @@ object `package` extends mill.Module {
   trait SharedModule extends PlatformScalaModule with SonatypeCentralPublishModule {
     def artifactName = "circe-sanely-auto"
     def scalaVersion = build.scala3Version
-    def publishVersion = "0.3.0"
+    def publishVersion = "0.3.1"
 
     def pomSettings = PomSettings(
       description = "Drop-in replacement for circe's auto-derivation using sanely-automatic Scala 3 macros",


### PR DESCRIPTION
## Summary
- Bump version to 0.3.1
- Update CHANGELOG.md with CI and warning fix entries
- Update README.md version reference

## Published
- `io.github.nguyenyou::circe-sanely-auto:0.3.1` (JVM + Scala.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)