### PR TITLE
feat: add profiling to configured macros + README profiling section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ Mill 1.1.2. Run from repo root:
 ./mill demo.run                 # run demo
 ./mill benchmark.sanely.compile # benchmark: our library
 ./mill benchmark.generic.compile # benchmark: circe-generic
+./mill benchmark-configured.sanely.compile   # configured benchmark: our library
+./mill benchmark-configured.generic.compile  # configured benchmark: circe-generic
 bash bench.sh 5                 # timed compile comparison
 ```
 
@@ -37,6 +39,7 @@ bash bench.sh 5                 # timed compile comparison
 | `compat/` | Circe compatibility tests (munit + discipline). Uses circe's own `CodecTests` |
 | `demo/` | Runnable examples |
 | `benchmark/` | Compile-time benchmark. Two sub-modules sharing `benchmark/shared/src/` |
+| `benchmark-configured/` | Configured derivation benchmark. Three sub-modules: `sanely`, `generic`, `generic-compat` sharing `benchmark-configured/shared/src/` |
 
 ## Source Files
 
@@ -122,6 +125,7 @@ Update `CHANGELOG.md` with new features, bug fixes, and breaking changes. Use `g
 
 ## Known Issues
 
+- Configured macro profiling: `topDerive` is a **container category** that includes `summonIgnoring`, `derive`, `summonMirror`, `subTraitDetect`, `resolveDefaults`. Category percentages sum > 100% due to nesting.
 - `Long.MaxValue`/`Long.MinValue` lose precision on Scala.js due to JSON number representation. Skipped via `Platform.isJS` (platform-specific sources in `test/src-jvm/` and `test/src-js/`).
 - `inline def derived` inside utest `test {}` blocks may not expand for generic types. Workaround: derive in a helper object outside the test block.
 
@@ -137,5 +141,7 @@ Test sources to match:
 ## Mill Notes
 
 - `benchmark/package.mill`: two modules share `benchmark/shared/src/` via `override def moduleDir`
+- `benchmark-configured/package.mill`: three modules (`sanely`, `generic`, `generic-compat`) share `benchmark-configured/shared/src/`
+- Module names with hyphens: use `benchmark-configured.sanely`, NOT `benchmark.configured`
 - Mill 1.x: override `moduleDir` (public API), not `millSourcePath` (internal)
 - `sanely/package.mill`: cross-compile via `PlatformScalaModule` with `jvm` and `js` sub-modules

--- a/README.md
+++ b/README.md
@@ -192,6 +192,45 @@ The speedup only applies to **auto derivation**. With `import io.circe.generic.a
 
 In short: sanely's advantage is specifically in eliminating implicit search overhead, which only affects auto derivation.
 
+### Macro profiling
+
+Built-in compile-time profiling is available via the `SANELY_PROFILE=true` environment variable. When enabled, each macro expansion prints timing data to stderr with zero cost when disabled.
+
+```bash
+# Profile auto derivation (~300 types)
+SANELY_PROFILE=true ./mill --no-server clean benchmark.sanely && \
+SANELY_PROFILE=true ./mill --no-server benchmark.sanely.compile 2>&1 | tee /tmp/profile.txt
+
+# Profile configured derivation (~230 types)
+SANELY_PROFILE=true ./mill --no-server clean benchmark-configured.sanely && \
+SANELY_PROFILE=true ./mill --no-server benchmark-configured.sanely.compile 2>&1 | tee /tmp/profile.txt
+```
+
+**Auto derivation profile** (308 expansions, ~2.4s total macro time):
+
+| Category | Time | % | Calls | Avg |
+|---|---|---|---|---|
+| `summonIgnoring` | 1217ms | 50.0% | 1366 | 0.89ms |
+| `derive` | 683ms | 28.1% | 586 | 1.17ms |
+| `summonMirror` | 81ms | 3.3% | 586 | 0.14ms |
+| `subTraitDetect` | 42ms | 1.7% | 336 | 0.13ms |
+| overhead | 410ms | 16.8% | — | — |
+| cache hits | — | — | 1714 (75%) | — |
+
+**Configured derivation profile** (460 expansions, ~1.5s total macro time):
+
+| Category | Time | % | Calls | Avg |
+|---|---|---|---|---|
+| `topDerive` | 1283ms | 86.6%* | 460 | 2.79ms |
+| `summonIgnoring` | 522ms | 35.2% | 984 | 0.53ms |
+| `subTraitDetect` | 30ms | 2.0% | 138 | 0.21ms |
+| `resolveDefaults` | 11ms | 0.7% | 214 | 0.05ms |
+| cache hits | — | — | 654 | — |
+
+*`topDerive` is a container category that includes `summonIgnoring`, `derive`, `summonMirror`, `subTraitDetect`, and `resolveDefaults`.
+
+**Key insight**: `summonIgnoring` (the compiler's implicit search via `Expr.summonIgnoring`) dominates auto derivation at 50%. For configured derivation, AST construction (building encode/decode expression chains) accounts for ~59% of `topDerive` time, with `summonIgnoring` at ~41%. The intra-expansion cache achieves a 75% hit rate, avoiding redundant derivations for repeated types within a single macro call.
+
 ## Building
 
 Requires [Mill](https://mill-build.org/) 1.1.2+.
@@ -213,7 +252,7 @@ This entire library — every macro, every test, every line of build config, and
 
 - [ ] **Emit `lazy val` for derived codecs in generated code** — when a derived `Encoder[Foo]` is used by multiple fields in the same product, the full AST tree is currently duplicated at each splice site. Emit a single `lazy val encoder_Foo = ...` and reference it by name to deduplicate.
 - [ ] **Accumulating decoder** (`decodeAccumulating`) — generate both fail-fast and accumulating decode paths, matching circe-generic's behavior for collecting all errors instead of stopping at the first.
-- [ ] **Profile macro expansion** — add `System.nanoTime` measurements around key phases (Mirror summoning, `Expr.summonIgnoring`, recursive derivation) to identify actual bottlenecks and guide further optimization.
+- [x] **Profile macro expansion** — compile-time profiling via `SANELY_PROFILE=true` tracks `summonIgnoring`, `summonMirror`, `derive`, `subTraitDetect`, `resolveDefaults`, and cache hits per expansion.
 - [ ] **Derive key encoders/decoders inline for built-in types** — generate `key.toString` directly for `Int`, `Long`, etc. instead of summoning `KeyEncoder[K]` via implicit search.
 
 ## Contributing

--- a/sanely/src/sanely/SanelyConfiguredDecoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredDecoder.scala
@@ -31,9 +31,9 @@ object SanelyConfiguredDecoder:
           val selfRef: Expr[Decoder[A]] = '{ _selfDec }
           mirror match
             case '{ $m: Mirror.ProductOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-              deriveProduct[A, types, labels](m, selfRef)
+              timer.time("topDerive") { deriveProduct[A, types, labels](m, selfRef) }
             case '{ $m: Mirror.SumOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-              deriveSum[A, types, labels](m, selfRef)
+              timer.time("topDerive") { deriveSum[A, types, labels](m, selfRef) }
         }
         _selfDec
       }
@@ -43,7 +43,7 @@ object SanelyConfiguredDecoder:
       selfRef: Expr[Decoder[A]]
     ): Expr[Decoder[P]] =
       val fields = resolveFields[Types, Labels](selfRef)
-      val defaults = resolveDefaults[P]
+      val defaults = timer.time("resolveDefaults") { resolveDefaults[P] }
 
       def buildDecodeChain(c: Expr[HCursor], fieldNames: Expr[Array[String]], remaining: List[(String, Type[?], Expr[Decoder[?]], Option[Expr[Any]])], fieldIdx: Int, acc: List[Expr[Any]]): Expr[Decoder.Result[P]] =
         remaining match

--- a/sanely/src/sanely/SanelyConfiguredEncoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredEncoder.scala
@@ -31,9 +31,9 @@ object SanelyConfiguredEncoder:
           val selfRef: Expr[Encoder.AsObject[A]] = '{ _selfEnc }
           mirror match
             case '{ $m: Mirror.ProductOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-              deriveProduct[A, types, labels](m, selfRef)
+              timer.time("topDerive") { deriveProduct[A, types, labels](m, selfRef) }
             case '{ $m: Mirror.SumOf[A] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
-              deriveSum[A, types, labels](m, selfRef)
+              timer.time("topDerive") { deriveSum[A, types, labels](m, selfRef) }
         }
         _selfEnc
       }


### PR DESCRIPTION
## Summary

- Add `topDerive` and `resolveDefaults` timing to `SanelyConfiguredEncoder` and `SanelyConfiguredDecoder`, closing the 62% "overhead" visibility gap in configured derivation profiling
- Add macro profiling section to README with auto and configured derivation breakdowns
- Check off profiling roadmap item
- Update CLAUDE.md with `benchmark-configured` module docs

## Profile results (configured, 460 expansions)

| Category | Time | % | Calls |
|---|---|---|---|
| `topDerive` | 1283ms | 86.6%* | 460 |
| `summonIgnoring` | 522ms | 35.2% | 984 |
| `subTraitDetect` | 30ms | 2.0% | 138 |
| `resolveDefaults` | 11ms | 0.7% | 214 |

*container category — percentages sum >100% due to nesting

## Test plan

- [x] `./mill sanely.jvm.compile` — compiles
- [x] `./mill sanely.jvm.test` — 59/59 tests pass
- [x] Profiled compilation produces expected output with new categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)