### PR TITLE
feat: support nested recursive container types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## Important Rules
+
+- **This is a purely open source project.** Never mention any company names, internal projects, proprietary codebases, or employer-related information anywhere — not in code, commit messages, PR descriptions, comments, changelogs, or documentation. All references must remain generic and public.
+
 ## Project
 
 Drop-in replacement for circe's auto/semi-auto/configured derivation. Scala 3.8.2+ only. Uses the "sanely-automatic" approach — Scala 3 macros with `Expr.summonIgnoring` to derive all instances in a single macro expansion, avoiding implicit search chains.

--- a/sanely/src/sanely/SanelyConfiguredDecoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredDecoder.scala
@@ -307,29 +307,7 @@ object SanelyConfiguredDecoder:
           arg.asType match
             case '[a] =>
               val innerDec = selfRef.asInstanceOf[Expr[Decoder[a]]]
-              tycon.typeSymbol.fullName match
-                case "scala.Option" =>
-                  '{ Decoder.decodeOption[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case s if s.endsWith(".List") =>
-                  '{ Decoder.decodeList[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case s if s.endsWith(".Vector") =>
-                  '{ Decoder.decodeVector[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case s if s.endsWith(".Set") =>
-                  '{ Decoder.decodeSet[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case s if s.endsWith(".Seq") =>
-                  '{ Decoder.decodeSeq[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.Chain" =>
-                  '{ Decoder.decodeChain[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.NonEmptyList" =>
-                  '{ Decoder.decodeNonEmptyList[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.NonEmptyVector" =>
-                  '{ Decoder.decodeNonEmptyVector[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.NonEmptySeq" =>
-                  '{ Decoder.decodeNonEmptySeq[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.NonEmptyChain" =>
-                  '{ Decoder.decodeNonEmptyChain[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case other =>
-                  report.errorAndAbort(s"Cannot derive Decoder for recursive type in container ${other}[${Type.show[a]}]")
+              buildContainerDecoder[T, a](tycon, innerDec)
         case AppliedType(tycon, List(keyArg, valArg)) if valArg =:= selfType =>
           (keyArg.asType, valArg.asType) match
             case ('[k], '[v]) =>
@@ -340,5 +318,48 @@ object SanelyConfiguredDecoder:
                 case None =>
                   report.errorAndAbort(s"Cannot derive Decoder for Map: no KeyDecoder for ${Type.show[k]}")
             case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive decoder")
+        case AppliedType(tycon, List(arg)) if containsType(arg, selfType) =>
+          arg.asType match
+            case '[a] =>
+              val innerDec = constructRecursiveDecoder[a](arg, selfRef)
+              buildContainerDecoder[T, a](tycon, innerDec)
+        case AppliedType(tycon, List(keyArg, valArg)) if containsType(valArg, selfType) =>
+          (keyArg.asType, valArg.asType) match
+            case ('[k], '[v]) =>
+              val innerDec = constructRecursiveDecoder[v](valArg, selfRef)
+              Expr.summon[io.circe.KeyDecoder[k]] match
+                case Some(keyDec) =>
+                  '{ Decoder.decodeMap[k, v](using $keyDec, $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case None =>
+                  report.errorAndAbort(s"Cannot derive Decoder for Map: no KeyDecoder for ${Type.show[k]}")
+            case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive decoder")
         case _ =>
           report.errorAndAbort(s"Cannot derive Decoder for recursive type application: ${Type.show[T]}")
+
+    private def buildContainerDecoder[T: Type, A: Type](
+      tycon: TypeRepr,
+      innerDec: Expr[Decoder[A]]
+    ): Expr[Decoder[T]] =
+      tycon.typeSymbol.fullName match
+        case "scala.Option" =>
+          '{ Decoder.decodeOption[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case s if s.endsWith(".List") =>
+          '{ Decoder.decodeList[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case s if s.endsWith(".Vector") =>
+          '{ Decoder.decodeVector[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case s if s.endsWith(".Set") =>
+          '{ Decoder.decodeSet[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case s if s.endsWith(".Seq") =>
+          '{ Decoder.decodeSeq[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.Chain" =>
+          '{ Decoder.decodeChain[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.NonEmptyList" =>
+          '{ Decoder.decodeNonEmptyList[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.NonEmptyVector" =>
+          '{ Decoder.decodeNonEmptyVector[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.NonEmptySeq" =>
+          '{ Decoder.decodeNonEmptySeq[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.NonEmptyChain" =>
+          '{ Decoder.decodeNonEmptyChain[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case other =>
+          report.errorAndAbort(s"Cannot derive Decoder for recursive type in container ${other}[${Type.show[A]}]")

--- a/sanely/src/sanely/SanelyConfiguredEncoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredEncoder.scala
@@ -201,29 +201,7 @@ object SanelyConfiguredEncoder:
           arg.asType match
             case '[a] =>
               val innerEnc = selfRef.asInstanceOf[Expr[Encoder[a]]]
-              tycon.typeSymbol.fullName match
-                case "scala.Option" =>
-                  '{ Encoder.encodeOption[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case s if s.endsWith(".List") =>
-                  '{ Encoder.encodeList[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case s if s.endsWith(".Vector") =>
-                  '{ Encoder.encodeVector[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case s if s.endsWith(".Set") =>
-                  '{ Encoder.encodeSet[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case s if s.endsWith(".Seq") =>
-                  '{ Encoder.encodeSeq[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.Chain" =>
-                  '{ Encoder.encodeChain[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.NonEmptyList" =>
-                  '{ Encoder.encodeNonEmptyList[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.NonEmptyVector" =>
-                  '{ Encoder.encodeNonEmptyVector[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.NonEmptySeq" =>
-                  '{ Encoder.encodeNonEmptySeq[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.NonEmptyChain" =>
-                  '{ Encoder.encodeNonEmptyChain[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case other =>
-                  report.errorAndAbort(s"Cannot derive Encoder for recursive type in container ${other}[${Type.show[a]}]")
+              buildContainerEncoder[T, a](tycon, innerEnc)
         case AppliedType(tycon, List(keyArg, valArg)) if valArg =:= selfType =>
           (keyArg.asType, valArg.asType) match
             case ('[k], '[v]) =>
@@ -234,5 +212,48 @@ object SanelyConfiguredEncoder:
                 case None =>
                   report.errorAndAbort(s"Cannot derive Encoder for Map: no KeyEncoder for ${Type.show[k]}")
             case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive encoder")
+        case AppliedType(tycon, List(arg)) if containsType(arg, selfType) =>
+          arg.asType match
+            case '[a] =>
+              val innerEnc = constructRecursiveEncoder[a](arg, selfRef)
+              buildContainerEncoder[T, a](tycon, innerEnc)
+        case AppliedType(tycon, List(keyArg, valArg)) if containsType(valArg, selfType) =>
+          (keyArg.asType, valArg.asType) match
+            case ('[k], '[v]) =>
+              val innerEnc = constructRecursiveEncoder[v](valArg, selfRef)
+              Expr.summon[io.circe.KeyEncoder[k]] match
+                case Some(keyEnc) =>
+                  '{ Encoder.encodeMap[k, v](using $keyEnc, $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case None =>
+                  report.errorAndAbort(s"Cannot derive Encoder for Map: no KeyEncoder for ${Type.show[k]}")
+            case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive encoder")
         case _ =>
           report.errorAndAbort(s"Cannot derive Encoder for recursive type application: ${Type.show[T]}")
+
+    private def buildContainerEncoder[T: Type, A: Type](
+      tycon: TypeRepr,
+      innerEnc: Expr[Encoder[A]]
+    ): Expr[Encoder[T]] =
+      tycon.typeSymbol.fullName match
+        case "scala.Option" =>
+          '{ Encoder.encodeOption[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case s if s.endsWith(".List") =>
+          '{ Encoder.encodeList[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case s if s.endsWith(".Vector") =>
+          '{ Encoder.encodeVector[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case s if s.endsWith(".Set") =>
+          '{ Encoder.encodeSet[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case s if s.endsWith(".Seq") =>
+          '{ Encoder.encodeSeq[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.Chain" =>
+          '{ Encoder.encodeChain[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.NonEmptyList" =>
+          '{ Encoder.encodeNonEmptyList[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.NonEmptyVector" =>
+          '{ Encoder.encodeNonEmptyVector[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.NonEmptySeq" =>
+          '{ Encoder.encodeNonEmptySeq[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.NonEmptyChain" =>
+          '{ Encoder.encodeNonEmptyChain[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case other =>
+          report.errorAndAbort(s"Cannot derive Encoder for recursive type in container ${other}[${Type.show[A]}]")

--- a/sanely/src/sanely/SanelyDecoder.scala
+++ b/sanely/src/sanely/SanelyDecoder.scala
@@ -193,29 +193,7 @@ object SanelyDecoder:
           arg.asType match
             case '[a] =>
               val innerDec = selfRef.asInstanceOf[Expr[Decoder[a]]]
-              tycon.typeSymbol.fullName match
-                case "scala.Option" =>
-                  '{ Decoder.decodeOption[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case s if s.endsWith(".List") =>
-                  '{ Decoder.decodeList[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case s if s.endsWith(".Vector") =>
-                  '{ Decoder.decodeVector[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case s if s.endsWith(".Set") =>
-                  '{ Decoder.decodeSet[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case s if s.endsWith(".Seq") =>
-                  '{ Decoder.decodeSeq[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.Chain" =>
-                  '{ Decoder.decodeChain[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.NonEmptyList" =>
-                  '{ Decoder.decodeNonEmptyList[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.NonEmptyVector" =>
-                  '{ Decoder.decodeNonEmptyVector[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.NonEmptySeq" =>
-                  '{ Decoder.decodeNonEmptySeq[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case "cats.data.NonEmptyChain" =>
-                  '{ Decoder.decodeNonEmptyChain[a](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
-                case other =>
-                  report.errorAndAbort(s"Cannot derive Decoder for recursive type in container ${other}[${Type.show[a]}]")
+              buildContainerDecoder[T, a](tycon, innerDec)
         case AppliedType(tycon, List(keyArg, valArg)) if valArg =:= selfType =>
           (keyArg.asType, valArg.asType) match
             case ('[k], '[v]) =>
@@ -226,5 +204,48 @@ object SanelyDecoder:
                 case None =>
                   report.errorAndAbort(s"Cannot derive Decoder for Map: no KeyDecoder for ${Type.show[k]}")
             case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive decoder")
+        case AppliedType(tycon, List(arg)) if containsType(arg, selfType) =>
+          arg.asType match
+            case '[a] =>
+              val innerDec = constructRecursiveDecoder[a](arg, selfRef)
+              buildContainerDecoder[T, a](tycon, innerDec)
+        case AppliedType(tycon, List(keyArg, valArg)) if containsType(valArg, selfType) =>
+          (keyArg.asType, valArg.asType) match
+            case ('[k], '[v]) =>
+              val innerDec = constructRecursiveDecoder[v](valArg, selfRef)
+              Expr.summon[io.circe.KeyDecoder[k]] match
+                case Some(keyDec) =>
+                  '{ Decoder.decodeMap[k, v](using $keyDec, $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+                case None =>
+                  report.errorAndAbort(s"Cannot derive Decoder for Map: no KeyDecoder for ${Type.show[k]}")
+            case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive decoder")
         case _ =>
           report.errorAndAbort(s"Cannot derive Decoder for recursive type application: ${Type.show[T]}")
+
+    private def buildContainerDecoder[T: Type, A: Type](
+      tycon: TypeRepr,
+      innerDec: Expr[Decoder[A]]
+    ): Expr[Decoder[T]] =
+      tycon.typeSymbol.fullName match
+        case "scala.Option" =>
+          '{ Decoder.decodeOption[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case s if s.endsWith(".List") =>
+          '{ Decoder.decodeList[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case s if s.endsWith(".Vector") =>
+          '{ Decoder.decodeVector[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case s if s.endsWith(".Set") =>
+          '{ Decoder.decodeSet[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case s if s.endsWith(".Seq") =>
+          '{ Decoder.decodeSeq[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.Chain" =>
+          '{ Decoder.decodeChain[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.NonEmptyList" =>
+          '{ Decoder.decodeNonEmptyList[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.NonEmptyVector" =>
+          '{ Decoder.decodeNonEmptyVector[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.NonEmptySeq" =>
+          '{ Decoder.decodeNonEmptySeq[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case "cats.data.NonEmptyChain" =>
+          '{ Decoder.decodeNonEmptyChain[A](using $innerDec) }.asInstanceOf[Expr[Decoder[T]]]
+        case other =>
+          report.errorAndAbort(s"Cannot derive Decoder for recursive type in container ${other}[${Type.show[A]}]")

--- a/sanely/src/sanely/SanelyEncoder.scala
+++ b/sanely/src/sanely/SanelyEncoder.scala
@@ -180,29 +180,7 @@ object SanelyEncoder:
           arg.asType match
             case '[a] =>
               val innerEnc = selfRef.asInstanceOf[Expr[Encoder[a]]]
-              tycon.typeSymbol.fullName match
-                case "scala.Option" =>
-                  '{ Encoder.encodeOption[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case s if s.endsWith(".List") =>
-                  '{ Encoder.encodeList[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case s if s.endsWith(".Vector") =>
-                  '{ Encoder.encodeVector[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case s if s.endsWith(".Set") =>
-                  '{ Encoder.encodeSet[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case s if s.endsWith(".Seq") =>
-                  '{ Encoder.encodeSeq[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.Chain" =>
-                  '{ Encoder.encodeChain[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.NonEmptyList" =>
-                  '{ Encoder.encodeNonEmptyList[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.NonEmptyVector" =>
-                  '{ Encoder.encodeNonEmptyVector[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.NonEmptySeq" =>
-                  '{ Encoder.encodeNonEmptySeq[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case "cats.data.NonEmptyChain" =>
-                  '{ Encoder.encodeNonEmptyChain[a](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
-                case other =>
-                  report.errorAndAbort(s"Cannot derive Encoder for recursive type in container ${other}[${Type.show[a]}]")
+              buildContainerEncoder[T, a](tycon, innerEnc)
         case AppliedType(tycon, List(keyArg, valArg)) if valArg =:= selfType =>
           (keyArg.asType, valArg.asType) match
             case ('[k], '[v]) =>
@@ -213,5 +191,48 @@ object SanelyEncoder:
                 case None =>
                   report.errorAndAbort(s"Cannot derive Encoder for Map: no KeyEncoder for ${Type.show[k]}")
             case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive encoder")
+        case AppliedType(tycon, List(arg)) if containsType(arg, selfType) =>
+          arg.asType match
+            case '[a] =>
+              val innerEnc = constructRecursiveEncoder[a](arg, selfRef)
+              buildContainerEncoder[T, a](tycon, innerEnc)
+        case AppliedType(tycon, List(keyArg, valArg)) if containsType(valArg, selfType) =>
+          (keyArg.asType, valArg.asType) match
+            case ('[k], '[v]) =>
+              val innerEnc = constructRecursiveEncoder[v](valArg, selfRef)
+              Expr.summon[io.circe.KeyEncoder[k]] match
+                case Some(keyEnc) =>
+                  '{ Encoder.encodeMap[k, v](using $keyEnc, $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+                case None =>
+                  report.errorAndAbort(s"Cannot derive Encoder for Map: no KeyEncoder for ${Type.show[k]}")
+            case _ => report.errorAndAbort(s"Unexpected type pattern in Map recursive encoder")
         case _ =>
           report.errorAndAbort(s"Cannot derive Encoder for recursive type application: ${Type.show[T]}")
+
+    private def buildContainerEncoder[T: Type, A: Type](
+      tycon: TypeRepr,
+      innerEnc: Expr[Encoder[A]]
+    ): Expr[Encoder[T]] =
+      tycon.typeSymbol.fullName match
+        case "scala.Option" =>
+          '{ Encoder.encodeOption[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case s if s.endsWith(".List") =>
+          '{ Encoder.encodeList[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case s if s.endsWith(".Vector") =>
+          '{ Encoder.encodeVector[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case s if s.endsWith(".Set") =>
+          '{ Encoder.encodeSet[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case s if s.endsWith(".Seq") =>
+          '{ Encoder.encodeSeq[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.Chain" =>
+          '{ Encoder.encodeChain[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.NonEmptyList" =>
+          '{ Encoder.encodeNonEmptyList[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.NonEmptyVector" =>
+          '{ Encoder.encodeNonEmptyVector[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.NonEmptySeq" =>
+          '{ Encoder.encodeNonEmptySeq[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case "cats.data.NonEmptyChain" =>
+          '{ Encoder.encodeNonEmptyChain[A](using $innerEnc) }.asInstanceOf[Expr[Encoder[T]]]
+        case other =>
+          report.errorAndAbort(s"Cannot derive Encoder for recursive type in container ${other}[${Type.show[A]}]")

--- a/sanely/test/src/sanely/SanelyAutoSuite.scala
+++ b/sanely/test/src/sanely/SanelyAutoSuite.scala
@@ -141,6 +141,11 @@ case class RecursiveWithSeq(children: Seq[RecursiveWithSeq], value: String)
 // Recursive with Map
 case class RecursiveWithMap(children: Map[String, RecursiveWithMap], value: String)
 
+// Recursive with nested containers (Option[List[Self]], Option[Map[String, Self]])
+case class RecursiveWithOptionList(children: Option[List[RecursiveWithOptionList]], value: String)
+case class RecursiveWithOptionMap(properties: Option[Map[String, RecursiveWithOptionMap]], name: String)
+case class RecursiveWithListOption(items: List[Option[RecursiveWithListOption]], value: String)
+
 // Tagged type member
 case class ProductWithTaggedMember(x: ProductWithTaggedMember.TaggedString)
 object ProductWithTaggedMember:
@@ -689,6 +694,37 @@ object SanelyAutoSuite extends TestSuite:
       val json = v.asJson
       val decoded = decode[RecursiveWithMap](json.noSpaces)
       assert(decoded == Right(v))
+    }
+
+    // --- Recursive with nested containers ---
+
+    test("Recursive with Option[List[Self]] round-trip") {
+      val leaf = RecursiveWithOptionList(None, "leaf")
+      val branch = RecursiveWithOptionList(Some(List(leaf, leaf)), "branch")
+      val root = RecursiveWithOptionList(Some(List(branch)), "root")
+      val json = root.asJson
+      val decoded = decode[RecursiveWithOptionList](json.noSpaces)
+      assert(decoded == Right(root))
+      // Also test None case
+      val decoded2 = decode[RecursiveWithOptionList](leaf.asJson.noSpaces)
+      assert(decoded2 == Right(leaf))
+    }
+
+    test("Recursive with Option[Map[String, Self]] round-trip") {
+      val leaf = RecursiveWithOptionMap(None, "leaf")
+      val branch = RecursiveWithOptionMap(Some(Map("a" -> leaf, "b" -> leaf)), "branch")
+      val root = RecursiveWithOptionMap(Some(Map("child" -> branch)), "root")
+      val json = root.asJson
+      val decoded = decode[RecursiveWithOptionMap](json.noSpaces)
+      assert(decoded == Right(root))
+    }
+
+    test("Recursive with List[Option[Self]] round-trip") {
+      val leaf = RecursiveWithListOption(List(None), "leaf")
+      val branch = RecursiveWithListOption(List(Some(leaf), None), "branch")
+      val json = branch.asJson
+      val decoded = decode[RecursiveWithListOption](json.noSpaces)
+      assert(decoded == Right(branch))
     }
 
     // --- Tagged type member ---

--- a/sanely/test/src/sanely/SanelyConfiguredSuite.scala
+++ b/sanely/test/src/sanely/SanelyConfiguredSuite.scala
@@ -84,6 +84,10 @@ object HierarchicalEnum:
 // Generic class with defaults (mirrors circe's GenericFoo)
 case class GenericFoo[T](a: List[T] = List.empty, b: String = "b")
 
+// Recursive types with nested containers (real-world patterns)
+case class ConfigRecursiveOptionList(children: Option[List[ConfigRecursiveOptionList]] = None, value: String = "")
+case class ConfigRecursiveOptionMap(properties: Option[Map[String, ConfigRecursiveOptionMap]] = None, name: String = "")
+
 object GenericFooHelper:
   given Configuration = Configuration.default.withDefaults
   val genericFooIntDecoder: Decoder[GenericFoo[Int]] = SanelyConfiguredDecoder.derived
@@ -793,5 +797,36 @@ object SanelyConfiguredSuite extends TestSuite:
 
       assert(Color.Red.asJson == Json.fromString("Red"))
       assert(Json.fromString("Blue").as[Color] == Right(Color.Blue))
+    }
+
+    // === Recursive types with nested containers ===
+
+    test("configured - recursive with Option[List[Self]]") {
+      given Configuration = Configuration.default.withDefaults
+      given Codec.AsObject[ConfigRecursiveOptionList] = SanelyConfiguredCodec.derived
+
+      val leaf = ConfigRecursiveOptionList(None, "leaf")
+      val branch = ConfigRecursiveOptionList(Some(List(leaf, leaf)), "branch")
+      val root = ConfigRecursiveOptionList(Some(List(branch)), "root")
+      val json = root.asJson
+      val decoded = json.as[ConfigRecursiveOptionList]
+      assert(decoded == Right(root))
+
+      // None terminates recursion
+      val leafJson = leaf.asJson
+      val decodedLeaf = leafJson.as[ConfigRecursiveOptionList]
+      assert(decodedLeaf == Right(leaf))
+    }
+
+    test("configured - recursive with Option[Map[String, Self]]") {
+      given Configuration = Configuration.default.withDefaults
+      given Codec.AsObject[ConfigRecursiveOptionMap] = SanelyConfiguredCodec.derived
+
+      val leaf = ConfigRecursiveOptionMap(None, "leaf")
+      val branch = ConfigRecursiveOptionMap(Some(Map("a" -> leaf, "b" -> leaf)), "branch")
+      val root = ConfigRecursiveOptionMap(Some(Map("child" -> branch)), "root")
+      val json = root.asJson
+      val decoded = json.as[ConfigRecursiveOptionMap]
+      assert(decoded == Right(root))
     }
   }


### PR DESCRIPTION
## Summary
- Support nested recursive container types like `Option[List[Self]]`, `Option[Map[String, Self]]`, `List[Option[Self]]`
- Previously only single-depth containers were handled (e.g. `Option[Self]`, `List[Self]`)
- Refactored container codec construction into reusable `buildContainerDecoder`/`buildContainerEncoder` helpers
- Added 5 new test cases covering nested recursive patterns in both auto and configured derivation suites
- Updated CLAUDE.md with open source project rule

## Test plan
- [x] `./mill sanely.jvm.test` — 114 passed
- [x] `./mill sanely.js.test` — 114 passed
- [x] `./mill compat.test` — 160 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)