### PR TITLE
Add configured derivation benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,22 +159,38 @@ Semiauto calls (`deriveEncoder`, `deriveDecoder`, `deriveCodec`) work identicall
 - **Scala 3 only** — no Scala 2 support, requires 3.8.2+
 - **No Shapeless** — uses Scala 3 `Mirror` + `Expr.summonIgnoring`
 
-## Compile-time benchmark
+## Compile-time benchmarks
 
-The benchmark compiles the same source (~300 types across 9 files) against both libraries:
+Two benchmark suites compare compile times against circe's native derivation:
 
-```
-bash bench.sh 5   # 5 iterations, reports median
+```bash
+bash bench.sh 5              # auto derivation (~300 types)
+bash bench.sh --configured 5 # configured derivation (~230 types)
 ```
 
 Results on M3 Max MacBook Pro (Mill 1.1.2, Scala 3.8.2):
 
+### Auto derivation
+
 | | Median compile time | |
 |---|---|---|
-| **circe-sanely-auto** | **3.77s** | |
-| **circe-generic** | **6.07s** | 1.6x slower |
+| **circe-sanely-auto** | **3.82s** | |
+| **circe-generic** | **6.14s** | 1.6x slower |
 
-The benchmark includes nested products, sealed trait hierarchies, generic instantiations, wide case classes (22 fields x 8), and cross-domain compositions.
+### Configured derivation
+
+| | Median compile time | |
+|---|---|---|
+| **circe-sanely-auto** | **2.76s** | |
+| **circe-core** | **2.69s** | ~same |
+
+### Why the difference?
+
+The speedup only applies to **auto derivation**. With `import io.circe.generic.auto.given`, the compiler must implicitly search for and synthesize codecs at every use site — each nested type triggers another round of implicit resolution. Sanely avoids this by deriving everything in a single macro expansion.
+
+**Configured derivation** uses explicit semi-auto calls (`deriveConfiguredCodec` in each companion object). There's no implicit search — you're telling the compiler exactly what to derive. Both implementations end up doing similar inline macro expansion, so compile times converge.
+
+In short: sanely's advantage is specifically in eliminating implicit search overhead, which only affects auto derivation.
 
 ## Building
 

--- a/bench.sh
+++ b/bench.sh
@@ -1,24 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-N=${1:-5}
+# Parse arguments
+BENCH_TYPE="benchmark"
+N=""
+for arg in "$@"; do
+  case "$arg" in
+    --configured) BENCH_TYPE="benchmark-configured" ;;
+    *) N="$arg" ;;
+  esac
+done
+N=${N:-5}
+
 echo "Compile-time benchmark: circe-sanely-auto vs circe-generic (N=$N)"
+echo "Benchmark suite: $BENCH_TYPE"
 echo "================================================================"
 
 for module in sanely generic; do
   times=()
   for i in $(seq 1 "$N"); do
-    rm -rf out/benchmark/$module
+    rm -rf "out/$BENCH_TYPE/$module"
     start=$(python3 -c 'import time; print(time.time())')
-    ./mill benchmark.$module.compile 2>/dev/null 1>/dev/null
+    ./mill "$BENCH_TYPE.$module.compile" 2>/dev/null 1>/dev/null
     end=$(python3 -c 'import time; print(time.time())')
     elapsed=$(python3 -c "print(f'{$end - $start:.2f}')")
     times+=("$elapsed")
-    echo "  benchmark.$module run $i: ${elapsed}s"
+    echo "  $BENCH_TYPE.$module run $i: ${elapsed}s"
   done
 
   # compute median
   median=$(printf '%s\n' "${times[@]}" | sort -n | awk -v n="$N" 'NR==int((n+1)/2){print}')
-  echo "benchmark.$module median: ${median}s (of ${times[*]})"
+  echo "$BENCH_TYPE.$module median: ${median}s (of ${times[*]})"
   echo ""
 done

--- a/benchmark-configured/generic-compat/src/io/circe/generic/semiauto.scala
+++ b/benchmark-configured/generic-compat/src/io/circe/generic/semiauto.scala
@@ -1,0 +1,15 @@
+package io.circe.generic
+
+import io.circe.{Codec, Decoder, Encoder}
+import io.circe.derivation.Configuration
+import scala.deriving.Mirror
+
+// Compatibility shim: exposes deriveConfiguredCodec using circe-core's native derivation.
+// This allows the configured benchmark to share source between the sanely and generic modules.
+object semiauto:
+  inline def deriveConfiguredDecoder[A](using inline conf: Configuration, inline m: Mirror.Of[A]): Decoder[A] =
+    io.circe.derivation.ConfiguredDecoder.derived[A]
+  inline def deriveConfiguredEncoder[A](using inline conf: Configuration, inline m: Mirror.Of[A]): Encoder.AsObject[A] =
+    io.circe.derivation.ConfiguredEncoder.derived[A]
+  inline def deriveConfiguredCodec[A](using inline conf: Configuration, inline m: Mirror.Of[A]): Codec.AsObject[A] =
+    io.circe.derivation.ConfiguredCodec.derived[A]

--- a/benchmark-configured/package.mill
+++ b/benchmark-configured/package.mill
@@ -1,0 +1,46 @@
+package build.`benchmark-configured`
+
+import mill.*, scalalib.*
+
+object `package` extends mill.Module {
+
+  object sanely extends ScalaModule {
+    def scalaVersion = build.scala3Version
+    override def moduleDir = super.moduleDir / os.up / "shared"
+    def scalacOptions = Task {
+      super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
+    }
+    def moduleDeps = Seq(build.sanely.jvm)
+    def mvnDeps = Task {
+      super.mvnDeps() ++ Seq(
+        mvn"io.circe::circe-core:${build.circeVersion}",
+        mvn"io.circe::circe-parser:${build.circeVersion}",
+      )
+    }
+  }
+
+  /** Compat shim providing io.circe.generic.semiauto.deriveConfiguredCodec via circe-core */
+  object `generic-compat` extends ScalaModule {
+    def scalaVersion = build.scala3Version
+    def mvnDeps = Task {
+      super.mvnDeps() ++ Seq(
+        mvn"io.circe::circe-core:${build.circeVersion}",
+      )
+    }
+  }
+
+  object generic extends ScalaModule {
+    def scalaVersion = build.scala3Version
+    override def moduleDir = super.moduleDir / os.up / "shared"
+    def scalacOptions = Task {
+      super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
+    }
+    def moduleDeps = Seq(`generic-compat`)
+    def mvnDeps = Task {
+      super.mvnDeps() ++ Seq(
+        mvn"io.circe::circe-core:${build.circeVersion}",
+        mvn"io.circe::circe-parser:${build.circeVersion}",
+      )
+    }
+  }
+}

--- a/benchmark-configured/shared/src/configured/Main.scala
+++ b/benchmark-configured/shared/src/configured/Main.scala
@@ -1,0 +1,13 @@
+package configured
+
+object Main:
+  def main(args: Array[String]): Unit =
+    configured.crm.CrmDomain.run()
+    configured.inventory.InventoryDomain.run()
+    configured.billing.BillingDomain.run()
+    configured.messaging.MessagingDomain.run()
+    configured.access.AccessDomain.run()
+    configured.content.ContentDomain.run()
+    configured.workflow.WorkflowDomain.run()
+    configured.analytics.AnalyticsDomain.run()
+    println("All configured domains passed!")

--- a/benchmark-configured/shared/src/configured/protocols_access.scala
+++ b/benchmark-configured/shared/src/configured/protocols_access.scala
@@ -1,0 +1,144 @@
+package configured.access
+
+import io.circe.*
+import io.circe.syntax.*
+import io.circe.parser.*
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+
+// ═══════════════════════════════════════════════════════════════════════
+// Roles / Permissions / Access Control (~25 types)
+// withDefaults, withDiscriminator
+// ═══════════════════════════════════════════════════════════════════════
+
+private given Configuration = Configuration.default.withDefaults
+
+final case class UserId(value: String)
+object UserId:
+  given Codec.AsObject[UserId] = deriveConfiguredCodec
+
+final case class GroupId(value: String)
+object GroupId:
+  given Codec.AsObject[GroupId] = deriveConfiguredCodec
+
+final case class ResourceId(value: String, resourceType: String = "document")
+object ResourceId:
+  given Codec.AsObject[ResourceId] = deriveConfiguredCodec
+
+final case class Permission(action: String, resource: String, effect: String = "allow")
+object Permission:
+  given Codec.AsObject[Permission] = deriveConfiguredCodec
+
+final case class Role(id: String, name: String, description: String = "", permissions: List[Permission])
+object Role:
+  given Codec.AsObject[Role] = deriveConfiguredCodec
+
+final case class RoleAssignment(userId: String, roleId: String, scope: String = "global", assignedAt: String)
+object RoleAssignment:
+  given Codec.AsObject[RoleAssignment] = deriveConfiguredCodec
+
+final case class Group(id: GroupId, name: String, description: String = "", memberCount: Int = 0)
+object Group:
+  given Codec.AsObject[Group] = deriveConfiguredCodec
+
+final case class GroupMembership(groupId: String, userId: String, role: String = "member", addedAt: String)
+object GroupMembership:
+  given Codec.AsObject[GroupMembership] = deriveConfiguredCodec
+
+final case class PolicyCondition(field: String, operator: String, value: String)
+object PolicyCondition:
+  given Codec.AsObject[PolicyCondition] = deriveConfiguredCodec
+
+final case class AccessPolicy(id: String, name: String, conditions: List[PolicyCondition], effect: String = "allow", priority: Int = 0)
+object AccessPolicy:
+  given Codec.AsObject[AccessPolicy] = deriveConfiguredCodec
+
+final case class ApiKey(id: String, name: String, prefix: String, scopes: List[String], expiresAt: String = "", active: Boolean = true)
+object ApiKey:
+  given Codec.AsObject[ApiKey] = deriveConfiguredCodec
+
+final case class OAuthClient(clientId: String, clientName: String, redirectUris: List[String], grantTypes: List[String])
+object OAuthClient:
+  given Codec.AsObject[OAuthClient] = deriveConfiguredCodec
+
+final case class TokenInfo(tokenId: String, userId: String, issuedAt: String, expiresAt: String, scopes: List[String])
+object TokenInfo:
+  given Codec.AsObject[TokenInfo] = deriveConfiguredCodec
+
+final case class SessionInfo(sessionId: String, userId: String, ipAddress: String, userAgent: String = "", startedAt: String, lastActiveAt: String)
+object SessionInfo:
+  given Codec.AsObject[SessionInfo] = deriveConfiguredCodec
+
+final case class AuditLogEntry(id: String, actor: String, action: String, resource: String, timestamp: String, result: String = "success")
+object AuditLogEntry:
+  given Codec.AsObject[AuditLogEntry] = deriveConfiguredCodec
+
+final case class IpAllowRule(cidr: String, description: String = "", active: Boolean = true)
+object IpAllowRule:
+  given Codec.AsObject[IpAllowRule] = deriveConfiguredCodec
+
+final case class RateLimitRule(endpoint: String, maxRequests: Int, windowSeconds: Int, burstLimit: Int = 0)
+object RateLimitRule:
+  given Codec.AsObject[RateLimitRule] = deriveConfiguredCodec
+
+final case class SecurityConfig(mfaRequired: Boolean = false, passwordMinLength: Int = 8, sessionTimeoutMinutes: Int = 30, ipAllowList: List[IpAllowRule])
+object SecurityConfig:
+  given Codec.AsObject[SecurityConfig] = deriveConfiguredCodec
+
+// ADTs
+sealed trait AuthEvent
+object AuthEvent:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("auth_event")
+  given Codec.AsObject[AuthEvent] = deriveConfiguredCodec
+final case class LoginSuccess(userId: String, method: String, ipAddress: String, mfaUsed: Boolean = false) extends AuthEvent
+object LoginSuccess:
+  given Codec.AsObject[LoginSuccess] = deriveConfiguredCodec
+final case class LoginFailure(userId: String, reason: String, ipAddress: String, attemptNumber: Int = 1) extends AuthEvent
+object LoginFailure:
+  given Codec.AsObject[LoginFailure] = deriveConfiguredCodec
+final case class TokenRefreshed(userId: String, tokenId: String, newExpiresAt: String) extends AuthEvent
+object TokenRefreshed:
+  given Codec.AsObject[TokenRefreshed] = deriveConfiguredCodec
+final case class AccountLocked(userId: String, reason: String = "too_many_attempts", lockedUntil: String = "") extends AuthEvent
+object AccountLocked:
+  given Codec.AsObject[AccountLocked] = deriveConfiguredCodec
+final case class PasswordChanged(userId: String, forced: Boolean = false) extends AuthEvent
+object PasswordChanged:
+  given Codec.AsObject[PasswordChanged] = deriveConfiguredCodec
+
+sealed trait AccessDecision
+object AccessDecision:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("decision")
+  given Codec.AsObject[AccessDecision] = deriveConfiguredCodec
+final case class Allowed(resource: String, action: String, matchedPolicy: String) extends AccessDecision
+object Allowed:
+  given Codec.AsObject[Allowed] = deriveConfiguredCodec
+final case class Denied(resource: String, action: String, reason: String = "no matching policy") extends AccessDecision
+object Denied:
+  given Codec.AsObject[Denied] = deriveConfiguredCodec
+final case class RequiresMfa(resource: String, action: String, mfaType: String = "totp") extends AccessDecision
+object RequiresMfa:
+  given Codec.AsObject[RequiresMfa] = deriveConfiguredCodec
+final case class RateLimited(resource: String, retryAfterSeconds: Int) extends AccessDecision
+object RateLimited:
+  given Codec.AsObject[RateLimited] = deriveConfiguredCodec
+
+object AccessDomain:
+  def run(): Unit =
+    val role = Role("r1", "Editor", "Can edit content", List(Permission("write", "articles"), Permission("read", "articles")))
+    assert(decode[Role](role.asJson.noSpaces) == Right(role))
+
+    val policy = AccessPolicy("p1", "Admin Only", List(PolicyCondition("role", "eq", "admin")))
+    assert(decode[AccessPolicy](policy.asJson.noSpaces) == Right(policy))
+
+    val event: AuthEvent = LoginSuccess("u1", "password", "1.2.3.4")
+    assert(decode[AuthEvent](event.asJson.noSpaces) == Right(event))
+
+    val decision: AccessDecision = Denied("secret-doc", "read", "insufficient permissions")
+    assert(decode[AccessDecision](decision.asJson.noSpaces) == Right(decision))
+
+    val security = SecurityConfig(true, 12, 60, List(IpAllowRule("10.0.0.0/8", "Internal")))
+    assert(decode[SecurityConfig](security.asJson.noSpaces) == Right(security))
+
+    val apiKey = ApiKey("k1", "CI Key", "sk_", List("read", "write"), "2025-01-01")
+    assert(decode[ApiKey](apiKey.asJson.noSpaces) == Right(apiKey))

--- a/benchmark-configured/shared/src/configured/protocols_analytics.scala
+++ b/benchmark-configured/shared/src/configured/protocols_analytics.scala
@@ -1,0 +1,139 @@
+package configured.analytics
+
+import io.circe.*
+import io.circe.syntax.*
+import io.circe.parser.*
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+
+// ═══════════════════════════════════════════════════════════════════════
+// Analytics / Metrics / Reports (~20 types)
+// withDefaults, withDiscriminator, nested structures
+// ═══════════════════════════════════════════════════════════════════════
+
+private given Configuration = Configuration.default.withDefaults
+
+final case class MetricId(value: String)
+object MetricId:
+  given Codec.AsObject[MetricId] = deriveConfiguredCodec
+
+final case class TimeBucket(start: String, end: String, granularity: String = "hour")
+object TimeBucket:
+  given Codec.AsObject[TimeBucket] = deriveConfiguredCodec
+
+final case class MetricValue(name: String, value: Double, unit: String = "", tags: Map[String, String] = Map.empty)
+object MetricValue:
+  given Codec.AsObject[MetricValue] = deriveConfiguredCodec
+
+final case class MetricSeries(metricId: MetricId, buckets: List[TimeBucket], values: List[Double], aggregation: String = "sum")
+object MetricSeries:
+  given Codec.AsObject[MetricSeries] = deriveConfiguredCodec
+
+final case class DimensionFilter(dimension: String, operator: String = "eq", value: String)
+object DimensionFilter:
+  given Codec.AsObject[DimensionFilter] = deriveConfiguredCodec
+
+final case class ReportQuery(metrics: List[String], dimensions: List[String] = Nil, filters: List[DimensionFilter] = Nil, limit: Int = 100)
+object ReportQuery:
+  given Codec.AsObject[ReportQuery] = deriveConfiguredCodec
+
+final case class ReportRow(dimensions: Map[String, String], values: Map[String, Double])
+object ReportRow:
+  given Codec.AsObject[ReportRow] = deriveConfiguredCodec
+
+final case class Report(id: String, name: String, query: ReportQuery, rows: List[ReportRow], generatedAt: String, cached: Boolean = false)
+object Report:
+  given Codec.AsObject[Report] = deriveConfiguredCodec
+
+final case class Dashboard(id: String, name: String, widgets: List[String], owner: String, shared: Boolean = false)
+object Dashboard:
+  given Codec.AsObject[Dashboard] = deriveConfiguredCodec
+
+final case class AlertThreshold(metric: String, operator: String, value: Double, windowMinutes: Int = 5)
+object AlertThreshold:
+  given Codec.AsObject[AlertThreshold] = deriveConfiguredCodec
+
+final case class AlertRule(id: String, name: String, threshold: AlertThreshold, channels: List[String], enabled: Boolean = true, cooldownMinutes: Int = 15)
+object AlertRule:
+  given Codec.AsObject[AlertRule] = deriveConfiguredCodec
+
+final case class AlertIncident(id: String, ruleId: String, triggeredAt: String, resolvedAt: String = "", currentValue: Double)
+object AlertIncident:
+  given Codec.AsObject[AlertIncident] = deriveConfiguredCodec
+
+final case class FunnelStep(name: String, count: Int, conversionRate: Double = 0.0)
+object FunnelStep:
+  given Codec.AsObject[FunnelStep] = deriveConfiguredCodec
+
+final case class FunnelReport(id: String, name: String, steps: List[FunnelStep], period: TimeBucket)
+object FunnelReport:
+  given Codec.AsObject[FunnelReport] = deriveConfiguredCodec
+
+final case class CohortGroup(label: String, size: Int, retentionRates: List[Double])
+object CohortGroup:
+  given Codec.AsObject[CohortGroup] = deriveConfiguredCodec
+
+final case class CohortAnalysis(id: String, name: String, cohorts: List[CohortGroup], metric: String = "retention")
+object CohortAnalysis:
+  given Codec.AsObject[CohortAnalysis] = deriveConfiguredCodec
+
+final case class ExperimentResult(experimentId: String, variantName: String, sampleSize: Int, conversionRate: Double, confidence: Double = 0.0)
+object ExperimentResult:
+  given Codec.AsObject[ExperimentResult] = deriveConfiguredCodec
+
+// ADTs
+sealed trait WidgetType
+object WidgetType:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("widget")
+  given Codec.AsObject[WidgetType] = deriveConfiguredCodec
+final case class LineChart(metrics: List[String], timeRange: String = "7d", stacked: Boolean = false) extends WidgetType
+object LineChart:
+  given Codec.AsObject[LineChart] = deriveConfiguredCodec
+final case class BarChart(metric: String, dimension: String, limit: Int = 10) extends WidgetType
+object BarChart:
+  given Codec.AsObject[BarChart] = deriveConfiguredCodec
+final case class PieChart(metric: String, dimension: String, showLegend: Boolean = true) extends WidgetType
+object PieChart:
+  given Codec.AsObject[PieChart] = deriveConfiguredCodec
+final case class ScalarWidget(metric: String, aggregation: String = "sum", comparisonPeriod: String = "") extends WidgetType
+object ScalarWidget:
+  given Codec.AsObject[ScalarWidget] = deriveConfiguredCodec
+final case class TableWidget(query: ReportQuery, sortBy: String = "", sortDir: String = "desc") extends WidgetType
+object TableWidget:
+  given Codec.AsObject[TableWidget] = deriveConfiguredCodec
+
+sealed trait DataSource
+object DataSource:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("source_type")
+  given Codec.AsObject[DataSource] = deriveConfiguredCodec
+final case class DatabaseSource(connectionString: String, query: String, refreshMinutes: Int = 60) extends DataSource
+object DatabaseSource:
+  given Codec.AsObject[DatabaseSource] = deriveConfiguredCodec
+final case class ApiSource(endpoint: String, method: String = "GET", headers: Map[String, String] = Map.empty) extends DataSource
+object ApiSource:
+  given Codec.AsObject[ApiSource] = deriveConfiguredCodec
+final case class FileSource(path: String, format: String = "csv", delimiter: String = ",") extends DataSource
+object FileSource:
+  given Codec.AsObject[FileSource] = deriveConfiguredCodec
+
+object AnalyticsDomain:
+  def run(): Unit =
+    val query = ReportQuery(List("pageviews", "sessions"), List("country"), List(DimensionFilter("country", "eq", "US")))
+    val row = ReportRow(Map("country" -> "US"), Map("pageviews" -> 10000.0, "sessions" -> 5000.0))
+    val report = Report("r1", "Traffic Report", query, List(row), "2024-01-15T12:00:00Z")
+    assert(decode[Report](report.asJson.noSpaces) == Right(report))
+
+    val widget: WidgetType = LineChart(List("revenue", "orders"), "30d", true)
+    assert(decode[WidgetType](widget.asJson.noSpaces) == Right(widget))
+
+    val source: DataSource = DatabaseSource("jdbc:postgresql://localhost/analytics", "SELECT * FROM events")
+    assert(decode[DataSource](source.asJson.noSpaces) == Right(source))
+
+    val funnel = FunnelReport("f1", "Signup Funnel",
+      List(FunnelStep("Visit", 10000, 1.0), FunnelStep("Signup", 3000, 0.3), FunnelStep("Activate", 1500, 0.5)),
+      TimeBucket("2024-01-01", "2024-01-31", "day"),
+    )
+    assert(decode[FunnelReport](funnel.asJson.noSpaces) == Right(funnel))
+
+    val alert = AlertRule("a1", "High Error Rate", AlertThreshold("error_rate", "gt", 0.05), List("slack", "email"))
+    assert(decode[AlertRule](alert.asJson.noSpaces) == Right(alert))

--- a/benchmark-configured/shared/src/configured/protocols_billing.scala
+++ b/benchmark-configured/shared/src/configured/protocols_billing.scala
@@ -1,0 +1,148 @@
+package configured.billing
+
+import io.circe.*
+import io.circe.syntax.*
+import io.circe.parser.*
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+
+// ═══════════════════════════════════════════════════════════════════════
+// Billing / Invoices / Payments (~25 types)
+// withDefaults, withDiscriminator
+// ═══════════════════════════════════════════════════════════════════════
+
+private given Configuration = Configuration.default.withDefaults
+
+final case class Money(amount: Double, currency: String = "USD")
+object Money:
+  given Codec.AsObject[Money] = deriveConfiguredCodec
+
+final case class TaxRate(rate: Double, jurisdiction: String, category: String = "standard")
+object TaxRate:
+  given Codec.AsObject[TaxRate] = deriveConfiguredCodec
+
+final case class TaxLine(description: String, rate: TaxRate, amount: Money)
+object TaxLine:
+  given Codec.AsObject[TaxLine] = deriveConfiguredCodec
+
+final case class InvoiceLineItem(description: String, quantity: Int, unitPrice: Money, taxable: Boolean = true)
+object InvoiceLineItem:
+  given Codec.AsObject[InvoiceLineItem] = deriveConfiguredCodec
+
+final case class Discount(code: String, description: String = "", amount: Money)
+object Discount:
+  given Codec.AsObject[Discount] = deriveConfiguredCodec
+
+final case class BillingAddress(name: String, line1: String, line2: String = "", city: String, state: String, zip: String, country: String = "US")
+object BillingAddress:
+  given Codec.AsObject[BillingAddress] = deriveConfiguredCodec
+
+final case class Invoice(
+  id: String,
+  customerId: String,
+  lineItems: List[InvoiceLineItem],
+  taxes: List[TaxLine],
+  discounts: List[Discount],
+  subtotal: Money,
+  total: Money,
+  billingAddress: BillingAddress,
+  issuedAt: String,
+  dueAt: String,
+  status: String = "pending",
+)
+object Invoice:
+  given Codec.AsObject[Invoice] = deriveConfiguredCodec
+
+final case class PaymentRef(transactionId: String, gateway: String, timestamp: String)
+object PaymentRef:
+  given Codec.AsObject[PaymentRef] = deriveConfiguredCodec
+
+final case class Refund(id: String, invoiceId: String, amount: Money, reason: String = "", processedAt: String)
+object Refund:
+  given Codec.AsObject[Refund] = deriveConfiguredCodec
+
+final case class CreditNote(id: String, customerId: String, amount: Money, reason: String, validUntil: String = "")
+object CreditNote:
+  given Codec.AsObject[CreditNote] = deriveConfiguredCodec
+
+final case class SubscriptionPlan(id: String, name: String, price: Money, interval: String = "monthly", trialDays: Int = 0)
+object SubscriptionPlan:
+  given Codec.AsObject[SubscriptionPlan] = deriveConfiguredCodec
+
+final case class Subscription(id: String, customerId: String, plan: SubscriptionPlan, startDate: String, status: String = "active")
+object Subscription:
+  given Codec.AsObject[Subscription] = deriveConfiguredCodec
+
+final case class UsageRecord(subscriptionId: String, metric: String, quantity: Double, recordedAt: String)
+object UsageRecord:
+  given Codec.AsObject[UsageRecord] = deriveConfiguredCodec
+
+final case class BillingPeriod(start: String, end: String, invoiceId: String = "")
+object BillingPeriod:
+  given Codec.AsObject[BillingPeriod] = deriveConfiguredCodec
+
+final case class PaymentRetry(attemptNumber: Int, scheduledAt: String, lastError: String = "")
+object PaymentRetry:
+  given Codec.AsObject[PaymentRetry] = deriveConfiguredCodec
+
+final case class DunningRecord(customerId: String, invoiceId: String, retries: List[PaymentRetry], escalated: Boolean = false)
+object DunningRecord:
+  given Codec.AsObject[DunningRecord] = deriveConfiguredCodec
+
+// ADTs
+sealed trait PaymentMethod
+object PaymentMethod:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("method")
+  given Codec.AsObject[PaymentMethod] = deriveConfiguredCodec
+final case class CardPayment(last4: String, brand: String, expiryMonth: Int, expiryYear: Int) extends PaymentMethod
+object CardPayment:
+  given Codec.AsObject[CardPayment] = deriveConfiguredCodec
+final case class BankTransfer(bankName: String, reference: String) extends PaymentMethod
+object BankTransfer:
+  given Codec.AsObject[BankTransfer] = deriveConfiguredCodec
+final case class WalletPayment(provider: String, accountId: String) extends PaymentMethod
+object WalletPayment:
+  given Codec.AsObject[WalletPayment] = deriveConfiguredCodec
+final case class CheckPayment(checkNumber: String, bankName: String = "") extends PaymentMethod
+object CheckPayment:
+  given Codec.AsObject[CheckPayment] = deriveConfiguredCodec
+
+sealed trait InvoiceEvent
+object InvoiceEvent:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("event")
+  given Codec.AsObject[InvoiceEvent] = deriveConfiguredCodec
+final case class InvoiceCreated(invoiceId: String, createdAt: String) extends InvoiceEvent
+object InvoiceCreated:
+  given Codec.AsObject[InvoiceCreated] = deriveConfiguredCodec
+final case class InvoiceSent(invoiceId: String, sentAt: String, channel: String = "email") extends InvoiceEvent
+object InvoiceSent:
+  given Codec.AsObject[InvoiceSent] = deriveConfiguredCodec
+final case class InvoicePaid(invoiceId: String, paidAt: String, paymentRef: PaymentRef) extends InvoiceEvent
+object InvoicePaid:
+  given Codec.AsObject[InvoicePaid] = deriveConfiguredCodec
+final case class InvoiceOverdue(invoiceId: String, dueAt: String, daysPastDue: Int) extends InvoiceEvent
+object InvoiceOverdue:
+  given Codec.AsObject[InvoiceOverdue] = deriveConfiguredCodec
+final case class InvoiceVoided(invoiceId: String, voidedAt: String, reason: String = "") extends InvoiceEvent
+object InvoiceVoided:
+  given Codec.AsObject[InvoiceVoided] = deriveConfiguredCodec
+
+object BillingDomain:
+  def run(): Unit =
+    val addr = BillingAddress("Acme Inc", "123 Main St", "", "NYC", "NY", "10001")
+    val item = InvoiceLineItem("Widget x10", 10, Money(29.99))
+    val tax = TaxLine("Sales Tax", TaxRate(0.08, "NY"), Money(24.0))
+    val invoice = Invoice("inv1", "c1", List(item), List(tax), Nil, Money(299.90), Money(323.90), addr, "2024-01-15", "2024-02-15")
+    assert(decode[Invoice](invoice.asJson.noSpaces) == Right(invoice))
+
+    val pm: PaymentMethod = CardPayment("4242", "visa", 12, 2025)
+    assert(decode[PaymentMethod](pm.asJson.noSpaces) == Right(pm))
+
+    val event: InvoiceEvent = InvoicePaid("inv1", "2024-01-20", PaymentRef("tx1", "stripe", "2024-01-20"))
+    assert(decode[InvoiceEvent](event.asJson.noSpaces) == Right(event))
+
+    val sub = Subscription("s1", "c1", SubscriptionPlan("plan1", "Pro", Money(99.0)), "2024-01-01")
+    assert(decode[Subscription](sub.asJson.noSpaces) == Right(sub))
+
+    val refund = Refund("r1", "inv1", Money(50.0), "partial", "2024-02-01")
+    assert(decode[Refund](refund.asJson.noSpaces) == Right(refund))

--- a/benchmark-configured/shared/src/configured/protocols_content.scala
+++ b/benchmark-configured/shared/src/configured/protocols_content.scala
@@ -1,0 +1,158 @@
+package configured.content
+
+import io.circe.*
+import io.circe.syntax.*
+import io.circe.parser.*
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+
+// ═══════════════════════════════════════════════════════════════════════
+// CMS / Articles / Media (~25 types)
+// withDefaults, withDiscriminator
+// ═══════════════════════════════════════════════════════════════════════
+
+private given Configuration = Configuration.default.withDefaults
+
+final case class ArticleId(value: String)
+object ArticleId:
+  given Codec.AsObject[ArticleId] = deriveConfiguredCodec
+
+final case class Author(id: String, name: String, bio: String = "", avatarUrl: String = "")
+object Author:
+  given Codec.AsObject[Author] = deriveConfiguredCodec
+
+final case class CategoryLabel(slug: String, name: String, parentSlug: String = "")
+object CategoryLabel:
+  given Codec.AsObject[CategoryLabel] = deriveConfiguredCodec
+
+final case class TagLabel(slug: String, name: String)
+object TagLabel:
+  given Codec.AsObject[TagLabel] = deriveConfiguredCodec
+
+final case class SeoMeta(title: String, description: String = "", keywords: List[String] = Nil, canonicalUrl: String = "")
+object SeoMeta:
+  given Codec.AsObject[SeoMeta] = deriveConfiguredCodec
+
+final case class FeaturedImage(url: String, alt: String = "", width: Int = 0, height: Int = 0, caption: String = "")
+object FeaturedImage:
+  given Codec.AsObject[FeaturedImage] = deriveConfiguredCodec
+
+final case class ArticleBody(format: String = "markdown", content: String, wordCount: Int = 0)
+object ArticleBody:
+  given Codec.AsObject[ArticleBody] = deriveConfiguredCodec
+
+final case class Article(
+  id: ArticleId,
+  title: String,
+  slug: String,
+  author: Author,
+  body: ArticleBody,
+  category: CategoryLabel,
+  tags: List[TagLabel],
+  seo: SeoMeta,
+  featuredImage: Option[FeaturedImage] = None,
+  publishedAt: String = "",
+  updatedAt: String = "",
+)
+object Article:
+  given Codec.AsObject[Article] = deriveConfiguredCodec
+
+final case class Comment(id: String, articleId: String, authorName: String, body: String, approved: Boolean = false, createdAt: String)
+object Comment:
+  given Codec.AsObject[Comment] = deriveConfiguredCodec
+
+final case class CommentThread(parentId: String, replies: List[Comment], locked: Boolean = false)
+object CommentThread:
+  given Codec.AsObject[CommentThread] = deriveConfiguredCodec
+
+final case class MediaAsset(id: String, filename: String, mimeType: String, sizeBytes: Long, url: String, uploadedAt: String)
+object MediaAsset:
+  given Codec.AsObject[MediaAsset] = deriveConfiguredCodec
+
+final case class MediaFolder(id: String, name: String, parentId: String = "", assetCount: Int = 0)
+object MediaFolder:
+  given Codec.AsObject[MediaFolder] = deriveConfiguredCodec
+
+final case class PageLayout(id: String, name: String, template: String, regions: List[String])
+object PageLayout:
+  given Codec.AsObject[PageLayout] = deriveConfiguredCodec
+
+final case class NavigationItem(label: String, url: String, children: List[NavigationItem] = Nil, active: Boolean = true)
+object NavigationItem:
+  given Codec.AsObject[NavigationItem] = deriveConfiguredCodec
+
+final case class NavigationMenu(id: String, name: String, items: List[NavigationItem], position: String = "header")
+object NavigationMenu:
+  given Codec.AsObject[NavigationMenu] = deriveConfiguredCodec
+
+final case class Redirect(fromPath: String, toPath: String, statusCode: Int = 301, active: Boolean = true)
+object Redirect:
+  given Codec.AsObject[Redirect] = deriveConfiguredCodec
+
+final case class SiteSettings(siteName: String, tagline: String = "", locale: String = "en", timezone: String = "UTC", analyticsId: String = "")
+object SiteSettings:
+  given Codec.AsObject[SiteSettings] = deriveConfiguredCodec
+
+final case class ContentRevision(id: String, articleId: String, authorId: String, diff: String, createdAt: String, message: String = "")
+object ContentRevision:
+  given Codec.AsObject[ContentRevision] = deriveConfiguredCodec
+
+// ADTs
+sealed trait ContentStatus
+object ContentStatus:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("status")
+  given Codec.AsObject[ContentStatus] = deriveConfiguredCodec
+final case class DraftContent(createdBy: String, lastEditedAt: String = "") extends ContentStatus
+object DraftContent:
+  given Codec.AsObject[DraftContent] = deriveConfiguredCodec
+final case class InReview(reviewerId: String, submittedAt: String) extends ContentStatus
+object InReview:
+  given Codec.AsObject[InReview] = deriveConfiguredCodec
+final case class PublishedContent(publishedAt: String, publishedBy: String) extends ContentStatus
+object PublishedContent:
+  given Codec.AsObject[PublishedContent] = deriveConfiguredCodec
+final case class ScheduledContent(scheduledAt: String, scheduledBy: String) extends ContentStatus
+object ScheduledContent:
+  given Codec.AsObject[ScheduledContent] = deriveConfiguredCodec
+final case class ArchivedContent(archivedAt: String, reason: String = "") extends ContentStatus
+object ArchivedContent:
+  given Codec.AsObject[ArchivedContent] = deriveConfiguredCodec
+
+sealed trait MediaType
+object MediaType:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("media_type")
+  given Codec.AsObject[MediaType] = deriveConfiguredCodec
+final case class ImageMedia(width: Int, height: Int, format: String = "jpeg") extends MediaType
+object ImageMedia:
+  given Codec.AsObject[ImageMedia] = deriveConfiguredCodec
+final case class VideoMedia(duration: Int, resolution: String, codec: String = "h264") extends MediaType
+object VideoMedia:
+  given Codec.AsObject[VideoMedia] = deriveConfiguredCodec
+final case class AudioMedia(duration: Int, bitrate: Int, format: String = "mp3") extends MediaType
+object AudioMedia:
+  given Codec.AsObject[AudioMedia] = deriveConfiguredCodec
+final case class DocumentMedia(pageCount: Int, format: String = "pdf") extends MediaType
+object DocumentMedia:
+  given Codec.AsObject[DocumentMedia] = deriveConfiguredCodec
+
+object ContentDomain:
+  def run(): Unit =
+    val article = Article(
+      ArticleId("a1"), "Getting Started", "getting-started",
+      Author("auth1", "Alice"), ArticleBody(content = "Hello world", wordCount = 2),
+      CategoryLabel("tutorial", "Tutorials"), List(TagLabel("beginner", "Beginner")),
+      SeoMeta("Getting Started Guide"), Some(FeaturedImage("img.jpg", "hero")),
+    )
+    assert(decode[Article](article.asJson.noSpaces) == Right(article))
+
+    val status: ContentStatus = InReview("rev1", "2024-01-15")
+    assert(decode[ContentStatus](status.asJson.noSpaces) == Right(status))
+
+    val media: MediaType = VideoMedia(120, "1080p")
+    assert(decode[MediaType](media.asJson.noSpaces) == Right(media))
+
+    val nav = NavigationMenu("m1", "Main", List(NavigationItem("Home", "/"), NavigationItem("Blog", "/blog")))
+    assert(decode[NavigationMenu](nav.asJson.noSpaces) == Right(nav))
+
+    val settings = SiteSettings("My Blog", "A great blog")
+    assert(decode[SiteSettings](settings.asJson.noSpaces) == Right(settings))

--- a/benchmark-configured/shared/src/configured/protocols_crm.scala
+++ b/benchmark-configured/shared/src/configured/protocols_crm.scala
@@ -1,0 +1,168 @@
+package configured.crm
+
+import io.circe.*
+import io.circe.syntax.*
+import io.circe.parser.*
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+
+// ═══════════════════════════════════════════════════════════════════════
+// CRM / Customer Management (~30 types)
+// withDefaults, withDiscriminator
+// ═══════════════════════════════════════════════════════════════════════
+
+private given Configuration = Configuration.default.withDefaults
+
+final case class CustomerId(value: String)
+object CustomerId:
+  given Codec.AsObject[CustomerId] = deriveConfiguredCodec
+
+final case class ContactEmail(address: String, verified: Boolean = false)
+object ContactEmail:
+  given Codec.AsObject[ContactEmail] = deriveConfiguredCodec
+
+final case class ContactPhone(countryCode: String, number: String, primary: Boolean = true)
+object ContactPhone:
+  given Codec.AsObject[ContactPhone] = deriveConfiguredCodec
+
+final case class ContactName(first: String, middle: String = "", last: String)
+object ContactName:
+  given Codec.AsObject[ContactName] = deriveConfiguredCodec
+
+final case class PostalAddress(line1: String, line2: String = "", city: String, state: String, zip: String, country: String = "US")
+object PostalAddress:
+  given Codec.AsObject[PostalAddress] = deriveConfiguredCodec
+
+final case class Company(name: String, domain: String = "", industry: String = "")
+object Company:
+  given Codec.AsObject[Company] = deriveConfiguredCodec
+
+final case class ContactSource(channel: String, campaign: String = "", referrer: String = "")
+object ContactSource:
+  given Codec.AsObject[ContactSource] = deriveConfiguredCodec
+
+final case class CustomerProfile(name: ContactName, email: ContactEmail, phone: ContactPhone, company: Company)
+object CustomerProfile:
+  given Codec.AsObject[CustomerProfile] = deriveConfiguredCodec
+
+final case class LeadScore(value: Int, lastUpdated: String, source: String = "auto")
+object LeadScore:
+  given Codec.AsObject[LeadScore] = deriveConfiguredCodec
+
+final case class DealStage(name: String, probability: Double, daysInStage: Int = 0)
+object DealStage:
+  given Codec.AsObject[DealStage] = deriveConfiguredCodec
+
+final case class Deal(id: String, title: String, amount: Double, stage: DealStage, ownerId: String)
+object Deal:
+  given Codec.AsObject[Deal] = deriveConfiguredCodec
+
+final case class ActivityNote(content: String, author: String, createdAt: String, pinned: Boolean = false)
+object ActivityNote:
+  given Codec.AsObject[ActivityNote] = deriveConfiguredCodec
+
+final case class TaskReminder(taskId: String, dueAt: String, assignee: String, completed: Boolean = false)
+object TaskReminder:
+  given Codec.AsObject[TaskReminder] = deriveConfiguredCodec
+
+final case class MeetingRecord(id: String, title: String, scheduledAt: String, duration: Int, attendees: List[String])
+object MeetingRecord:
+  given Codec.AsObject[MeetingRecord] = deriveConfiguredCodec
+
+final case class Pipeline(id: String, name: String, stages: List[DealStage], active: Boolean = true)
+object Pipeline:
+  given Codec.AsObject[Pipeline] = deriveConfiguredCodec
+
+final case class CustomField(key: String, label: String, value: String, fieldType: String = "text")
+object CustomField:
+  given Codec.AsObject[CustomField] = deriveConfiguredCodec
+
+final case class Tag(name: String, color: String = "gray")
+object Tag:
+  given Codec.AsObject[Tag] = deriveConfiguredCodec
+
+final case class CustomerSegment(id: String, name: String, criteria: String, memberCount: Int = 0)
+object CustomerSegment:
+  given Codec.AsObject[CustomerSegment] = deriveConfiguredCodec
+
+final case class CampaignRef(id: String, name: String, channel: String, active: Boolean = true)
+object CampaignRef:
+  given Codec.AsObject[CampaignRef] = deriveConfiguredCodec
+
+final case class InteractionLog(id: String, customerId: String, channel: String, summary: String, timestamp: String)
+object InteractionLog:
+  given Codec.AsObject[InteractionLog] = deriveConfiguredCodec
+
+final case class SupportTicket(id: String, subject: String, priority: String = "medium", status: String = "open")
+object SupportTicket:
+  given Codec.AsObject[SupportTicket] = deriveConfiguredCodec
+
+final case class CustomerRecord(
+  id: CustomerId,
+  profile: CustomerProfile,
+  address: PostalAddress,
+  source: ContactSource,
+  score: LeadScore,
+  tags: List[Tag],
+  createdAt: String,
+  updatedAt: String,
+)
+object CustomerRecord:
+  given Codec.AsObject[CustomerRecord] = deriveConfiguredCodec
+
+// ADTs with discriminator
+sealed trait CustomerStatus
+object CustomerStatus:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("type")
+  given Codec.AsObject[CustomerStatus] = deriveConfiguredCodec
+final case class ActiveCustomer(since: String, tier: String = "standard") extends CustomerStatus
+object ActiveCustomer:
+  given Codec.AsObject[ActiveCustomer] = deriveConfiguredCodec
+final case class ChurnedCustomer(reason: String, churnedAt: String) extends CustomerStatus
+object ChurnedCustomer:
+  given Codec.AsObject[ChurnedCustomer] = deriveConfiguredCodec
+final case class ProspectCustomer(leadScore: Int, source: String = "web") extends CustomerStatus
+object ProspectCustomer:
+  given Codec.AsObject[ProspectCustomer] = deriveConfiguredCodec
+final case class TrialCustomer(trialEnd: String, convertedDeal: String = "") extends CustomerStatus
+object TrialCustomer:
+  given Codec.AsObject[TrialCustomer] = deriveConfiguredCodec
+
+sealed trait ActivityType
+object ActivityType:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("kind")
+  given Codec.AsObject[ActivityType] = deriveConfiguredCodec
+final case class CallActivity(duration: Int, outcome: String = "completed") extends ActivityType
+object CallActivity:
+  given Codec.AsObject[CallActivity] = deriveConfiguredCodec
+final case class EmailActivity(subject: String, opened: Boolean = false) extends ActivityType
+object EmailActivity:
+  given Codec.AsObject[EmailActivity] = deriveConfiguredCodec
+final case class MeetingActivity(location: String, attendeeCount: Int) extends ActivityType
+object MeetingActivity:
+  given Codec.AsObject[MeetingActivity] = deriveConfiguredCodec
+final case class NoteActivity(content: String, pinned: Boolean = false) extends ActivityType
+object NoteActivity:
+  given Codec.AsObject[NoteActivity] = deriveConfiguredCodec
+
+object CrmDomain:
+  def run(): Unit =
+    val name = ContactName("Alice", "M", "Smith")
+    val profile = CustomerProfile(name, ContactEmail("a@b.com", true), ContactPhone("+1", "5551234"), Company("Acme"))
+    val record = CustomerRecord(
+      CustomerId("c1"), profile, PostalAddress("123 Main", "", "NYC", "NY", "10001"),
+      ContactSource("web"), LeadScore(85, "2024-01-01"), List(Tag("vip", "gold")), "2024-01-01", "2024-06-01",
+    )
+    assert(decode[CustomerRecord](record.asJson.noSpaces) == Right(record))
+
+    val status: CustomerStatus = ActiveCustomer("2024-01-01")
+    assert(decode[CustomerStatus](status.asJson.noSpaces) == Right(status))
+
+    val activity: ActivityType = CallActivity(300)
+    assert(decode[ActivityType](activity.asJson.noSpaces) == Right(activity))
+
+    val deal = Deal("d1", "Big Deal", 50000.0, DealStage("negotiation", 0.6), "rep1")
+    assert(decode[Deal](deal.asJson.noSpaces) == Right(deal))
+
+    val ticket = SupportTicket("t1", "Issue with login")
+    assert(decode[SupportTicket](ticket.asJson.noSpaces) == Right(ticket))

--- a/benchmark-configured/shared/src/configured/protocols_inventory.scala
+++ b/benchmark-configured/shared/src/configured/protocols_inventory.scala
@@ -1,0 +1,169 @@
+package configured.inventory
+
+import io.circe.*
+import io.circe.syntax.*
+import io.circe.parser.*
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+
+// ═══════════════════════════════════════════════════════════════════════
+// Product / Inventory Management (~30 types)
+// withDefaults, withDiscriminator
+// ═══════════════════════════════════════════════════════════════════════
+
+private given Configuration = Configuration.default.withDefaults
+
+final case class Sku(value: String)
+object Sku:
+  given Codec.AsObject[Sku] = deriveConfiguredCodec
+
+final case class ProductName(value: String, locale: String = "en")
+object ProductName:
+  given Codec.AsObject[ProductName] = deriveConfiguredCodec
+
+final case class Price(amount: Double, currency: String = "USD")
+object Price:
+  given Codec.AsObject[Price] = deriveConfiguredCodec
+
+final case class Weight(value: Double, unit: String = "kg")
+object Weight:
+  given Codec.AsObject[Weight] = deriveConfiguredCodec
+
+final case class Dimensions(length: Double, width: Double, height: Double, unit: String = "cm")
+object Dimensions:
+  given Codec.AsObject[Dimensions] = deriveConfiguredCodec
+
+final case class CategoryRef(id: String, name: String, parentId: String = "")
+object CategoryRef:
+  given Codec.AsObject[CategoryRef] = deriveConfiguredCodec
+
+final case class Brand(name: String, logo: String = "", website: String = "")
+object Brand:
+  given Codec.AsObject[Brand] = deriveConfiguredCodec
+
+final case class ProductImage(url: String, alt: String = "", primary: Boolean = false)
+object ProductImage:
+  given Codec.AsObject[ProductImage] = deriveConfiguredCodec
+
+final case class VariantOption(name: String, value: String)
+object VariantOption:
+  given Codec.AsObject[VariantOption] = deriveConfiguredCodec
+
+final case class ProductVariant(sku: Sku, options: List[VariantOption], price: Price, stock: Int = 0)
+object ProductVariant:
+  given Codec.AsObject[ProductVariant] = deriveConfiguredCodec
+
+final case class InventoryLevel(sku: String, warehouseId: String, quantity: Int, reserved: Int = 0)
+object InventoryLevel:
+  given Codec.AsObject[InventoryLevel] = deriveConfiguredCodec
+
+final case class Warehouse(id: String, name: String, location: String, active: Boolean = true)
+object Warehouse:
+  given Codec.AsObject[Warehouse] = deriveConfiguredCodec
+
+final case class Supplier(id: String, name: String, contactEmail: String, leadTimeDays: Int = 7)
+object Supplier:
+  given Codec.AsObject[Supplier] = deriveConfiguredCodec
+
+final case class PurchaseOrderLine(sku: String, quantity: Int, unitCost: Price)
+object PurchaseOrderLine:
+  given Codec.AsObject[PurchaseOrderLine] = deriveConfiguredCodec
+
+final case class PurchaseOrder(id: String, supplierId: String, lines: List[PurchaseOrderLine], status: String = "draft")
+object PurchaseOrder:
+  given Codec.AsObject[PurchaseOrder] = deriveConfiguredCodec
+
+final case class StockMovement(id: String, sku: String, fromWarehouse: String, toWarehouse: String, quantity: Int)
+object StockMovement:
+  given Codec.AsObject[StockMovement] = deriveConfiguredCodec
+
+final case class RestockAlert(sku: String, currentQty: Int, threshold: Int, supplierId: String = "")
+object RestockAlert:
+  given Codec.AsObject[RestockAlert] = deriveConfiguredCodec
+
+final case class ProductReview(id: String, productId: String, rating: Int, comment: String = "", verified: Boolean = false)
+object ProductReview:
+  given Codec.AsObject[ProductReview] = deriveConfiguredCodec
+
+final case class PricingRule(id: String, name: String, discountPct: Double, minQuantity: Int = 1, active: Boolean = true)
+object PricingRule:
+  given Codec.AsObject[PricingRule] = deriveConfiguredCodec
+
+final case class ProductBundle(id: String, name: String, skus: List[String], bundlePrice: Price)
+object ProductBundle:
+  given Codec.AsObject[ProductBundle] = deriveConfiguredCodec
+
+final case class Product(
+  id: String,
+  name: ProductName,
+  brand: Brand,
+  category: CategoryRef,
+  price: Price,
+  weight: Weight,
+  dimensions: Dimensions,
+  images: List[ProductImage],
+  variants: List[ProductVariant],
+  active: Boolean = true,
+)
+object Product:
+  given Codec.AsObject[Product] = deriveConfiguredCodec
+
+// ADTs
+sealed trait InventoryAction
+object InventoryAction:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("action")
+  given Codec.AsObject[InventoryAction] = deriveConfiguredCodec
+final case class ReceiveStock(sku: String, quantity: Int, warehouseId: String) extends InventoryAction
+object ReceiveStock:
+  given Codec.AsObject[ReceiveStock] = deriveConfiguredCodec
+final case class ShipStock(sku: String, quantity: Int, orderId: String) extends InventoryAction
+object ShipStock:
+  given Codec.AsObject[ShipStock] = deriveConfiguredCodec
+final case class AdjustStock(sku: String, delta: Int, reason: String = "correction") extends InventoryAction
+object AdjustStock:
+  given Codec.AsObject[AdjustStock] = deriveConfiguredCodec
+final case class TransferStock(sku: String, quantity: Int, fromId: String, toId: String) extends InventoryAction
+object TransferStock:
+  given Codec.AsObject[TransferStock] = deriveConfiguredCodec
+final case class ReserveStock(sku: String, quantity: Int, orderId: String, expiresAt: String = "") extends InventoryAction
+object ReserveStock:
+  given Codec.AsObject[ReserveStock] = deriveConfiguredCodec
+
+sealed trait ProductStatus
+object ProductStatus:
+  private given Configuration = Configuration.default.withDefaults.withDiscriminator("status")
+  given Codec.AsObject[ProductStatus] = deriveConfiguredCodec
+final case class DraftProduct(createdBy: String) extends ProductStatus
+object DraftProduct:
+  given Codec.AsObject[DraftProduct] = deriveConfiguredCodec
+final case class PublishedProduct(publishedAt: String, channel: String = "web") extends ProductStatus
+object PublishedProduct:
+  given Codec.AsObject[PublishedProduct] = deriveConfiguredCodec
+final case class ArchivedProduct(archivedAt: String, reason: String = "") extends ProductStatus
+object ArchivedProduct:
+  given Codec.AsObject[ArchivedProduct] = deriveConfiguredCodec
+final case class DiscontinuedProduct(discontinuedAt: String, replacementSku: String = "") extends ProductStatus
+object DiscontinuedProduct:
+  given Codec.AsObject[DiscontinuedProduct] = deriveConfiguredCodec
+
+object InventoryDomain:
+  def run(): Unit =
+    val product = Product(
+      "p1", ProductName("Widget"), Brand("Acme"), CategoryRef("c1", "Gadgets"),
+      Price(29.99), Weight(0.5), Dimensions(10, 5, 3),
+      List(ProductImage("img.png", "widget", true)),
+      List(ProductVariant(Sku("W-RED"), List(VariantOption("color", "red")), Price(29.99), 100)),
+    )
+    assert(decode[Product](product.asJson.noSpaces) == Right(product))
+
+    val action: InventoryAction = ReceiveStock("W-RED", 50, "wh1")
+    assert(decode[InventoryAction](action.asJson.noSpaces) == Right(action))
+
+    val status: ProductStatus = PublishedProduct("2024-01-15")
+    assert(decode[ProductStatus](status.asJson.noSpaces) == Right(status))
+
+    val order = PurchaseOrder("po1", "sup1", List(PurchaseOrderLine("W-RED", 100, Price(15.0))))
+    assert(decode[PurchaseOrder](order.asJson.noSpaces) == Right(order))
+
+    val bundle = ProductBundle("b1", "Starter Kit", List("W-RED", "W-BLUE"), Price(49.99))
+    assert(decode[ProductBundle](bundle.asJson.noSpaces) == Right(bundle))

--- a/benchmark-configured/shared/src/configured/protocols_messaging.scala
+++ b/benchmark-configured/shared/src/configured/protocols_messaging.scala
@@ -1,0 +1,151 @@
+package configured.messaging
+
+import io.circe.*
+import io.circe.syntax.*
+import io.circe.parser.*
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+
+// ═══════════════════════════════════════════════════════════════════════
+// Messaging / Notifications (~25 types)
+// withSnakeCaseMemberNames, withDefaults, withDiscriminator
+// ═══════════════════════════════════════════════════════════════════════
+
+private given Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults
+
+final case class MessageId(value: String)
+object MessageId:
+  given Codec.AsObject[MessageId] = deriveConfiguredCodec
+
+final case class Sender(userId: String, displayName: String, avatarUrl: String = "")
+object Sender:
+  given Codec.AsObject[Sender] = deriveConfiguredCodec
+
+final case class Recipient(userId: String, displayName: String)
+object Recipient:
+  given Codec.AsObject[Recipient] = deriveConfiguredCodec
+
+final case class MessageBody(contentType: String = "text/plain", content: String, truncated: Boolean = false)
+object MessageBody:
+  given Codec.AsObject[MessageBody] = deriveConfiguredCodec
+
+final case class Attachment(fileName: String, fileSize: Long, mimeType: String, downloadUrl: String = "")
+object Attachment:
+  given Codec.AsObject[Attachment] = deriveConfiguredCodec
+
+final case class Reaction(emoji: String, userId: String, createdAt: String)
+object Reaction:
+  given Codec.AsObject[Reaction] = deriveConfiguredCodec
+
+final case class ThreadRef(parentMessageId: String, replyCount: Int = 0, lastReplyAt: String = "")
+object ThreadRef:
+  given Codec.AsObject[ThreadRef] = deriveConfiguredCodec
+
+final case class ChatMessage(
+  messageId: MessageId,
+  sender: Sender,
+  recipients: List[Recipient],
+  body: MessageBody,
+  attachments: List[Attachment],
+  threadRef: Option[ThreadRef] = None,
+  sentAt: String,
+  editedAt: String = "",
+)
+object ChatMessage:
+  given Codec.AsObject[ChatMessage] = deriveConfiguredCodec
+
+final case class Channel(channelId: String, channelName: String, description: String = "", memberCount: Int = 0, isPrivate: Boolean = false)
+object Channel:
+  given Codec.AsObject[Channel] = deriveConfiguredCodec
+
+final case class ChannelMember(userId: String, channelId: String, role: String = "member", joinedAt: String)
+object ChannelMember:
+  given Codec.AsObject[ChannelMember] = deriveConfiguredCodec
+
+final case class NotificationPref(channelType: String, enabled: Boolean = true, quietHoursStart: Int = 22, quietHoursEnd: Int = 8)
+object NotificationPref:
+  given Codec.AsObject[NotificationPref] = deriveConfiguredCodec
+
+final case class EmailTemplate(templateId: String, templateName: String, subjectLine: String, bodyHtml: String = "", bodyText: String = "")
+object EmailTemplate:
+  given Codec.AsObject[EmailTemplate] = deriveConfiguredCodec
+
+final case class PushConfig(deviceToken: String, platform: String, badgeCount: Int = 0, soundEnabled: Boolean = true)
+object PushConfig:
+  given Codec.AsObject[PushConfig] = deriveConfiguredCodec
+
+final case class WebhookEndpoint(endpointUrl: String, secretKey: String = "", retryCount: Int = 3, timeoutMs: Int = 5000)
+object WebhookEndpoint:
+  given Codec.AsObject[WebhookEndpoint] = deriveConfiguredCodec
+
+final case class MessageSearch(queryText: String, channelId: String = "", senderId: String = "", beforeDate: String = "", afterDate: String = "")
+object MessageSearch:
+  given Codec.AsObject[MessageSearch] = deriveConfiguredCodec
+
+final case class ReadReceipt(messageId: String, userId: String, readAt: String)
+object ReadReceipt:
+  given Codec.AsObject[ReadReceipt] = deriveConfiguredCodec
+
+final case class TypingIndicator(channelId: String, userId: String, isTyping: Boolean = true)
+object TypingIndicator:
+  given Codec.AsObject[TypingIndicator] = deriveConfiguredCodec
+
+final case class MuteConfig(channelId: String, userId: String, mutedUntil: String = "", permanent: Boolean = false)
+object MuteConfig:
+  given Codec.AsObject[MuteConfig] = deriveConfiguredCodec
+
+// ADTs
+sealed trait NotificationEvent
+object NotificationEvent:
+  private given Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults.withDiscriminator("event_type")
+  given Codec.AsObject[NotificationEvent] = deriveConfiguredCodec
+final case class NewMessageNotif(messageId: String, channelId: String, previewText: String = "") extends NotificationEvent
+object NewMessageNotif:
+  given Codec.AsObject[NewMessageNotif] = deriveConfiguredCodec
+final case class MentionNotif(messageId: String, mentionedBy: String) extends NotificationEvent
+object MentionNotif:
+  given Codec.AsObject[MentionNotif] = deriveConfiguredCodec
+final case class ReactionNotif(messageId: String, emoji: String, reactedBy: String) extends NotificationEvent
+object ReactionNotif:
+  given Codec.AsObject[ReactionNotif] = deriveConfiguredCodec
+final case class ChannelInviteNotif(channelId: String, invitedBy: String, channelName: String = "") extends NotificationEvent
+object ChannelInviteNotif:
+  given Codec.AsObject[ChannelInviteNotif] = deriveConfiguredCodec
+
+sealed trait DeliveryStatus
+object DeliveryStatus:
+  private given Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults.withDiscriminator("delivery_status")
+  given Codec.AsObject[DeliveryStatus] = deriveConfiguredCodec
+final case class Queued(queuedAt: String, priority: Int = 0) extends DeliveryStatus
+object Queued:
+  given Codec.AsObject[Queued] = deriveConfiguredCodec
+final case class Delivered(deliveredAt: String, channel: String) extends DeliveryStatus
+object Delivered:
+  given Codec.AsObject[Delivered] = deriveConfiguredCodec
+final case class Bounced(bouncedAt: String, errorCode: String, retryable: Boolean = true) extends DeliveryStatus
+object Bounced:
+  given Codec.AsObject[Bounced] = deriveConfiguredCodec
+final case class Suppressed(reason: String, suppressedAt: String) extends DeliveryStatus
+object Suppressed:
+  given Codec.AsObject[Suppressed] = deriveConfiguredCodec
+
+object MessagingDomain:
+  def run(): Unit =
+    val msg = ChatMessage(
+      MessageId("m1"), Sender("u1", "Alice"), List(Recipient("u2", "Bob")),
+      MessageBody(content = "Hello!"), List(Attachment("doc.pdf", 1024, "application/pdf")),
+      None, "2024-01-15T10:30:00Z",
+    )
+    assert(decode[ChatMessage](msg.asJson.noSpaces) == Right(msg))
+
+    val notif: NotificationEvent = MentionNotif("m1", "u1")
+    assert(decode[NotificationEvent](notif.asJson.noSpaces) == Right(notif))
+
+    val status: DeliveryStatus = Delivered("2024-01-15T10:30:01Z", "push")
+    assert(decode[DeliveryStatus](status.asJson.noSpaces) == Right(status))
+
+    val channel = Channel("ch1", "general", "General chat")
+    assert(decode[Channel](channel.asJson.noSpaces) == Right(channel))
+
+    val webhook = WebhookEndpoint("https://example.com/hook")
+    assert(decode[WebhookEndpoint](webhook.asJson.noSpaces) == Right(webhook))

--- a/benchmark-configured/shared/src/configured/protocols_workflow.scala
+++ b/benchmark-configured/shared/src/configured/protocols_workflow.scala
@@ -1,0 +1,148 @@
+package configured.workflow
+
+import io.circe.*
+import io.circe.syntax.*
+import io.circe.parser.*
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+
+// ═══════════════════════════════════════════════════════════════════════
+// Workflow / Pipelines (~20 types)
+// withSnakeCaseMemberNames, withDefaults, withDiscriminator
+// ═══════════════════════════════════════════════════════════════════════
+
+private given Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults
+
+final case class WorkflowId(value: String)
+object WorkflowId:
+  given Codec.AsObject[WorkflowId] = deriveConfiguredCodec
+
+final case class StepId(value: String)
+object StepId:
+  given Codec.AsObject[StepId] = deriveConfiguredCodec
+
+final case class StepInput(name: String, inputType: String = "string", required: Boolean = true, defaultValue: String = "")
+object StepInput:
+  given Codec.AsObject[StepInput] = deriveConfiguredCodec
+
+final case class StepOutput(name: String, outputType: String = "string")
+object StepOutput:
+  given Codec.AsObject[StepOutput] = deriveConfiguredCodec
+
+final case class RetryPolicy(maxAttempts: Int = 3, backoffMs: Int = 1000, maxBackoffMs: Int = 30000)
+object RetryPolicy:
+  given Codec.AsObject[RetryPolicy] = deriveConfiguredCodec
+
+final case class TimeoutConfig(stepTimeoutMs: Int = 60000, workflowTimeoutMs: Int = 3600000)
+object TimeoutConfig:
+  given Codec.AsObject[TimeoutConfig] = deriveConfiguredCodec
+
+final case class WorkflowStep(
+  stepId: StepId,
+  stepName: String,
+  stepType: String,
+  inputs: List[StepInput],
+  outputs: List[StepOutput],
+  retryPolicy: RetryPolicy = RetryPolicy(),
+  dependsOn: List[String] = Nil,
+)
+object WorkflowStep:
+  given Codec.AsObject[WorkflowStep] = deriveConfiguredCodec
+
+final case class WorkflowDefinition(
+  workflowId: WorkflowId,
+  workflowName: String,
+  description: String = "",
+  steps: List[WorkflowStep],
+  timeoutConfig: TimeoutConfig = TimeoutConfig(),
+  enabled: Boolean = true,
+)
+object WorkflowDefinition:
+  given Codec.AsObject[WorkflowDefinition] = deriveConfiguredCodec
+
+final case class ExecutionContext(executionId: String, workflowId: String, triggeredBy: String, startedAt: String, variables: Map[String, String] = Map.empty)
+object ExecutionContext:
+  given Codec.AsObject[ExecutionContext] = deriveConfiguredCodec
+
+final case class StepExecution(stepId: String, executionId: String, startedAt: String, completedAt: String = "", outputData: String = "")
+object StepExecution:
+  given Codec.AsObject[StepExecution] = deriveConfiguredCodec
+
+final case class PipelineStage(stageName: String, stageOrder: Int, parallelSteps: List[String], gateApproval: Boolean = false)
+object PipelineStage:
+  given Codec.AsObject[PipelineStage] = deriveConfiguredCodec
+
+final case class Pipeline(pipelineId: String, pipelineName: String, stages: List[PipelineStage], triggerCron: String = "")
+object Pipeline:
+  given Codec.AsObject[Pipeline] = deriveConfiguredCodec
+
+final case class ApprovalRequest(requestId: String, stepId: String, requestedBy: String, approvers: List[String], expiresAt: String = "")
+object ApprovalRequest:
+  given Codec.AsObject[ApprovalRequest] = deriveConfiguredCodec
+
+final case class WebhookTrigger(triggerId: String, endpointPath: String, workflowId: String, secretToken: String = "", active: Boolean = true)
+object WebhookTrigger:
+  given Codec.AsObject[WebhookTrigger] = deriveConfiguredCodec
+
+final case class ScheduleTrigger(triggerId: String, cronExpression: String, workflowId: String, timezone: String = "UTC", enabled: Boolean = true)
+object ScheduleTrigger:
+  given Codec.AsObject[ScheduleTrigger] = deriveConfiguredCodec
+
+// ADTs
+sealed trait StepStatus
+object StepStatus:
+  private given Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults.withDiscriminator("step_status")
+  given Codec.AsObject[StepStatus] = deriveConfiguredCodec
+final case class PendingStep(scheduledAt: String = "") extends StepStatus
+object PendingStep:
+  given Codec.AsObject[PendingStep] = deriveConfiguredCodec
+final case class RunningStep(startedAt: String, progressPct: Int = 0) extends StepStatus
+object RunningStep:
+  given Codec.AsObject[RunningStep] = deriveConfiguredCodec
+final case class CompletedStep(completedAt: String, durationMs: Long) extends StepStatus
+object CompletedStep:
+  given Codec.AsObject[CompletedStep] = deriveConfiguredCodec
+final case class FailedStep(failedAt: String, errorMessage: String, retryCount: Int = 0) extends StepStatus
+object FailedStep:
+  given Codec.AsObject[FailedStep] = deriveConfiguredCodec
+final case class SkippedStep(reason: String = "condition not met") extends StepStatus
+object SkippedStep:
+  given Codec.AsObject[SkippedStep] = deriveConfiguredCodec
+
+sealed trait WorkflowEvent
+object WorkflowEvent:
+  private given Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults.withDiscriminator("workflow_event")
+  given Codec.AsObject[WorkflowEvent] = deriveConfiguredCodec
+final case class WorkflowStarted(executionId: String, workflowId: String, startedAt: String) extends WorkflowEvent
+object WorkflowStarted:
+  given Codec.AsObject[WorkflowStarted] = deriveConfiguredCodec
+final case class WorkflowCompleted(executionId: String, completedAt: String, totalDurationMs: Long) extends WorkflowEvent
+object WorkflowCompleted:
+  given Codec.AsObject[WorkflowCompleted] = deriveConfiguredCodec
+final case class WorkflowFailed(executionId: String, failedAt: String, failedStep: String, errorMessage: String) extends WorkflowEvent
+object WorkflowFailed:
+  given Codec.AsObject[WorkflowFailed] = deriveConfiguredCodec
+final case class WorkflowCancelled(executionId: String, cancelledAt: String, cancelledBy: String = "") extends WorkflowEvent
+object WorkflowCancelled:
+  given Codec.AsObject[WorkflowCancelled] = deriveConfiguredCodec
+
+object WorkflowDomain:
+  def run(): Unit =
+    val step = WorkflowStep(
+      StepId("s1"), "Extract Data", "transform",
+      List(StepInput("source", "string")), List(StepOutput("result")),
+    )
+    val wf = WorkflowDefinition(WorkflowId("wf1"), "ETL Pipeline", "Daily ETL", List(step))
+    assert(decode[WorkflowDefinition](wf.asJson.noSpaces) == Right(wf))
+
+    val status: StepStatus = RunningStep("2024-01-15T10:00:00Z", 45)
+    assert(decode[StepStatus](status.asJson.noSpaces) == Right(status))
+
+    val event: WorkflowEvent = WorkflowCompleted("ex1", "2024-01-15T11:00:00Z", 3600000)
+    assert(decode[WorkflowEvent](event.asJson.noSpaces) == Right(event))
+
+    val pipeline = Pipeline("p1", "Deploy", List(PipelineStage("build", 1, List("compile", "test")), PipelineStage("deploy", 2, List("release"), true)))
+    assert(decode[Pipeline](pipeline.asJson.noSpaces) == Right(pipeline))
+
+    val trigger = ScheduleTrigger("t1", "0 0 * * *", "wf1")
+    assert(decode[ScheduleTrigger](trigger.asJson.noSpaces) == Right(trigger))


### PR DESCRIPTION
## Summary
- Add `benchmark-configured/` suite (~230 types, 8 domain files) testing `withDefaults`, `withDiscriminator`, and `withSnakeCaseMemberNames`
- Add `generic-compat` shim so both modules share source (circe-generic doesn't expose `deriveConfiguredCodec`)
- Update `bench.sh` with `--configured` flag
- Update README with benchmark results and analysis

## Results (M3 Max, Mill 1.1.2, Scala 3.8.2)

**Auto derivation**: sanely **3.82s** vs generic **6.14s** (sanely 1.6x faster)  
**Configured derivation**: sanely **2.76s** vs circe-core **2.69s** (essentially the same)

The speedup only applies to auto derivation because that's where implicit search overhead exists. Configured derivation uses explicit semi-auto calls with no implicit search, so both implementations converge.

## Test plan
- [x] `./mill benchmark-configured.sanely.compile` passes
- [x] `./mill benchmark-configured.generic.compile` passes
- [x] `./mill benchmark-configured.sanely.run` — all roundtrip assertions pass
- [x] `./mill benchmark-configured.generic.run` — all roundtrip assertions pass
- [x] `bash bench.sh --configured 5` runs successfully
- [x] `bash bench.sh 5` (original) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)