### PR TITLE
feat: add compile-time macro profiling

### DIFF
--- a/.claude/skills/sanely-profile/SKILL.md
+++ b/.claude/skills/sanely-profile/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: sanely-profile
+description: >
+  Profile and analyze circe-sanely-auto macro expansion performance.
+  Use this skill whenever investigating compile time, macro performance,
+  slow derivation, or optimizing the macro engine. Also use when the user
+  says "profile", "why is compilation slow", "macro timing", "what's taking
+  so long", "optimize macros", or wants to understand where time is spent
+  during codec derivation. This skill covers the full workflow: running
+  profiled compilation, analyzing results with the bundled Python script,
+  and interpreting the output to plan optimizations.
+---
+
+# Macro Expansion Profiling
+
+circe-sanely-auto has built-in compile-time profiling gated by the
+`SANELY_PROFILE=true` environment variable. When enabled, each macro
+expansion prints timing data to stderr. This has zero cost when disabled.
+
+## Quick Start
+
+### 1. Run profiled compilation
+
+```bash
+# Auto derivation benchmark (~300 types)
+SANELY_PROFILE=true ./mill --no-server benchmark.sanely.compile 2>&1 | tee /tmp/sanely-profile-output.txt
+
+# Configured derivation benchmark (~230 types)
+SANELY_PROFILE=true ./mill --no-server benchmark.configured.compile 2>&1 | tee /tmp/sanely-profile-output.txt
+
+# Just the library (unit test types)
+SANELY_PROFILE=true ./mill --no-server sanely.jvm.test 2>&1 | tee /tmp/sanely-profile-output.txt
+```
+
+Use `--no-server` so Mill doesn't reuse a cached compilation.
+
+### 2. Analyze with the Python script
+
+```bash
+# Full report
+python .claude/skills/sanely-profile/scripts/analyze_profile.py /tmp/sanely-profile-output.txt
+
+# Top 20 slowest, sorted by summonIgnoring time
+python .claude/skills/sanely-profile/scripts/analyze_profile.py /tmp/sanely-profile-output.txt --top 20 --sort summonIgnoring
+
+# Only Decoder expansions
+python .claude/skills/sanely-profile/scripts/analyze_profile.py /tmp/sanely-profile-output.txt --kind Decoder
+
+# JSON output for programmatic use
+python .claude/skills/sanely-profile/scripts/analyze_profile.py /tmp/sanely-profile-output.txt --json
+```
+
+### 3. Interpret the results
+
+The report shows:
+
+| Section | What it tells you |
+|---|---|
+| **By Kind** | Encoder vs Decoder vs CfgEncoder vs CfgDecoder breakdown |
+| **Category Breakdown** | Where time is spent across all expansions |
+| **Top N Slowest** | Which types are the compilation bottlenecks |
+| **Optimization Insights** | Actionable recommendations based on the data |
+
+## What Gets Profiled
+
+Each macro expansion (one per `Encoder[T]` or `Decoder[T]` derivation) tracks:
+
+| Category | What it measures |
+|---|---|
+| `summonIgnoring` | `Expr.summonIgnoring[Encoder/Decoder[T]]` - compiler implicit search |
+| `summonMirror` | `Expr.summon[Mirror.Of[T]]` - fetching the type's Mirror |
+| `derive` | Recursive `deriveProduct`/`deriveSum` calls - AST construction |
+| `subTraitDetect` | Checking if a sum type variant is itself a sub-trait |
+| `cacheHit` | Times the intra-expansion cache avoided re-derivation |
+
+## Instrumented Files
+
+Profiling code lives in these files:
+
+- `sanely/src/sanely/MacroTimer.scala` - Timer utility (zero-cost when disabled)
+- `sanely/src/sanely/SanelyEncoder.scala` - `EncoderDerivation` class
+- `sanely/src/sanely/SanelyDecoder.scala` - `DecoderDerivation` class
+- `sanely/src/sanely/SanelyConfiguredEncoder.scala` - `ConfiguredEncoderDerivation` class
+- `sanely/src/sanely/SanelyConfiguredDecoder.scala` - `ConfiguredDecoderDerivation` class
+
+## Baseline Profile (v0.6.1, ~300 types auto benchmark)
+
+Reference numbers from M3 Max MacBook Pro:
+
+```
+308 macro expansions, ~2450ms total macro time
+
+Category Breakdown:
+  summonIgnoring        1256ms (51.3%)  1366 calls  avg 0.92ms
+  derive                 716ms (29.2%)   586 calls
+  summonMirror            80ms  (3.3%)   586 calls  avg 0.14ms
+  subTraitDetect          43ms  (1.8%)   336 calls
+  cacheHit                       1714 hits
+  overhead               355ms (14.5%)
+```
+
+Key insight: `summonIgnoring` (compiler implicit search) dominates at 51%.
+The main optimization lever is reducing the number of summonIgnoring calls,
+either through cross-expansion caching or lazy val emission patterns.
+
+## Optimization Planning Guide
+
+After analyzing profile data, use this to prioritize:
+
+1. **If summonIgnoring > 40%**: Focus on reducing implicit search calls.
+   Cross-expansion caching (lazy val emission) would help most. Currently
+   each macro expansion starts with a fresh cache.
+
+2. **If derive > 30%**: Focus on reducing generated AST size. Extract more
+   logic from inline macro output to `SanelyRuntime` helper methods.
+
+3. **If specific types are > 50ms**: Those types have deep nesting. Consider
+   whether they could benefit from user-provided instances or structural
+   changes.
+
+4. **If Decoder >> Encoder**: Decoder's field-by-field decode chain is
+   inherently more expensive. The `buildDecodeChain` recursive Expr
+   construction is the cause.
+
+5. **If cache hit ratio is low**: The intra-expansion cache isn't catching
+   enough repeated types. Check if `cacheKey` computation is too specific.

--- a/.claude/skills/sanely-profile/scripts/analyze_profile.py
+++ b/.claude/skills/sanely-profile/scripts/analyze_profile.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Analyze SANELY_PROFILE output from circe-sanely-auto macro expansion.
+
+Usage:
+  # From a file:
+  python analyze_profile.py profile_output.txt
+
+  # From stdin (pipe compilation stderr):
+  SANELY_PROFILE=true ./mill --no-server benchmark.sanely.compile 2>&1 | python analyze_profile.py
+
+  # With options:
+  python analyze_profile.py profile_output.txt --top 20 --sort summonIgnoring --kind Encoder
+"""
+
+import sys
+import re
+import argparse
+import json
+from collections import defaultdict
+
+
+def parse_profile_lines(lines):
+    """Parse [PROFILE] lines into structured data."""
+    expansions = []
+
+    for line in lines:
+        # Extract profile line content after [PROFILE] prefix
+        m = re.search(r'\[PROFILE\]\s+(\w+)\[(.+?)\]:\s+(.+)', line)
+        if not m:
+            continue
+
+        kind = m.group(1)       # Encoder, Decoder, CfgEncoder, CfgDecoder
+        type_name = m.group(2)  # e.g., benchmark.domain7.Ticket
+        rest = m.group(3)
+
+        entry = {
+            'kind': kind,
+            'type': type_name,
+            'short_type': type_name.rsplit('.', 1)[-1],
+            'categories': {}
+        }
+
+        # Parse total=Xms
+        total_m = re.search(r'total=([\d.]+)ms', rest)
+        if total_m:
+            entry['total_ms'] = float(total_m.group(1))
+
+        # Parse category=Xms(Nx) pairs
+        for cat_m in re.finditer(r'(\w+)=([\d.]+)ms\((\d+)x\)', rest):
+            cat_name = cat_m.group(1)
+            entry['categories'][cat_name] = {
+                'ms': float(cat_m.group(2)),
+                'calls': int(cat_m.group(3))
+            }
+
+        expansions.append(entry)
+
+    return expansions
+
+
+def aggregate(expansions):
+    """Compute aggregate statistics across all expansions."""
+    total_ms = sum(e.get('total_ms', 0) for e in expansions)
+    n = len(expansions)
+
+    cats = defaultdict(lambda: {'ms': 0.0, 'calls': 0})
+    for e in expansions:
+        for cat, data in e['categories'].items():
+            cats[cat]['ms'] += data['ms']
+            cats[cat]['calls'] += data['calls']
+
+    # Count by kind
+    kinds = defaultdict(int)
+    kind_ms = defaultdict(float)
+    for e in expansions:
+        kinds[e['kind']] += 1
+        kind_ms[e['kind']] += e.get('total_ms', 0)
+
+    return {
+        'total_expansions': n,
+        'total_ms': total_ms,
+        'avg_ms': total_ms / n if n > 0 else 0,
+        'categories': dict(cats),
+        'kinds': dict(kinds),
+        'kind_ms': dict(kind_ms),
+    }
+
+
+def print_report(expansions, agg, top_n=15, sort_by='total', kind_filter=None):
+    """Print a human-readable profiling report."""
+
+    filtered = expansions
+    if kind_filter:
+        filtered = [e for e in filtered if e['kind'] == kind_filter]
+        if not filtered:
+            print(f"No expansions found for kind '{kind_filter}'")
+            return
+
+    n = agg['total_expansions']
+    total = agg['total_ms']
+
+    print(f"{'=' * 70}")
+    print(f"SANELY MACRO PROFILE ({n} expansions, {total:.0f}ms total)")
+    print(f"{'=' * 70}")
+
+    # Kind breakdown
+    print(f"\n--- By Kind ---")
+    for kind, count in sorted(agg['kinds'].items()):
+        ms = agg['kind_ms'][kind]
+        print(f"  {kind:<15} {count:>4} expansions  {ms:>8.1f}ms  avg {ms/count:.2f}ms")
+
+    # Category breakdown
+    print(f"\n--- Category Breakdown ---")
+    cats = agg['categories']
+    for cat in sorted(cats.keys(), key=lambda c: -cats[c]['ms']):
+        data = cats[cat]
+        pct = data['ms'] / total * 100 if total > 0 else 0
+        avg = data['ms'] / data['calls'] if data['calls'] > 0 else 0
+        if cat == 'cacheHit':
+            print(f"  {cat:<20} {'':>10}  {data['calls']:>6} hits")
+        else:
+            print(f"  {cat:<20} {data['ms']:>8.1f}ms ({pct:>5.1f}%)  {data['calls']:>6} calls  avg {avg:.2f}ms")
+
+    unaccounted = total - sum(d['ms'] for c, d in cats.items() if c != 'cacheHit')
+    if total > 0:
+        print(f"  {'overhead':<20} {unaccounted:>8.1f}ms ({unaccounted/total*100:>5.1f}%)  (type checks, AST, etc)")
+
+    # Top N slowest
+    if sort_by in ('total', 'total_ms'):
+        key = lambda e: e.get('total_ms', 0)
+        sort_label = 'total time'
+    else:
+        key = lambda e: e['categories'].get(sort_by, {}).get('ms', 0)
+        sort_label = f'{sort_by} time'
+
+    ranked = sorted(filtered, key=key, reverse=True)[:top_n]
+
+    print(f"\n--- Top {top_n} Slowest ({sort_label}) ---")
+    for i, e in enumerate(ranked, 1):
+        cats_str = ' '.join(
+            f"{c}={d['ms']:.1f}ms({d['calls']}x)"
+            for c, d in sorted(e['categories'].items(), key=lambda x: -x[1]['ms'])
+        )
+        print(f"  {i:>2}. {e['kind']}[{e['short_type']}]: total={e.get('total_ms', 0):.1f}ms  {cats_str}")
+
+    # Optimization insights
+    print(f"\n--- Optimization Insights ---")
+    insights = generate_insights(expansions, agg)
+    for insight in insights:
+        print(f"  * {insight}")
+
+    print(f"{'=' * 70}")
+
+
+def generate_insights(expansions, agg):
+    """Generate actionable optimization insights from the profile data."""
+    insights = []
+    total = agg['total_ms']
+    cats = agg['categories']
+
+    # summonIgnoring dominance
+    si = cats.get('summonIgnoring', {})
+    if si and total > 0:
+        si_pct = si['ms'] / total * 100
+        if si_pct > 40:
+            insights.append(
+                f"summonIgnoring is {si_pct:.0f}% of total time ({si['ms']:.0f}ms, {si['calls']} calls). "
+                f"This is the compiler's implicit search. Reducing calls via cross-expansion "
+                f"caching (lazy val emission) would have the biggest impact."
+            )
+            avg = si['ms'] / si['calls'] if si['calls'] > 0 else 0
+            if avg > 5:
+                insights.append(
+                    f"Average summonIgnoring call takes {avg:.1f}ms - some types have expensive "
+                    f"implicit search. Check the slowest expansions for high per-call cost."
+                )
+
+    # derive time
+    derive = cats.get('derive', {})
+    if derive and total > 0:
+        d_pct = derive['ms'] / total * 100
+        if d_pct > 25:
+            insights.append(
+                f"Derivation (AST construction) is {d_pct:.0f}% of total ({derive['ms']:.0f}ms). "
+                f"Extracting more logic to SanelyRuntime could reduce generated AST size."
+            )
+
+    # Cache effectiveness
+    ch = cats.get('cacheHit', {})
+    if ch and derive:
+        ratio = ch['calls'] / (ch['calls'] + derive['calls']) if (ch['calls'] + derive['calls']) > 0 else 0
+        if ratio > 0.5:
+            insights.append(
+                f"Cache hit ratio: {ratio:.0%} ({ch['calls']} hits vs {derive['calls']} derivations). "
+                f"Intra-expansion caching is working well."
+            )
+        else:
+            insights.append(
+                f"Cache hit ratio: {ratio:.0%} ({ch['calls']} hits vs {derive['calls']} derivations). "
+                f"Consider caching more aggressively."
+            )
+
+    # subTraitDetect
+    st = cats.get('subTraitDetect', {})
+    if st and total > 0:
+        st_pct = st['ms'] / total * 100
+        if st_pct > 5:
+            insights.append(
+                f"Sub-trait detection is {st_pct:.0f}% of total ({st['ms']:.0f}ms). "
+                f"Consider caching sub-trait status per type."
+            )
+
+    # Hot types (types appearing in many expansions' summonIgnoring)
+    hot = [e for e in expansions if e.get('total_ms', 0) > 50]
+    if hot:
+        names = [f"{e['kind']}[{e['short_type']}] ({e['total_ms']:.0f}ms)" for e in hot[:5]]
+        insights.append(f"Hot types (>50ms): {', '.join(names)}")
+
+    # Encoder vs Decoder asymmetry
+    enc_ms = agg['kind_ms'].get('Encoder', 0) + agg['kind_ms'].get('CfgEncoder', 0)
+    dec_ms = agg['kind_ms'].get('Decoder', 0) + agg['kind_ms'].get('CfgDecoder', 0)
+    if enc_ms > 0 and dec_ms > 0:
+        ratio = dec_ms / enc_ms
+        if ratio > 1.3:
+            insights.append(
+                f"Decoder derivation is {ratio:.1f}x slower than Encoder ({dec_ms:.0f}ms vs {enc_ms:.0f}ms). "
+                f"Decoder's field-by-field chain building is more expensive."
+            )
+
+    if not insights:
+        insights.append("No significant bottlenecks detected. Macro expansion is well-optimized.")
+
+    return insights
+
+
+def output_json(expansions, agg):
+    """Output results as JSON for programmatic consumption."""
+    result = {
+        'summary': agg,
+        'insights': generate_insights(expansions, agg),
+        'top_slowest': [
+            {
+                'kind': e['kind'],
+                'type': e['type'],
+                'total_ms': e.get('total_ms', 0),
+                'categories': e['categories']
+            }
+            for e in sorted(expansions, key=lambda e: e.get('total_ms', 0), reverse=True)[:20]
+        ]
+    }
+    print(json.dumps(result, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Analyze SANELY_PROFILE macro expansion data'
+    )
+    parser.add_argument('file', nargs='?', default='-',
+                        help='Profile output file (default: stdin)')
+    parser.add_argument('--top', type=int, default=15,
+                        help='Number of slowest expansions to show (default: 15)')
+    parser.add_argument('--sort', default='total',
+                        choices=['total', 'summonIgnoring', 'summonMirror', 'derive', 'subTraitDetect'],
+                        help='Sort top expansions by category (default: total)')
+    parser.add_argument('--kind', default=None,
+                        choices=['Encoder', 'Decoder', 'CfgEncoder', 'CfgDecoder'],
+                        help='Filter to specific derivation kind')
+    parser.add_argument('--json', action='store_true',
+                        help='Output as JSON instead of human-readable report')
+
+    args = parser.parse_args()
+
+    if args.file == '-':
+        lines = sys.stdin.readlines()
+    else:
+        with open(args.file) as f:
+            lines = f.readlines()
+
+    expansions = parse_profile_lines(lines)
+
+    if not expansions:
+        print("No [PROFILE] data found in input.", file=sys.stderr)
+        print("Make sure to compile with SANELY_PROFILE=true", file=sys.stderr)
+        sys.exit(1)
+
+    agg = aggregate(expansions)
+
+    if args.json:
+        output_json(expansions, agg)
+    else:
+        print_report(expansions, agg, top_n=args.top, sort_by=args.sort, kind_filter=args.kind)
+
+
+if __name__ == '__main__':
+    main()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.0] - 2026-03-05
+
+### Added
+- **Compile-time macro profiling** — enable with `SANELY_PROFILE=true` to get per-expansion timing breakdown. Shows time spent in implicit search (`summonIgnoring`), mirror summoning, AST derivation, sub-trait detection, and cache hits. Includes a global summary across all expansions. Zero cost when disabled.
+- **Profiling analysis skill** — `.claude/skills/sanely-profile/` with a Python script (`scripts/analyze_profile.py`) that aggregates profile data, ranks slowest types, and generates actionable optimization insights.
+
 ## [0.6.1] - 2026-03-05
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Supports hierarchical sealed traits with diamond inheritance.
 
 ```diff
 - mvn"io.circe::circe-generic:0.14.x"
-+ mvn"io.github.nguyenyou::circe-sanely-auto:0.6.1"
++ mvn"io.github.nguyenyou::circe-sanely-auto:0.7.0"
 ```
 
 ### Step 2: Update imports

--- a/sanely/package.mill
+++ b/sanely/package.mill
@@ -16,7 +16,7 @@ object `package` extends mill.Module {
   trait SharedModule extends PlatformScalaModule with SonatypeCentralPublishModule {
     def artifactName = "circe-sanely-auto"
     def scalaVersion = build.scala3Version
-    def publishVersion = "0.6.1"
+    def publishVersion = "0.7.0"
 
     def pomSettings = PomSettings(
       description = "Drop-in replacement for circe's auto-derivation using sanely-automatic Scala 3 macros",

--- a/sanely/src/sanely/MacroTimer.scala
+++ b/sanely/src/sanely/MacroTimer.scala
@@ -1,0 +1,77 @@
+package sanely
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
+import scala.jdk.CollectionConverters.*
+
+/** Compile-time profiling utility for macro expansion.
+  * Enable with environment variable: SANELY_PROFILE=true
+  * Prints per-expansion timing and a global summary at JVM shutdown.
+  */
+private[sanely] object MacroTimer:
+  val enabled: Boolean = System.getenv("SANELY_PROFILE") == "true"
+
+  private val globalTimings = new ConcurrentHashMap[String, AtomicLong]()
+  private val globalCounts = new ConcurrentHashMap[String, AtomicLong]()
+  private val totalExpansions = new AtomicInteger(0)
+  private val hookRegistered = new AtomicBoolean(false)
+
+  private def ensureShutdownHook(): Unit =
+    if enabled && hookRegistered.compareAndSet(false, true) then
+      Runtime.getRuntime.addShutdownHook(new Thread(() => printSummary(), "sanely-profile"))
+
+  def create(typeName: String, kind: String): MacroTimer =
+    ensureShutdownHook()
+    new MacroTimer(typeName, kind)
+
+  private[sanely] def addGlobal(category: String, nanos: Long, count: Int): Unit =
+    globalTimings.computeIfAbsent(category, _ => new AtomicLong(0)).addAndGet(nanos)
+    globalCounts.computeIfAbsent(category, _ => new AtomicLong(0)).addAndGet(count)
+
+  private def printSummary(): Unit =
+    if !enabled then return
+    val n = totalExpansions.get
+    System.err.println()
+    System.err.println(s"[PROFILE] ══════════════════════════════════════════════════════")
+    System.err.println(s"[PROFILE] SUMMARY ($n macro expansions)")
+    System.err.println(s"[PROFILE] ──────────────────────────────────────────────────────")
+    val sorted = globalTimings.asScala.toList.sortBy(_._1)
+    val grouped = sorted.groupBy(_._1.split("\\.").head).toList.sortBy(_._1)
+    for (group, entries) <- grouped do
+      System.err.println(s"[PROFILE]")
+      for (cat, nanos) <- entries.sortBy(-_._2.get) do
+        val count = globalCounts.getOrDefault(cat, new AtomicLong(0)).get
+        val ms = nanos.get / 1e6
+        val avg = if count > 0 then ms / count else 0.0
+        System.err.println(f"[PROFILE]   $cat%-40s ${ms}%8.1fms  ${count}%5d calls  avg ${avg}%.2fms")
+    System.err.println(s"[PROFILE] ══════════════════════════════════════════════════════")
+
+private[sanely] class MacroTimer(typeName: String, kind: String):
+  private val categories = scala.collection.mutable.LinkedHashMap.empty[String, (Long, Int)]
+  private val startTime = if MacroTimer.enabled then System.nanoTime() else 0L
+
+  def time[T](category: String)(body: => T): T =
+    if !MacroTimer.enabled then return body
+    val start = System.nanoTime()
+    val result = body
+    val elapsed = System.nanoTime() - start
+    val (prev, count) = categories.getOrElse(category, (0L, 0))
+    categories(category) = (prev + elapsed, count + 1)
+    result
+
+  def count(category: String): Unit =
+    if !MacroTimer.enabled then return
+    val (prev, cnt) = categories.getOrElse(category, (0L, 0))
+    categories(category) = (prev, cnt + 1)
+
+  def report(): Unit =
+    if !MacroTimer.enabled then return
+    MacroTimer.totalExpansions.incrementAndGet()
+    val total = System.nanoTime() - startTime
+    MacroTimer.addGlobal(s"$kind.total", total, 1)
+    for (cat, (ns, cnt)) <- categories do
+      MacroTimer.addGlobal(s"$kind.$cat", ns, cnt)
+    val parts = categories.map { case (cat, (ns, cnt)) =>
+      f"$cat=${ns / 1e6}%.1fms(${cnt}x)"
+    }.mkString(" ")
+    System.err.println(f"[PROFILE] $kind[${typeName}]: total=${total / 1e6}%.1fms $parts")

--- a/sanely/src/sanely/SanelyConfiguredDecoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredDecoder.scala
@@ -14,12 +14,15 @@ object SanelyConfiguredDecoder:
 
   private def deriveMacro[A: Type](conf: Expr[Configuration], mirror: Expr[Mirror.Of[A]])(using Quotes): Expr[Decoder[A]] =
     val helper = new ConfiguredDecoderDerivation[A](conf)
-    helper.derive(mirror)
+    val result = helper.derive(mirror)
+    helper.timer.report()
+    result
 
   private class ConfiguredDecoderDerivation[A: Type](conf: Expr[Configuration])(using val quotes: Quotes):
     import quotes.reflect.*
 
     val selfType: TypeRepr = TypeRepr.of[A]
+    val timer: MacroTimer = MacroTimer.create(Type.show[A], "CfgDecoder")
     private val exprCache = mutable.Map.empty[String, Expr[?]]
 
     def derive(mirror: Expr[Mirror.Of[A]]): Expr[Decoder[A]] =
@@ -109,10 +112,12 @@ object SanelyConfiguredDecoder:
       // Only flatten sub-traits when no user-provided decoder exists
       val ignoreSymbols = cachedIgnoreSymbols
       val casesWithSubTrait = cases.map { case (label, tpe, dec) =>
-        val isSub = tpe match
-          case '[t] =>
-            Expr.summon[Mirror.SumOf[t]].isDefined &&
-            Expr.summonIgnoring[Decoder[t]](ignoreSymbols*).isEmpty
+        val isSub = timer.time("subTraitDetect") {
+          tpe match
+            case '[t] =>
+              Expr.summon[Mirror.SumOf[t]].isDefined &&
+              Expr.summonIgnoring[Decoder[t]](ignoreSymbols*).isEmpty
+        }
         (label, tpe, dec, isSub)
       }
 
@@ -215,20 +220,24 @@ object SanelyConfiguredDecoder:
       // Safe path: no recursion risk — check cache first
       val cacheKey = tpe.dealias.show
       exprCache.get(cacheKey) match
-        case Some(cached) => return cached.asInstanceOf[Expr[Decoder[T]]]
+        case Some(cached) =>
+          timer.count("cacheHit")
+          return cached.asInstanceOf[Expr[Decoder[T]]]
         case None => ()
 
       val resolved: Expr[Decoder[T]] =
-        Expr.summonIgnoring[Decoder[T]](cachedIgnoreSymbols*) match
+        timer.time("summonIgnoring")(Expr.summonIgnoring[Decoder[T]](cachedIgnoreSymbols*)) match
           case Some(dec) => dec
           case None =>
-            Expr.summon[Mirror.Of[T]] match
+            timer.time("summonMirror")(Expr.summon[Mirror.Of[T]]) match
               case Some(mirrorExpr) =>
-                mirrorExpr match
-                  case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                    deriveProduct[T, types, labels](m, selfRef)
-                  case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                    deriveSum[T, types, labels](m, selfRef)
+                timer.time("derive") {
+                  mirrorExpr match
+                    case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                      deriveProduct[T, types, labels](m, selfRef)
+                    case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                      deriveSum[T, types, labels](m, selfRef)
+                }
               case None =>
                 report.errorAndAbort(s"Cannot derive Decoder for ${Type.show[T]}: no implicit Decoder and no Mirror available")
       exprCache(cacheKey) = resolved

--- a/sanely/src/sanely/SanelyConfiguredEncoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredEncoder.scala
@@ -14,12 +14,15 @@ object SanelyConfiguredEncoder:
 
   private def deriveMacro[A: Type](conf: Expr[Configuration], mirror: Expr[Mirror.Of[A]])(using Quotes): Expr[Encoder.AsObject[A]] =
     val helper = new ConfiguredEncoderDerivation[A](conf)
-    helper.derive(mirror)
+    val result = helper.derive(mirror)
+    helper.timer.report()
+    result
 
   private class ConfiguredEncoderDerivation[A: Type](conf: Expr[Configuration])(using val quotes: Quotes):
     import quotes.reflect.*
 
     val selfType: TypeRepr = TypeRepr.of[A]
+    val timer: MacroTimer = MacroTimer.create(Type.show[A], "CfgEncoder")
     private val exprCache = mutable.Map.empty[String, Expr[?]]
 
     def derive(mirror: Expr[Mirror.Of[A]]): Expr[Encoder.AsObject[A]] =
@@ -67,10 +70,12 @@ object SanelyConfiguredEncoder:
       // Only flatten sub-traits when no user-provided encoder exists
       val ignoreSymbols = cachedIgnoreSymbols
       val casesWithSubTrait = cases.map { case (label, tpe, enc) =>
-        val isSub = tpe match
-          case '[t] =>
-            Expr.summon[Mirror.SumOf[t]].isDefined &&
-            Expr.summonIgnoring[Encoder[t]](ignoreSymbols*).isEmpty
+        val isSub = timer.time("subTraitDetect") {
+          tpe match
+            case '[t] =>
+              Expr.summon[Mirror.SumOf[t]].isDefined &&
+              Expr.summonIgnoring[Encoder[t]](ignoreSymbols*).isEmpty
+        }
         (label, tpe, enc, isSub)
       }
 
@@ -132,20 +137,24 @@ object SanelyConfiguredEncoder:
       // Safe path: no recursion risk — check cache first
       val cacheKey = tpe.dealias.show
       exprCache.get(cacheKey) match
-        case Some(cached) => return cached.asInstanceOf[Expr[Encoder[T]]]
+        case Some(cached) =>
+          timer.count("cacheHit")
+          return cached.asInstanceOf[Expr[Encoder[T]]]
         case None => ()
 
       val resolved: Expr[Encoder[T]] =
-        Expr.summonIgnoring[Encoder[T]](cachedIgnoreSymbols*) match
+        timer.time("summonIgnoring")(Expr.summonIgnoring[Encoder[T]](cachedIgnoreSymbols*)) match
           case Some(enc) => enc
           case None =>
-            Expr.summon[Mirror.Of[T]] match
+            timer.time("summonMirror")(Expr.summon[Mirror.Of[T]]) match
               case Some(mirrorExpr) =>
-                mirrorExpr match
-                  case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                    deriveProduct[T, types, labels](m, selfRef)
-                  case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                    deriveSum[T, types, labels](m, selfRef)
+                timer.time("derive") {
+                  mirrorExpr match
+                    case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                      deriveProduct[T, types, labels](m, selfRef)
+                    case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                      deriveSum[T, types, labels](m, selfRef)
+                }
               case None =>
                 report.errorAndAbort(s"Cannot derive Encoder for ${Type.show[T]}: no implicit Encoder and no Mirror available")
       exprCache(cacheKey) = resolved

--- a/sanely/src/sanely/SanelyDecoder.scala
+++ b/sanely/src/sanely/SanelyDecoder.scala
@@ -13,12 +13,15 @@ object SanelyDecoder:
 
   private def deriveMacro[A: Type](mirror: Expr[Mirror.Of[A]])(using Quotes): Expr[Decoder[A]] =
     val helper = new DecoderDerivation[A]
-    helper.derive(mirror)
+    val result = helper.derive(mirror)
+    helper.timer.report()
+    result
 
   private class DecoderDerivation[A: Type](using val quotes: Quotes):
     import quotes.reflect.*
 
     val selfType: TypeRepr = TypeRepr.of[A]
+    val timer: MacroTimer = MacroTimer.create(Type.show[A], "Decoder")
     private val exprCache = mutable.Map.empty[String, Expr[?]]
 
     def derive(mirror: Expr[Mirror.Of[A]]): Expr[Decoder[A]] =
@@ -76,10 +79,12 @@ object SanelyDecoder:
       // Only flatten when no user-provided decoder exists — a custom Decoder
       // may not handle the sub-dispatching that flattening requires.
       val casesWithSubTrait = cases.map { case (label, tpe, dec) =>
-        val isSub = tpe match
-          case '[t] =>
-            Expr.summon[Mirror.SumOf[t]].isDefined &&
-            Expr.summonIgnoring[Decoder[t]](cachedIgnoreSymbols*).isEmpty
+        val isSub = timer.time("subTraitDetect") {
+          tpe match
+            case '[t] =>
+              Expr.summon[Mirror.SumOf[t]].isDefined &&
+              Expr.summonIgnoring[Decoder[t]](cachedIgnoreSymbols*).isEmpty
+        }
         (label, tpe, dec, isSub)
       }
 
@@ -149,20 +154,24 @@ object SanelyDecoder:
       // Safe path: no recursion risk — check cache first
       val cacheKey = tpe.dealias.show
       exprCache.get(cacheKey) match
-        case Some(cached) => return cached.asInstanceOf[Expr[Decoder[T]]]
+        case Some(cached) =>
+          timer.count("cacheHit")
+          return cached.asInstanceOf[Expr[Decoder[T]]]
         case None => ()
 
       val resolved: Expr[Decoder[T]] =
-        Expr.summonIgnoring[Decoder[T]](cachedIgnoreSymbols*) match
+        timer.time("summonIgnoring")(Expr.summonIgnoring[Decoder[T]](cachedIgnoreSymbols*)) match
           case Some(dec) => dec
           case None =>
-            Expr.summon[Mirror.Of[T]] match
+            timer.time("summonMirror")(Expr.summon[Mirror.Of[T]]) match
               case Some(mirrorExpr) =>
-                mirrorExpr match
-                  case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                    deriveProduct[T, types, labels](m, selfRef)
-                  case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                    deriveSum[T, types, labels](m, selfRef)
+                timer.time("derive") {
+                  mirrorExpr match
+                    case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                      deriveProduct[T, types, labels](m, selfRef)
+                    case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                      deriveSum[T, types, labels](m, selfRef)
+                }
               case None =>
                 report.errorAndAbort(s"Cannot derive Decoder for ${Type.show[T]}: no implicit Decoder and no Mirror available")
       exprCache(cacheKey) = resolved

--- a/sanely/src/sanely/SanelyEncoder.scala
+++ b/sanely/src/sanely/SanelyEncoder.scala
@@ -13,12 +13,15 @@ object SanelyEncoder:
 
   private def deriveMacro[A: Type](mirror: Expr[Mirror.Of[A]])(using Quotes): Expr[Encoder.AsObject[A]] =
     val helper = new EncoderDerivation[A]
-    helper.derive(mirror)
+    val result = helper.derive(mirror)
+    helper.timer.report()
+    result
 
   private class EncoderDerivation[A: Type](using val quotes: Quotes):
     import quotes.reflect.*
 
     val selfType: TypeRepr = TypeRepr.of[A]
+    val timer: MacroTimer = MacroTimer.create(Type.show[A], "Encoder")
     private val exprCache = mutable.Map.empty[String, Expr[?]]
 
     def derive(mirror: Expr[Mirror.Of[A]]): Expr[Encoder.AsObject[A]] =
@@ -83,10 +86,12 @@ object SanelyEncoder:
       // Only flatten when no user-provided encoder exists — a custom Encoder
       // (e.g. string-based) can't be cast to AsObject for flattening.
       val casesWithSubTrait = cases.map { case (label, tpe, enc) =>
-        val isSub = tpe match
-          case '[t] =>
-            Expr.summon[Mirror.SumOf[t]].isDefined &&
-            Expr.summonIgnoring[Encoder[t]](cachedIgnoreSymbols*).isEmpty
+        val isSub = timer.time("subTraitDetect") {
+          tpe match
+            case '[t] =>
+              Expr.summon[Mirror.SumOf[t]].isDefined &&
+              Expr.summonIgnoring[Encoder[t]](cachedIgnoreSymbols*).isEmpty
+        }
         (label, tpe, enc, isSub)
       }
 
@@ -136,20 +141,24 @@ object SanelyEncoder:
       // Safe path: no recursion risk — check cache first
       val cacheKey = tpe.dealias.show
       exprCache.get(cacheKey) match
-        case Some(cached) => return cached.asInstanceOf[Expr[Encoder[T]]]
+        case Some(cached) =>
+          timer.count("cacheHit")
+          return cached.asInstanceOf[Expr[Encoder[T]]]
         case None => ()
 
       val resolved: Expr[Encoder[T]] =
-        Expr.summonIgnoring[Encoder[T]](cachedIgnoreSymbols*) match
+        timer.time("summonIgnoring")(Expr.summonIgnoring[Encoder[T]](cachedIgnoreSymbols*)) match
           case Some(enc) => enc
           case None =>
-            Expr.summon[Mirror.Of[T]] match
+            timer.time("summonMirror")(Expr.summon[Mirror.Of[T]]) match
               case Some(mirrorExpr) =>
-                mirrorExpr match
-                  case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                    deriveProduct[T, types, labels](m, selfRef)
-                  case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-                    deriveSum[T, types, labels](m, selfRef)
+                timer.time("derive") {
+                  mirrorExpr match
+                    case '{ $m: Mirror.ProductOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                      deriveProduct[T, types, labels](m, selfRef)
+                    case '{ $m: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+                      deriveSum[T, types, labels](m, selfRef)
+                }
               case None =>
                 report.errorAndAbort(s"Cannot derive Encoder for ${Type.show[T]}: no implicit Encoder and no Mirror available")
       exprCache(cacheKey) = resolved


### PR DESCRIPTION
## Summary
- Add `MacroTimer` utility gated by `SANELY_PROFILE=true` — instruments all 4 macro derivation files to track time in `summonIgnoring`, `summonMirror`, `derive`, `subTraitDetect`, and cache hits. Zero cost when disabled.
- Add Python analysis script (`.claude/skills/sanely-profile/`) that aggregates profile data, ranks slowest types, and generates optimization insights.
- Bump version to 0.7.0.

### Baseline profile (308 expansions, auto benchmark)
| Category | Time | % | Calls |
|---|---|---|---|
| summonIgnoring | 1256ms | 51.3% | 1366 |
| derive | 716ms | 29.2% | 586 |
| summonMirror | 80ms | 3.3% | 586 |
| subTraitDetect | 43ms | 1.8% | 336 |
| cacheHit | — | — | 1714 |

## Test plan
- [x] `./mill sanely.jvm.test` — 59 tests pass
- [x] `./mill compat.test` — 192 tests pass
- [x] `SANELY_PROFILE=true ./mill --no-server benchmark.sanely.compile` — profiling output verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)