### PR TITLE
perf: reduce generated AST size in configured derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.0] - 2026-03-05
+
+### Performance
+- **Eliminate 2x code duplication in configured sum type derivation** — configured encoder and decoder for sum types (sealed traits/enums) previously generated two complete dispatch chains (one for external tagging, one for discriminator mode). Now generates a single chain where each variant branch handles both modes inline. Cuts generated AST roughly in half for sum types.
+- **Cache `transformMemberNames` in configured product derivation** — transformed field names are now pre-computed once per encoder/decoder instance in an array, instead of calling `conf.transformMemberNames` per-field on every encode/decode call. Also reused for strict decoding validation.
+
 ## [0.5.0] - 2026-03-04
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Supports hierarchical sealed traits with diamond inheritance.
 
 ```diff
 - mvn"io.circe::circe-generic:0.14.x"
-+ mvn"io.github.nguyenyou::circe-sanely-auto:0.5.0"
++ mvn"io.github.nguyenyou::circe-sanely-auto:0.6.0"
 ```
 
 ### Step 2: Update imports
@@ -174,15 +174,15 @@ Results on M3 Max MacBook Pro (Mill 1.1.2, Scala 3.8.2):
 
 | | Median compile time | |
 |---|---|---|
-| **circe-sanely-auto** | **3.52s** | |
-| **circe-generic** | **6.49s** | 1.8x slower |
+| **circe-sanely-auto** | **3.69s** | |
+| **circe-generic** | **6.99s** | 1.9x slower |
 
 ### Configured derivation
 
 | | Median compile time | |
 |---|---|---|
-| **circe-sanely-auto** | **2.48s** | |
-| **circe-core** | **2.70s** | ~same |
+| **circe-sanely-auto** | **3.10s** | |
+| **circe-core** | **3.20s** | ~same |
 
 ### Why the difference?
 

--- a/sanely/package.mill
+++ b/sanely/package.mill
@@ -16,7 +16,7 @@ object `package` extends mill.Module {
   trait SharedModule extends PlatformScalaModule with SonatypeCentralPublishModule {
     def artifactName = "circe-sanely-auto"
     def scalaVersion = build.scala3Version
-    def publishVersion = "0.5.0"
+    def publishVersion = "0.6.0"
 
     def pomSettings = PomSettings(
       description = "Drop-in replacement for circe's auto-derivation using sanely-automatic Scala 3 macros",

--- a/sanely/src/sanely/SanelyConfiguredDecoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredDecoder.scala
@@ -1,6 +1,6 @@
 package sanely
 
-import io.circe.{Decoder, DecodingFailure, HCursor, Json}
+import io.circe.{ACursor, Decoder, DecodingFailure, HCursor, Json}
 import io.circe.derivation.Configuration
 import scala.deriving.Mirror
 import scala.collection.mutable
@@ -42,7 +42,7 @@ object SanelyConfiguredDecoder:
       val fields = resolveFields[Types, Labels](selfRef)
       val defaults = resolveDefaults[P]
 
-      def buildDecodeChain(c: Expr[HCursor], remaining: List[(String, Type[?], Expr[Decoder[?]], Option[Expr[Any]])], fieldIdx: Int, acc: List[Expr[Any]]): Expr[Decoder.Result[P]] =
+      def buildDecodeChain(c: Expr[HCursor], fieldNames: Expr[Array[String]], remaining: List[(String, Type[?], Expr[Decoder[?]], Option[Expr[Any]])], fieldIdx: Int, acc: List[Expr[Any]]): Expr[Decoder.Result[P]] =
         remaining match
           case Nil =>
             val tupleExpr = acc.reverse.foldRight('{ EmptyTuple }: Expr[Tuple]) { (elem, tuple) =>
@@ -53,7 +53,7 @@ object SanelyConfiguredDecoder:
             tpe match
               case '[t] =>
                 val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
-                val labelExpr = Expr(label)
+                val fieldIdxExpr = Expr(fieldIdx)
                 defaultOpt match
                   case Some(defaultExpr) =>
                     val typedDefault = defaultExpr.asInstanceOf[Expr[t]]
@@ -63,34 +63,32 @@ object SanelyConfiguredDecoder:
                       case _ => false
                     if isOptionType then
                       '{
-                        val fieldName = $conf.transformMemberNames($labelExpr)
-                        val cursor = $c.downField(fieldName)
+                        val cursor = $c.downField($fieldNames($fieldIdxExpr))
                         val result: Decoder.Result[t] =
                           if $conf.useDefaults && cursor.failed then
                             Right($typedDefault)
                           else
                             $typedDec.tryDecode(cursor)
                         result match
-                          case Right(v) => ${ buildDecodeChain(c, rest, fieldIdx + 1, 'v :: acc) }
+                          case Right(v) => ${ buildDecodeChain(c, fieldNames, rest, fieldIdx + 1, 'v :: acc) }
                           case Left(e)  => Left(e)
                       }
                     else
                       '{
-                        val fieldName = $conf.transformMemberNames($labelExpr)
-                        val cursor = $c.downField(fieldName)
+                        val cursor = $c.downField($fieldNames($fieldIdxExpr))
                         val result: Decoder.Result[t] =
                           if $conf.useDefaults && (cursor.failed || cursor.focus.exists(_.isNull)) then
                             Right($typedDefault)
                           else
                             $typedDec.tryDecode(cursor)
                         result match
-                          case Right(v) => ${ buildDecodeChain(c, rest, fieldIdx + 1, 'v :: acc) }
+                          case Right(v) => ${ buildDecodeChain(c, fieldNames, rest, fieldIdx + 1, 'v :: acc) }
                           case Left(e)  => Left(e)
                       }
                   case None =>
                     '{
-                      $typedDec.tryDecode($c.downField($conf.transformMemberNames($labelExpr))) match
-                        case Right(v) => ${ buildDecodeChain(c, rest, fieldIdx + 1, 'v :: acc) }
+                      $typedDec.tryDecode($c.downField($fieldNames($fieldIdxExpr))) match
+                        case Right(v) => ${ buildDecodeChain(c, fieldNames, rest, fieldIdx + 1, 'v :: acc) }
                         case Left(e)  => Left(e)
                     }
 
@@ -98,25 +96,24 @@ object SanelyConfiguredDecoder:
         (label, tpe, dec, defaults.lift(idx).flatten)
       }
 
-      // Collect field labels for strict decoding
       val fieldLabels = fields.map(_._1)
       val fieldLabelsExpr = Expr(fieldLabels)
 
       '{
+        val _fieldNames = $fieldLabelsExpr.map($conf.transformMemberNames).toArray
         new Decoder[P]:
           def apply(c: HCursor): Decoder.Result[P] =
             if !c.value.isObject then Left(DecodingFailure("Expected JSON object for product type", c.history))
             else
-              // Strict decoding check
               if $conf.strictDecoding then
-                val expectedKeys = $fieldLabelsExpr.map($conf.transformMemberNames).toSet
+                val expectedKeys = _fieldNames.toSet
                 c.keys match
                   case Some(keys) =>
                     val unexpected = keys.filterNot(expectedKeys.contains).toList
                     if unexpected.nonEmpty then
                       return Left(DecodingFailure(s"Unexpected field(s): ${unexpected.mkString(", ")}", c.history))
                   case None => ()
-              ${ buildDecodeChain('c, fieldsWithDefaults, 0, Nil) }
+              ${ buildDecodeChain('c, '{ _fieldNames }, fieldsWithDefaults, 0, Nil) }
       }
 
     private def deriveSum[S: Type, Types: Type, Labels: Type](
@@ -135,71 +132,53 @@ object SanelyConfiguredDecoder:
         (label, tpe, dec, isSub)
       }
 
-      // --- External tagging path (discriminator = None) ---
-      def buildMatchExternal(c: Expr[HCursor], key: Expr[String]): Expr[Decoder.Result[S]] =
-        casesWithSubTrait.foldRight('{ Left(DecodingFailure("Unknown variant", $c.history)) }: Expr[Decoder.Result[S]]) {
-          case ((label, tpe, dec, true), elseExpr) =>
-            tpe match
-              case '[t] =>
-                val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
-                '{ $typedDec.tryDecode($c) match
-                    case Right(v) => Right(v.asInstanceOf[S])
-                    case Left(_)  => $elseExpr
-                }
-          case ((label, tpe, dec, false), elseExpr) =>
-            tpe match
-              case '[t] =>
-                val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
-                val labelExpr = Expr(label)
-                '{ if $key == $conf.transformConstructorNames($labelExpr) then $typedDec.tryDecode($c.downField($key)).asInstanceOf[Decoder.Result[S]] else $elseExpr }
-        }
-
-      // --- Discriminator path (discriminator = Some(d)) ---
-      def buildMatchDiscriminator(c: Expr[HCursor], discriminatorValue: Expr[String]): Expr[Decoder.Result[S]] =
-        casesWithSubTrait.foldRight('{ Left(DecodingFailure("Unknown variant: " + $discriminatorValue, $c.history)) }: Expr[Decoder.Result[S]]) {
-          case ((label, tpe, dec, true), elseExpr) =>
-            tpe match
-              case '[t] =>
-                val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
-                '{ $typedDec.tryDecode($c) match
-                    case Right(v) => Right(v.asInstanceOf[S])
-                    case Left(_)  => $elseExpr
-                }
-          case ((label, tpe, dec, false), elseExpr) =>
-            tpe match
-              case '[t] =>
-                val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
-                val labelExpr = Expr(label)
-                '{ if $discriminatorValue == $conf.transformConstructorNames($labelExpr) then $typedDec.tryDecode($c).asInstanceOf[Decoder.Result[S]] else $elseExpr }
-        }
-
       val directLabels = casesWithSubTrait.collect { case (label, _, _, false) => label }
       val directLabelsExpr = Expr(directLabels)
+
+      def buildMatch(c: Expr[HCursor], matchValue: Expr[String], decodeCursor: Expr[ACursor]): Expr[Decoder.Result[S]] =
+        val fallback: Expr[Decoder.Result[S]] = '{
+          $conf.discriminator match
+            case Some(_) => Left(DecodingFailure("Unknown variant: " + $matchValue, $c.history))
+            case None    => Left(DecodingFailure("Unknown variant", $c.history))
+        }
+        casesWithSubTrait.foldRight(fallback) {
+          case ((label, tpe, dec, true), elseExpr) =>
+            tpe match
+              case '[t] =>
+                val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
+                '{ $typedDec.tryDecode($c) match
+                    case Right(v) => Right(v.asInstanceOf[S])
+                    case Left(_)  => $elseExpr
+                }
+          case ((label, tpe, dec, false), elseExpr) =>
+            tpe match
+              case '[t] =>
+                val typedDec = dec.asInstanceOf[Expr[Decoder[t]]]
+                val labelExpr = Expr(label)
+                '{ if $matchValue == $conf.transformConstructorNames($labelExpr) then $typedDec.tryDecode($decodeCursor).asInstanceOf[Decoder.Result[S]] else $elseExpr }
+        }
 
       '{
         new Decoder[S]:
           def apply(c: HCursor): Decoder.Result[S] =
-            $conf.discriminator match
+            val pair: (String, ACursor) = $conf.discriminator match
               case Some(discField) =>
-                // Discriminator mode: read discriminator field value
                 c.downField(discField).as[String] match
-                  case Right(typeName) =>
-                    ${ buildMatchDiscriminator('c, 'typeName) }
-                  case Left(e) =>
-                    Left(DecodingFailure(s"Missing discriminator field '$$discField'", c.history))
+                  case Right(typeName) => (typeName, c)
+                  case Left(_) =>
+                    return Left(DecodingFailure(s"Missing discriminator field '$$discField'", c.history))
               case None =>
-                // External tagging mode
                 c.keys match
                   case Some(keys) =>
                     val keysList = keys.toList
                     if $conf.strictDecoding && keysList.size > 1 then
-                      Left(DecodingFailure("Expected single-key JSON object for sum type", c.history))
-                    else
-                      val transformedLabels = $directLabelsExpr.map(l => $conf.transformConstructorNames(l))
-                      val key = keysList.find(transformedLabels.toSet.contains).getOrElse("")
-                      ${ buildMatchExternal('c, 'key) }
+                      return Left(DecodingFailure("Expected single-key JSON object for sum type", c.history))
+                    val transformedLabels = $directLabelsExpr.map(l => $conf.transformConstructorNames(l))
+                    val key = keysList.find(transformedLabels.toSet.contains).getOrElse("")
+                    (key, c.downField(key))
                   case None =>
-                    Left(DecodingFailure("Expected JSON object for sum type", c.history))
+                    return Left(DecodingFailure("Expected JSON object for sum type", c.history))
+            ${ buildMatch('c, '{ pair._1 }, '{ pair._2 }) }
       }
 
     private def resolveFields[Types: Type, Labels: Type](

--- a/sanely/src/sanely/SanelyConfiguredEncoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredEncoder.scala
@@ -40,22 +40,20 @@ object SanelyConfiguredEncoder:
       selfRef: Expr[Encoder.AsObject[A]]
     ): Expr[Encoder.AsObject[P]] =
       val fields = resolveFields[Types, Labels](selfRef)
-
-      def addField(base: Expr[JsonObject], product: Expr[Product], label: String, idx: Int, tpe: Type[?], enc: Expr[Encoder[?]]): Expr[JsonObject] =
-        tpe match
-          case '[t] =>
-            val typedEnc = enc.asInstanceOf[Expr[Encoder[t]]]
-            val labelExpr = Expr(label)
-            val idxExpr = Expr(idx)
-            '{ $base.add($conf.transformMemberNames($labelExpr), $typedEnc($product.productElement($idxExpr).asInstanceOf[t])) }
+      val labelsExpr = Expr(fields.map(_._1))
 
       '{
+        val _names = $labelsExpr.map($conf.transformMemberNames).toArray
         new Encoder.AsObject[P]:
           def encodeObject(a: P): JsonObject =
             ${
               val product = '{ a.asInstanceOf[Product] }
-              fields.zipWithIndex.foldLeft('{ JsonObject.empty }) { case (acc, ((label, tpe, enc), idx)) =>
-                addField(acc, product, label, idx, tpe, enc)
+              fields.zipWithIndex.foldLeft('{ JsonObject.empty }) { case (acc, ((_, tpe, enc), idx)) =>
+                tpe match
+                  case '[t] =>
+                    val typedEnc = enc.asInstanceOf[Expr[Encoder[t]]]
+                    val idxExpr = Expr(idx)
+                    '{ $acc.add(_names($idxExpr), $typedEnc($product.productElement($idxExpr).asInstanceOf[t])) }
               }
             }
       }
@@ -76,18 +74,7 @@ object SanelyConfiguredEncoder:
         (label, tpe, enc, isSub)
       }
 
-      def buildBranchExternal(a: Expr[S], label: String, tpe: Type[?], enc: Expr[Encoder[?]], isSubTrait: Boolean): Expr[JsonObject] =
-        tpe match
-          case '[t] =>
-            if isSubTrait then
-              val typedEnc = enc.asInstanceOf[Expr[Encoder.AsObject[t]]]
-              '{ $typedEnc.encodeObject($a.asInstanceOf[t]) }
-            else
-              val typedEnc = enc.asInstanceOf[Expr[Encoder[t]]]
-              val labelExpr = Expr(label)
-              '{ JsonObject.singleton($conf.transformConstructorNames($labelExpr), $typedEnc($a.asInstanceOf[t])) }
-
-      def buildBranchDiscriminator(a: Expr[S], discr: Expr[String], label: String, tpe: Type[?], enc: Expr[Encoder[?]], isSubTrait: Boolean): Expr[JsonObject] =
+      def buildBranch(a: Expr[S], label: String, tpe: Type[?], enc: Expr[Encoder[?]], isSubTrait: Boolean): Expr[JsonObject] =
         tpe match
           case '[t] =>
             if isSubTrait then
@@ -97,9 +84,14 @@ object SanelyConfiguredEncoder:
               val typedEnc = enc.asInstanceOf[Expr[Encoder[t]]]
               val labelExpr = Expr(label)
               '{
-                val inner = $typedEnc($a.asInstanceOf[t])
-                val base = inner.asObject.getOrElse(JsonObject.empty)
-                base.add($discr, Json.fromString($conf.transformConstructorNames($labelExpr)))
+                val encoded = $typedEnc($a.asInstanceOf[t])
+                val transformedLabel = $conf.transformConstructorNames($labelExpr)
+                $conf.discriminator match
+                  case None =>
+                    JsonObject.singleton(transformedLabel, encoded)
+                  case Some(discr) =>
+                    val base = encoded.asObject.getOrElse(JsonObject.empty)
+                    base.add(discr, Json.fromString(transformedLabel))
               }
 
       '{
@@ -107,26 +99,11 @@ object SanelyConfiguredEncoder:
           def encodeObject(a: S): JsonObject =
             val ord = $mirror.ordinal(a)
             ${
-              // We build two branches: one for discriminator mode, one for external tagging
-              // The runtime check on conf.discriminator selects which path
-              val externalMatch = casesWithSubTrait.zipWithIndex.foldRight('{ throw new MatchError(ord) }: Expr[JsonObject]) {
+              casesWithSubTrait.zipWithIndex.foldRight('{ throw new MatchError(ord) }: Expr[JsonObject]) {
                 case (((label, tpe, enc, isSub), idx), elseExpr) =>
                   val idxExpr = Expr(idx)
-                  val branch = buildBranchExternal('a, label, tpe, enc, isSub)
+                  val branch = buildBranch('a, label, tpe, enc, isSub)
                   '{ if ord == $idxExpr then $branch else $elseExpr }
-              }
-
-              val discrMatch = casesWithSubTrait.zipWithIndex.foldRight('{ throw new MatchError(ord) }: Expr[JsonObject]) {
-                case (((label, tpe, enc, isSub), idx), elseExpr) =>
-                  val idxExpr = Expr(idx)
-                  val branch = buildBranchDiscriminator('a, '{ $conf.discriminator.get }, label, tpe, enc, isSub)
-                  '{ if ord == $idxExpr then $branch else $elseExpr }
-              }
-
-              '{
-                $conf.discriminator match
-                  case None    => $externalMatch
-                  case Some(_) => $discrMatch
               }
             }
       }


### PR DESCRIPTION
## Summary

- **Sum type 2x dedup**: Configured encoder/decoder for sum types previously generated two complete dispatch chains (one for external tagging, one for discriminator mode). Now generates a single chain where each variant handles both modes inline. Cuts generated AST roughly in half for sum types.
- **Cache `transformMemberNames`**: Transformed field names are pre-computed once per encoder/decoder instance in an array, instead of calling `conf.transformMemberNames` per-field on every encode/decode. Also reused for strict decoding validation.
- Bump version to 0.6.0

## Benchmark (M3 Max, Mill 1.1.2, Scala 3.8.2)

| | Auto derivation | Configured derivation |
|---|---|---|
| **circe-sanely-auto** | **3.69s** | **3.10s** |
| **circe-generic / circe-core** | **6.99s** (1.9x slower) | **3.20s** (~same) |

## Test plan

- [x] 57 auto unit tests (JVM)
- [x] 59 configured unit tests (JVM)
- [x] 116 unit tests (Scala.js)
- [x] 160 circe compat tests
- [x] Auto derivation benchmark — no regression
- [x] Configured derivation benchmark — verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)