### PR TITLE
chore: enable -Werror on all modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ This entire library — every macro, every test, every line of build config, and
 - [x] **Ignore `Encoder.derived`/`Decoder.derived` from circe-core** — add circe-core's own `derived` methods to `cachedIgnoreSymbols` so they don't interfere with `Expr.summonIgnoring` when circe-core is on the classpath.
 - [ ] **Improved error messages** — when derivation fails, report what was tried and why each approach failed (builtin miss, summonIgnoring miss, no Mirror) instead of a single generic message.
 - [ ] **Derive key encoders/decoders inline for built-in types** — generate `key.toString` directly for `Int`, `Long`, etc. instead of summoning `KeyEncoder[K]` via implicit search.
-- [ ] **Enable `-Xfatal-warnings` in CI** — ensure macro-generated code produces zero compiler warnings so users with strict linting never need `@nowarn` annotations for code they didn't write.
+- [x] **Enable `-Werror` in CI** — all modules compile with `-Werror` (Scala 3's replacement for `-Xfatal-warnings`), ensuring macro-generated code produces zero compiler warnings. Users with strict linting never need `@nowarn` annotations for code they didn't write.
 - [ ] **Test coverage gaps** — add tests for: generic context derivation (type params not yet known), semiauto `derived` inside companion not causing infinite recursion, Tuple/Either fields.
 
 ## Contributing

--- a/build.mill
+++ b/build.mill
@@ -21,6 +21,7 @@ object compat extends ScalaModule {
   def scalacOptions = Task {
     super.scalacOptions() ++ Seq(
       "-Xmax-inlines", "64",
+      "-Werror",
       "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
     )
   }

--- a/sanely/package.mill
+++ b/sanely/package.mill
@@ -34,7 +34,7 @@ object `package` extends mill.Module {
     }
 
     def scalacOptions = Task {
-      super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
+      super.scalacOptions() ++ Seq("-Xmax-inlines", "64", "-Werror")
     }
 
     trait SharedTests extends ScalaTests with TestModule.Utest {
@@ -46,7 +46,7 @@ object `package` extends mill.Module {
         )
       }
       def scalacOptions = Task {
-        super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
+        super.scalacOptions() ++ Seq("-Xmax-inlines", "64", "-Werror")
       }
     }
   }

--- a/sanely/test/src-js/sanely/Platform.scala
+++ b/sanely/test/src-js/sanely/Platform.scala
@@ -1,4 +1,4 @@
 package sanely
 
 object Platform:
-  inline val isJS = true
+  val isJS = true

--- a/sanely/test/src-jvm/sanely/Platform.scala
+++ b/sanely/test/src-jvm/sanely/Platform.scala
@@ -1,4 +1,4 @@
 package sanely
 
 object Platform:
-  inline val isJS = false
+  val isJS = false


### PR DESCRIPTION
## Summary
- Enable `-Werror` (Scala 3's replacement for `-Xfatal-warnings`) on all modules: `sanely` (JVM + JS), `sanely/test`, and `compat`
- Fix `inline val isJS` → `val isJS` to avoid dead code warnings on Scala.js platform
- Mark `-Werror` roadmap item as complete in README

## Test plan
- [x] `./mill sanely.jvm.test` — 116 tests pass
- [x] `./mill sanely.js.test` — 116 tests pass
- [x] `./mill compat.test` — 160 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)