### PR TITLE
feat: full circe compat test coverage + hierarchical enum fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.9.0] - 2026-03-05
+
+### Fixed
+- **Hierarchical enum codec with diamond inheritance** — `SanelyEnumCodec` now correctly handles sealed trait hierarchies where a singleton extends multiple intermediate traits (diamond structure). Previously, `mirror.ordinal()` returned the ordinal of the intermediate trait rather than the leaf, causing ordinal collisions (e.g., both `B` and `D` mapping to ordinal 1). Now uses reference equality (`eq`) on singleton instances with deduplication, eliminating the collision.
+
+### Added
+- **Configured derivation compat tests** (`ConfiguredDerivesSuite`) — 25 tests ported from circe's `ConfiguredDerivesSuite` covering: member name transforms (snake_case, SCREAMING_SNAKE_CASE, kebab-case, PascalCase), default values (Option with/without defaults, null handling, generic classes), discriminator field, constructor name transforms, combined configuration options, strict decoding (sum types, product types, accumulating errors), multi-level hierarchies (2-level, 3-level with field name conflicts), and recursive discriminated types.
+- **Configured enum compat tests** (`ConfiguredEnumDerivesSuites`) — 11 tests ported from circe's `ConfiguredEnumDerivesSuites` covering: codec property tests, decode failure for unknown cases, constructor name transforms, and hierarchical enums with diamond inheritance.
+- **Expanded auto derivation compat tests** — added `RecursiveAdtExample`, `RecursiveWithOptionExample`, `ADTWithSubTraitExample`, `Outer` (nested with Option), `LongClass` (33 fields stress test), "nested sums not encoded redundantly" test, and "derived encoder respects existing instances" test.
+- **Expanded semiauto derivation compat tests** — added `Adt1` (class+object), `Adt2` (all objects), `Adt3` (empty class+object), `Adt4` (nested sub-traits), and "decoder ignores superfluous keys" test.
+- Compat test count: 160 → 253 (+93 tests)
+
 ## [0.8.0] - 2026-03-05
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Supports hierarchical sealed traits with diamond inheritance.
 
 ```diff
 - mvn"io.circe::circe-generic:0.14.x"
-+ mvn"io.github.nguyenyou::circe-sanely-auto:0.8.0"
++ mvn"io.github.nguyenyou::circe-sanely-auto:0.9.0"
 ```
 
 ### Step 2: Update imports

--- a/compat/test/src/io/circe/generic/AutoDerivedSuite.scala
+++ b/compat/test/src/io/circe/generic/AutoDerivedSuite.scala
@@ -2,11 +2,12 @@ package io.circe.generic
 
 import cats.kernel.Eq
 import cats.syntax.eq._
-import io.circe.{ Decoder, Encoder, Json }
+import io.circe.{ Codec, Decoder, Encoder, Json }
 import io.circe.generic.auto._
 import io.circe.testing.CodecTests
 import io.circe.tests.CirceMunitSuite
 import io.circe.tests.examples._
+import io.circe.syntax._
 import org.scalacheck.{ Arbitrary, Gen, Prop }
 
 object AutoDerivedSuite {
@@ -36,6 +37,100 @@ object AutoDerivedSuite {
         } yield OuterCaseClassExample(a, i)
       )
   }
+
+  // Recursive ADT — sealed trait hierarchy
+  sealed trait RecursiveAdtExample
+  case class BaseAdtExample(a: String) extends RecursiveAdtExample
+  case class NestedAdtExample(r: RecursiveAdtExample) extends RecursiveAdtExample
+
+  object RecursiveAdtExample {
+    implicit val eqRecursiveAdtExample: Eq[RecursiveAdtExample] = Eq.fromUniversalEquals
+
+    private def atDepth(depth: Int): Gen[RecursiveAdtExample] = if (depth < 3)
+      Gen.oneOf(
+        Arbitrary.arbitrary[String].map(BaseAdtExample(_)),
+        atDepth(depth + 1).map(NestedAdtExample(_))
+      )
+    else Arbitrary.arbitrary[String].map(BaseAdtExample(_))
+
+    implicit val arbitraryRecursiveAdtExample: Arbitrary[RecursiveAdtExample] =
+      Arbitrary(atDepth(0))
+  }
+
+  // Recursive with Option
+  case class RecursiveWithOptionExample(o: Option[RecursiveWithOptionExample])
+
+  object RecursiveWithOptionExample {
+    implicit val eqRecursiveWithOptionExample: Eq[RecursiveWithOptionExample] =
+      Eq.fromUniversalEquals
+
+    private def atDepth(depth: Int): Gen[RecursiveWithOptionExample] = if (depth < 3)
+      Gen.oneOf(
+        Gen.const(RecursiveWithOptionExample(None)),
+        atDepth(depth + 1).map(Some(_)).map(RecursiveWithOptionExample(_))
+      )
+    else Gen.const(RecursiveWithOptionExample(None))
+
+    implicit val arbitraryRecursiveWithOptionExample: Arbitrary[RecursiveWithOptionExample] =
+      Arbitrary(atDepth(0))
+  }
+
+  // ADT with nested sub-trait
+  sealed trait ADTWithSubTraitExample
+  sealed trait SubTrait extends ADTWithSubTraitExample
+  case class TheClass(a: Int) extends SubTrait
+
+  object ADTWithSubTraitExample {
+    implicit val arbitrary: Arbitrary[ADTWithSubTraitExample] = Arbitrary(Arbitrary.arbitrary[Int].map(TheClass.apply))
+    implicit val eq: Eq[ADTWithSubTraitExample] = Eq.fromUniversalEquals
+  }
+
+  // Nested case class with Option (tests existing instances)
+  case class Inner[A](field: A)
+  case class Outer(a: Option[Inner[String]])
+  object Outer {
+    given Eq[Outer] = Eq.fromUniversalEquals
+    given Arbitrary[Outer] =
+      Arbitrary(Gen.option(Arbitrary.arbitrary[String].map(Inner.apply)).map(Outer.apply))
+  }
+
+  // Large case class (33 fields) — stress test
+  case class LongClass(
+    v1: String, v2: String, v3: String, v4: String, v5: String,
+    v6: String, v7: String, v8: String, v9: String, v10: String,
+    v11: String, v12: String, v13: String, v14: String, v15: String,
+    v16: String, v17: String, v18: String, v19: String, v20: String,
+    v21: String, v22: String, v23: String, v24: String, v25: String,
+    v26: String, v27: String, v28: String, v29: String, v30: String,
+    v31: String, v32: String, v33: String
+  )
+  object LongClass {
+    given Eq[LongClass] = Eq.fromUniversalEquals
+    given Arbitrary[LongClass] = Arbitrary {
+      for
+        s1 <- Arbitrary.arbitrary[String]; s2 <- Arbitrary.arbitrary[String]
+        s3 <- Arbitrary.arbitrary[String]; s4 <- Arbitrary.arbitrary[String]
+        s5 <- Arbitrary.arbitrary[String]; s6 <- Arbitrary.arbitrary[String]
+        s7 <- Arbitrary.arbitrary[String]; s8 <- Arbitrary.arbitrary[String]
+        s9 <- Arbitrary.arbitrary[String]; s10 <- Arbitrary.arbitrary[String]
+        s11 <- Arbitrary.arbitrary[String]; s12 <- Arbitrary.arbitrary[String]
+        s13 <- Arbitrary.arbitrary[String]; s14 <- Arbitrary.arbitrary[String]
+        s15 <- Arbitrary.arbitrary[String]; s16 <- Arbitrary.arbitrary[String]
+        s17 <- Arbitrary.arbitrary[String]; s18 <- Arbitrary.arbitrary[String]
+        s19 <- Arbitrary.arbitrary[String]; s20 <- Arbitrary.arbitrary[String]
+        s21 <- Arbitrary.arbitrary[String]; s22 <- Arbitrary.arbitrary[String]
+        s23 <- Arbitrary.arbitrary[String]; s24 <- Arbitrary.arbitrary[String]
+        s25 <- Arbitrary.arbitrary[String]; s26 <- Arbitrary.arbitrary[String]
+        s27 <- Arbitrary.arbitrary[String]; s28 <- Arbitrary.arbitrary[String]
+        s29 <- Arbitrary.arbitrary[String]; s30 <- Arbitrary.arbitrary[String]
+        s31 <- Arbitrary.arbitrary[String]; s32 <- Arbitrary.arbitrary[String]
+        s33 <- Arbitrary.arbitrary[String]
+      yield LongClass(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10,
+        s11, s12, s13, s14, s15, s16, s17, s18, s19, s20,
+        s21, s22, s23, s24, s25, s26, s27, s28, s29, s30,
+        s31, s32, s33)
+    }
+  }
 }
 
 class AutoDerivedSuite extends CirceMunitSuite {
@@ -48,6 +143,11 @@ class AutoDerivedSuite extends CirceMunitSuite {
   checkAll("Codec[Baz]", CodecTests[Baz].codec)
   checkAll("Codec[Foo]", CodecTests[Foo].codec)
   checkAll("Codec[OuterCaseClassExample]", CodecTests[OuterCaseClassExample].codec)
+  checkAll("Codec[RecursiveAdtExample]", CodecTests[RecursiveAdtExample].unserializableCodec)
+  checkAll("Codec[RecursiveWithOptionExample]", CodecTests[RecursiveWithOptionExample].unserializableCodec)
+  checkAll("Codec[ADTWithSubTraitExample]", CodecTests[ADTWithSubTraitExample].codec)
+  checkAll("Codec[Outer]", CodecTests[Outer].codec)
+  checkAll("Codec[LongClass]", CodecTests[LongClass].codec)
 
   property("A generically derived codec should not interfere with base instances") {
     Prop.forAll { (is: List[Int]) =>
@@ -71,5 +171,20 @@ class AutoDerivedSuite extends CirceMunitSuite {
 
       assert(Encoder[Foo].apply(Baz(xs): Foo) === json)
     }
+  }
+
+  test("Nested sums should not be encoded redundantly") {
+    val foo: ADTWithSubTraitExample = TheClass(0)
+    val expected = Json.obj("TheClass" -> Json.obj("a" -> 0.asJson))
+    assertEquals(foo.asJson, expected)
+  }
+
+  test("Derived Encoder respects existing instances") {
+    val some = Outer(Some(Inner("c")))
+    val none = Outer(None)
+    val expectedSome = Json.obj("a" -> Json.obj("field" -> "c".asJson))
+    val expectedNone = Json.obj("a" -> Json.Null)
+    assertEquals(some.asJson, expectedSome)
+    assertEquals(none.asJson, expectedNone)
   }
 }

--- a/compat/test/src/io/circe/generic/ConfiguredDerivesSuite.scala
+++ b/compat/test/src/io/circe/generic/ConfiguredDerivesSuite.scala
@@ -1,0 +1,473 @@
+package io.circe.generic
+
+import cats.kernel.Eq
+import cats.kernel.instances.all.*
+import cats.syntax.eq.*
+import cats.data.{NonEmptyList, Validated}
+import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json}
+import io.circe.CursorOp.DownField
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+import io.circe.testing.CodecTests
+import io.circe.tests.CirceMunitSuite
+import io.circe.syntax.*
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Prop.forAll
+
+object ConfiguredDerivesSuite:
+  // Hierarchy of 1 level
+  sealed trait GrandParent
+  sealed trait Parent1 extends GrandParent
+  case class Child1(a: Int, b: String) extends Parent1
+  object GrandParent:
+    given Eq[GrandParent] = Eq.fromUniversalEquals
+
+  // Hierarchy of 2+ levels
+  sealed trait GreatGrandParent
+  sealed trait GrandParent2 extends GreatGrandParent
+  case class Uncle(Child: Int) extends GrandParent2
+  sealed trait Parent2 extends GrandParent2
+  case class Child2(a: Int, b: String) extends Parent2
+  object GreatGrandParent:
+    given Eq[GreatGrandParent] = Eq.fromUniversalEquals
+
+  // Recursive discriminated type
+  sealed trait Tree
+  case class Branch(l: Tree, r: Tree) extends Tree
+  case object Leaf extends Tree
+  object Tree:
+    given Eq[Tree] = Eq.fromUniversalEquals
+
+  enum ConfigExampleBase:
+    case ConfigExampleFoo(thisIsAField: String, a: Int = 0, b: Double)
+    case ConfigExampleBar
+  object ConfigExampleBase:
+    given Eq[ConfigExampleBase] = Eq.fromUniversalEquals
+    given Eq[ConfigExampleBase.ConfigExampleFoo] = Eq.fromUniversalEquals
+
+    given genConfigExampleFoo: Gen[ConfigExampleBase.ConfigExampleFoo] = for {
+      thisIsAField <- Arbitrary.arbitrary[String]
+      a <- Arbitrary.arbitrary[Int]
+      b <- Arbitrary.arbitrary[Double]
+    } yield ConfigExampleBase.ConfigExampleFoo(thisIsAField, a, b)
+    given Arbitrary[ConfigExampleBase.ConfigExampleFoo] = Arbitrary(genConfigExampleFoo)
+    given Arbitrary[ConfigExampleBase] = Arbitrary(
+      Gen.oneOf(
+        genConfigExampleFoo,
+        Gen.const(ConfigExampleBase.ConfigExampleBar)
+      )
+    )
+
+class ConfiguredDerivesSuite extends CirceMunitSuite:
+  import ConfiguredDerivesSuite.{*, given}
+
+  {
+    given Configuration = Configuration.default
+    given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+    checkAll("Codec[ConfigExampleBase] (default configuration)", CodecTests[ConfigExampleBase].codec)
+  }
+
+  property("Configuration#transformMemberNames should support member name transformation using snake_case") {
+    forAll { (foo: ConfigExampleBase.ConfigExampleFoo) =>
+      given Configuration = Configuration.default.withSnakeCaseMemberNames
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+
+      val json = Json.obj(
+        "this_is_a_field" -> foo.thisIsAField.asJson,
+        "a" -> foo.a.asJson,
+        "b" -> foo.b.asJson
+      )
+      assert(summon[Encoder[ConfigExampleBase.ConfigExampleFoo]].apply(foo) === json)
+      assert(summon[Decoder[ConfigExampleBase.ConfigExampleFoo]].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property("Configuration#transformMemberNames should support member name transformation using SCREAMING_SNAKE_CASE") {
+    forAll { (foo: ConfigExampleBase.ConfigExampleFoo) =>
+      given Configuration = Configuration.default.withScreamingSnakeCaseMemberNames
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+
+      val json = Json.obj(
+        "THIS_IS_A_FIELD" -> foo.thisIsAField.asJson,
+        "A" -> foo.a.asJson,
+        "B" -> foo.b.asJson
+      )
+      assert(Encoder[ConfigExampleBase.ConfigExampleFoo].apply(foo) === json)
+      assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property("Configuration#transformMemberNames should support member name transformation using kebab-case") {
+    forAll { (foo: ConfigExampleBase.ConfigExampleFoo) =>
+      given Configuration = Configuration.default.withKebabCaseMemberNames
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+      val json = Json.obj(
+        "this-is-a-field" -> foo.thisIsAField.asJson,
+        "a" -> foo.a.asJson,
+        "b" -> foo.b.asJson
+      )
+      assert(Encoder[ConfigExampleBase.ConfigExampleFoo].apply(foo) === json)
+      assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property("Configuration#transformMemberNames should support member name transformation using PascalCase") {
+    forAll { (foo: ConfigExampleBase.ConfigExampleFoo) =>
+      given Configuration = Configuration.default.withPascalCaseMemberNames
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+      val json = Json.obj(
+        "ThisIsAField" -> foo.thisIsAField.asJson,
+        "A" -> foo.a.asJson,
+        "B" -> foo.b.asJson
+      )
+      assert(Encoder[ConfigExampleBase.ConfigExampleFoo].apply(foo) === json)
+      assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property("Configuration#withDefaults should support using default values during decoding") {
+    forAll { (f: String, b: Double) =>
+      given Configuration = Configuration.default.withDefaults
+      given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+
+      val foo: ConfigExampleBase.ConfigExampleFoo = ConfigExampleBase.ConfigExampleFoo(f, 0, b)
+      val json = Json.obj(
+        "thisIsAField" -> f.asJson,
+        "b" -> b.asJson
+      )
+      val expected = Json.obj(
+        "thisIsAField" -> f.asJson,
+        "a" -> 0.asJson,
+        "b" -> b.asJson
+      )
+      assert(Encoder[ConfigExampleBase.ConfigExampleFoo].apply(foo) === expected)
+      assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json) === Right(foo))
+    }
+  }
+
+  {
+    given Configuration = Configuration.default.withDefaults
+
+    case class FooWithDefault(a: Option[Int] = Some(0), b: String = "b")
+    object FooWithDefault:
+      given Eq[FooWithDefault] = Eq.fromUniversalEquals
+      given Codec.AsObject[FooWithDefault] = deriveConfiguredCodec
+
+    case class FooNoDefault(a: Option[Int], b: String = "b")
+    object FooNoDefault:
+      given Eq[FooNoDefault] = Eq.fromUniversalEquals
+      given Codec.AsObject[FooNoDefault] = deriveConfiguredCodec
+
+    test("Option[T] without default should be None if null decoded") {
+      val json = Json.obj("a" -> Json.Null)
+      assert(Decoder[FooNoDefault].decodeJson(json) === Right(FooNoDefault(None, "b")))
+    }
+
+    test("Option[T] without default should be None if missing key decoded") {
+      val json = Json.obj()
+      assert(Decoder[FooNoDefault].decodeJson(json) === Right(FooNoDefault(None, "b")))
+    }
+
+    test("Option[T] with default should be None if null decoded") {
+      val json = Json.obj("a" -> Json.Null)
+      assert(Decoder[FooWithDefault].decodeJson(json) === Right(FooWithDefault(None, "b")))
+    }
+
+    test("Option[T] with default should be default value if missing key decoded") {
+      val json = Json.obj()
+      assert(Decoder[FooWithDefault].decodeJson(json) === Right(FooWithDefault(Some(0), "b")))
+      assert(Decoder[FooWithDefault].decodeAccumulating(json.hcursor) === Validated.valid(FooWithDefault(Some(0), "b")))
+    }
+
+    test("Value with default should be default value if value is null") {
+      val json = Json.obj("b" -> Json.Null)
+      assert(Decoder[FooWithDefault].decodeJson(json) === Right(FooWithDefault(Some(0), "b")))
+      assert(Decoder[FooWithDefault].decodeAccumulating(json.hcursor) === Validated.valid(FooWithDefault(Some(0), "b")))
+    }
+
+    test("Option[T] with default should fail to decode if type in json is not correct") {
+      val json = Json.obj("a" -> "NotAnInt".asJson)
+      assert(Decoder[FooWithDefault].decodeJson(json).isLeft)
+      assert(Decoder[FooWithDefault].decodeAccumulating(json.hcursor).isInvalid)
+    }
+
+    test("Field with default should fail to decode if type in json is not correct") {
+      val json = Json.obj("b" -> 25.asJson)
+      assert(Decoder[FooWithDefault].decodeJson(json).isLeft)
+      assert(Decoder[FooWithDefault].decodeAccumulating(json.hcursor).isInvalid)
+    }
+  }
+
+  {
+    given Configuration = Configuration.default.withDefaults
+
+    case class GenericFoo[T](a: List[T] = List.empty, b: String = "b")
+    object GenericFoo:
+      given [T: Encoder: Decoder]: Codec.AsObject[GenericFoo[T]] = deriveConfiguredCodec
+      given [T: Eq]: Eq[GenericFoo[T]] = Eq.fromUniversalEquals
+
+    test("Configuration#withDefaults should support generic classes") {
+      val json = Json.obj()
+      assert(Decoder[GenericFoo[Int]].decodeJson(json) === Right(GenericFoo(List.empty[Int], "b")))
+    }
+  }
+
+  test("Fail when the json to be decoded is not a Json object (product)") {
+    given Configuration = Configuration.default
+    given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+
+    val json = Json.fromString("a string")
+    assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json).isLeft)
+  }
+
+  test("Fail to decode if case name does not exist") {
+    given Configuration = Configuration.default
+    given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+    val json = Json.obj(
+      "invalid-name" -> Json.obj(
+        "thisIsAField" -> "not used".asJson,
+        "a" -> 0.asJson,
+        "b" -> 2.5.asJson
+      )
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json).isLeft)
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor).isInvalid)
+  }
+
+  test("Fail to decode if case name does not exist when constructor names are being transformed") {
+    given Configuration = Configuration.default.withSnakeCaseConstructorNames
+    given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+    val json = Json.obj(
+      "ConfigExampleFoo" -> Json.obj(
+        "thisIsAField" -> "not used".asJson,
+        "a" -> 0.asJson,
+        "b" -> 2.5.asJson
+      )
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json).isLeft)
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor).isInvalid)
+  }
+
+  test(
+    "Decoding when Configuration#discriminator is set should fail if the discriminator field does not exist or its null"
+  ) {
+    given Configuration = Configuration.default.withDiscriminator("type")
+    given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+    val json1 = Json.obj(
+      "_notType" -> "ConfigExampleFoo".asJson,
+      "thisIsAField" -> "not used".asJson,
+      "a" -> 0.asJson,
+      "b" -> 2.5.asJson
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json1).isLeft)
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json1.hcursor).isInvalid)
+
+    val json2 = Json.obj(
+      "_notType" -> Json.Null,
+      "thisIsAField" -> "not used".asJson,
+      "a" -> 0.asJson,
+      "b" -> 2.5.asJson
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json2).isLeft)
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json2.hcursor).isInvalid)
+  }
+
+  property("Configuration#discriminator should support a field indicating constructor") {
+    forAll { (foo: ConfigExampleBase.ConfigExampleFoo) =>
+      given Configuration = Configuration.default.withDiscriminator("type")
+      given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+      val json = Json.obj(
+        "type" -> "ConfigExampleFoo".asJson,
+        "thisIsAField" -> foo.thisIsAField.asJson,
+        "a" -> foo.a.asJson,
+        "b" -> foo.b.asJson
+      )
+      assert(Encoder[ConfigExampleBase].apply(foo) === json)
+      assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property("Configuration#transformConstructorNames should support constructor name transformation with snake_case") {
+    forAll { (foo: ConfigExampleBase.ConfigExampleFoo) =>
+      given Configuration = Configuration.default.withDiscriminator("type").withSnakeCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+      val json = Json.obj(
+        "type" -> "config_example_foo".asJson,
+        "thisIsAField" -> foo.thisIsAField.asJson,
+        "a" -> foo.a.asJson,
+        "b" -> foo.b.asJson
+      )
+      assert(Encoder[ConfigExampleBase].apply(foo) === json)
+      assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property(
+    "Configuration#transformConstructorNames should support constructor name transformation with SCREAMING_SNAKE_CASE"
+  ) {
+    forAll { (foo: ConfigExampleBase.ConfigExampleFoo) =>
+      given Configuration = Configuration.default.withDiscriminator("type").withScreamingSnakeCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+      val json = Json.obj(
+        "type" -> "CONFIG_EXAMPLE_FOO".asJson,
+        "thisIsAField" -> foo.thisIsAField.asJson,
+        "a" -> foo.a.asJson,
+        "b" -> foo.b.asJson
+      )
+      assert(Encoder[ConfigExampleBase].apply(foo) === json)
+      assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property("Configuration#transformConstructorNames should support constructor name transformation with kebab-case") {
+    forAll { (foo: ConfigExampleBase.ConfigExampleFoo) =>
+      given Configuration = Configuration.default.withDiscriminator("type").withKebabCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+      val json = Json.obj(
+        "type" -> "config-example-foo".asJson,
+        "thisIsAField" -> foo.thisIsAField.asJson,
+        "a" -> foo.a.asJson,
+        "b" -> foo.b.asJson
+      )
+      assert(Encoder[ConfigExampleBase].apply(foo) === json)
+      assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property("Configuration#transformConstructorNames should support constructor name transformation with PascalCase") {
+    forAll { (foo: ConfigExampleBase.ConfigExampleFoo) =>
+      given Configuration = Configuration.default.withDiscriminator("type").withPascalCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+      val json = Json.obj(
+        "type" -> "ConfigExampleFoo".asJson,
+        "thisIsAField" -> foo.thisIsAField.asJson,
+        "a" -> foo.a.asJson,
+        "b" -> foo.b.asJson
+      )
+      assert(Encoder[ConfigExampleBase].apply(foo) === json)
+      assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))
+    }
+  }
+
+  property("Configuration options should work together") {
+    forAll { (f: String, b: Double) =>
+      given Configuration = Configuration.default.withSnakeCaseMemberNames.withDefaults
+        .withDiscriminator("type")
+        .withKebabCaseConstructorNames
+      given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+      val foo: ConfigExampleBase.ConfigExampleFoo = ConfigExampleBase.ConfigExampleFoo(f, 0, b)
+      val json = Json.obj(
+        "type" -> "config-example-foo".asJson,
+        "this_is_a_field" -> foo.thisIsAField.asJson,
+        "b" -> foo.b.asJson
+      )
+      val expected = Json.obj(
+        "type" -> "config-example-foo".asJson,
+        "this_is_a_field" -> foo.thisIsAField.asJson,
+        "a" -> 0.asJson,
+        "b" -> foo.b.asJson
+      )
+      assert(Encoder[ConfigExampleBase].apply(foo) === expected)
+      assert(Decoder[ConfigExampleBase].decodeJson(json) === Right(foo))
+    }
+  }
+
+  test("Configuration#strictDecoding should fail for sum types when the json object has more than one field") {
+    given Configuration = Configuration.default.withStrictDecoding
+    given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
+
+    val json = Json.obj(
+      "ConfigExampleFoo" -> Json.obj(
+        "thisIsAField" -> "not used".asJson,
+        "a" -> 0.asJson,
+        "b" -> 2.5.asJson
+      ),
+      "anotherField" -> "some value".asJson
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json).isLeft)
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor).isInvalid)
+  }
+
+  test(
+    "Configuration#strictDecoding should fail for product types when the json object has more fields than expected"
+  ) {
+    given Configuration = Configuration.default.withStrictDecoding
+    given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+
+    val json = Json.obj(
+      "thisIsAField" -> "not used".asJson,
+      "a" -> 0.asJson,
+      "b" -> 2.5.asJson,
+      "anotherField" -> "some value".asJson
+    )
+    assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json).isLeft)
+    assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeAccumulating(json.hcursor).isInvalid)
+  }
+
+  test(
+    "Configuration#strictDecoding on product types should not fail fast on decodeAccumulating if there are unexpected fields"
+  ) {
+    given Configuration = Configuration.default.withStrictDecoding
+    given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+
+    val json = Json.obj(
+      "thisIsAField" -> "not used".asJson,
+      "a" -> 0.asJson,
+      "b" -> "should be a double".asJson,
+      "invalidField" -> "some value".asJson
+    )
+    // decodeJson should fail (strict decoding error)
+    assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json).isLeft)
+    // decodeAccumulating should collect both the strict error and the field type error
+    val accResult = Decoder[ConfigExampleBase.ConfigExampleFoo].decodeAccumulating(json.hcursor)
+    assert(accResult.isInvalid)
+    accResult match
+      case Validated.Invalid(errors) =>
+        // Should have at least 2 errors: strict decoding + type mismatch on "b"
+        assert(errors.size >= 2, s"Expected at least 2 errors but got ${errors.size}: $errors")
+      case _ => fail("Expected invalid result")
+  }
+
+  test("Codec for hierarchy of more than 1 level with discriminator should encode and decode correctly") {
+    given Configuration = Configuration.default.withDiscriminator("type")
+    given Codec.AsObject[ConfiguredDerivesSuite.GrandParent] = deriveConfiguredCodec
+
+    val child: ConfiguredDerivesSuite.GrandParent = ConfiguredDerivesSuite.Child1(1, "a")
+    val json = Encoder.AsObject[ConfiguredDerivesSuite.GrandParent].apply(child)
+    val result = Decoder[ConfiguredDerivesSuite.GrandParent].decodeJson(json)
+    assert(result === Right(child), result.toString)
+  }
+
+  test(
+    "Codec for hierarchy of more than 2 levels with discriminator should encode and decode correctly"
+  ) {
+    given Configuration = Configuration.default.withDiscriminator("type")
+    given Codec.AsObject[ConfiguredDerivesSuite.GreatGrandParent] = deriveConfiguredCodec
+
+    val child: ConfiguredDerivesSuite.GreatGrandParent = ConfiguredDerivesSuite.Child2(1, "a")
+    val json = Encoder.AsObject[ConfiguredDerivesSuite.GreatGrandParent].apply(child)
+    val result = Decoder[ConfiguredDerivesSuite.GreatGrandParent].decodeJson(json)
+    assert(result === Right(child), result.toString)
+  }
+
+  test("Codec for recursive type should encode and decode correctly") {
+    given Configuration = Configuration.default.withDiscriminator("type")
+    given Codec.AsObject[ConfiguredDerivesSuite.Tree] = deriveConfiguredCodec
+
+    val tree: ConfiguredDerivesSuite.Tree = ConfiguredDerivesSuite.Branch(
+      ConfiguredDerivesSuite.Branch(ConfiguredDerivesSuite.Leaf, ConfiguredDerivesSuite.Leaf),
+      ConfiguredDerivesSuite.Leaf
+    )
+    val json = Encoder.AsObject[ConfiguredDerivesSuite.Tree].apply(tree)
+    val result = Decoder[ConfiguredDerivesSuite.Tree].decodeJson(json)
+    assert(result === Right(tree), result.toString)
+  }

--- a/compat/test/src/io/circe/generic/ConfiguredEnumDerivesSuites.scala
+++ b/compat/test/src/io/circe/generic/ConfiguredEnumDerivesSuites.scala
@@ -1,0 +1,123 @@
+package io.circe.generic
+
+import cats.kernel.Eq
+import cats.kernel.instances.all.*
+import cats.syntax.eq.*
+import cats.data.Validated
+import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json}
+import io.circe.derivation.Configuration
+import io.circe.generic.semiauto.*
+import io.circe.testing.CodecTests
+import io.circe.tests.CirceMunitSuite
+import io.circe.syntax.*
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Prop.forAll
+
+object ConfiguredEnumDerivesSuites:
+  enum IntercardinalDirections:
+    case NorthEast, SouthEast, SouthWest, NorthWest
+  object IntercardinalDirections:
+    given Eq[IntercardinalDirections] = Eq.fromUniversalEquals
+    given Arbitrary[IntercardinalDirections] = Arbitrary(
+      Gen.oneOf(
+        Gen.const(IntercardinalDirections.NorthEast),
+        Gen.const(IntercardinalDirections.SouthEast),
+        Gen.const(IntercardinalDirections.SouthWest),
+        Gen.const(IntercardinalDirections.NorthWest)
+      )
+    )
+
+  sealed trait HierarchicalEnum
+  object HierarchicalEnum:
+    sealed trait NestedA extends HierarchicalEnum
+    sealed trait NestedB extends HierarchicalEnum
+
+    case object A extends HierarchicalEnum
+    case object B extends NestedA
+    case object C extends NestedB
+    case object D extends NestedA, NestedB // diamond structure
+
+    given Eq[HierarchicalEnum] = Eq.fromUniversalEquals
+    given Arbitrary[HierarchicalEnum] = Arbitrary(
+      Gen.oneOf(
+        Gen.const(HierarchicalEnum.A),
+        Gen.const(HierarchicalEnum.B),
+        Gen.const(HierarchicalEnum.C),
+        Gen.const(HierarchicalEnum.D)
+      )
+    )
+
+class ConfiguredEnumDerivesSuites extends CirceMunitSuite:
+  import ConfiguredEnumDerivesSuites.*
+
+  {
+    given Configuration = Configuration.default
+    given Codec[IntercardinalDirections] = deriveEnumCodec
+    checkAll("Codec[IntercardinalDirections] (default configuration)", CodecTests[IntercardinalDirections].codec)
+  }
+
+  test("Fail to decode if case name does not exist") {
+    given Configuration = Configuration.default
+    given Codec[IntercardinalDirections] = deriveEnumCodec
+    val json = Json.fromString("NorthNorth")
+    val result = Decoder[IntercardinalDirections].decodeJson(json)
+    assert(result.isLeft)
+    val accResult = Decoder[IntercardinalDirections].decodeAccumulating(json.hcursor)
+    assert(accResult.isInvalid)
+  }
+
+  test("Configuration#transformConstructorNames should support constructor name transformation with snake_case") {
+    given Configuration = Configuration.default.withSnakeCaseConstructorNames
+    given Codec[IntercardinalDirections] = deriveEnumCodec
+
+    val direction = IntercardinalDirections.NorthEast
+    val json = Json.fromString("north_east")
+    assert(summon[Encoder[IntercardinalDirections]].apply(direction) === json)
+    assert(summon[Decoder[IntercardinalDirections]].decodeJson(json) === Right(direction))
+  }
+
+  test(
+    "Configuration#transformConstructorNames should support constructor name transformation with SCREAMING_SNAKE_CASE"
+  ) {
+    given Configuration = Configuration.default.withScreamingSnakeCaseConstructorNames
+    given Codec[IntercardinalDirections] = deriveEnumCodec
+
+    val direction = IntercardinalDirections.SouthEast
+    val json = Json.fromString("SOUTH_EAST")
+    assert(summon[Encoder[IntercardinalDirections]].apply(direction) === json)
+    assert(summon[Decoder[IntercardinalDirections]].decodeJson(json) === Right(direction))
+  }
+
+  test("Configuration#transformConstructorNames should support constructor name transformation with kebab-case") {
+    given Configuration = Configuration.default.withKebabCaseConstructorNames
+    given Codec[IntercardinalDirections] = deriveEnumCodec
+
+    val direction = IntercardinalDirections.SouthWest
+    val json = Json.fromString("south-west")
+    assert(summon[Encoder[IntercardinalDirections]].apply(direction) === json)
+    assert(summon[Decoder[IntercardinalDirections]].decodeJson(json) === Right(direction))
+  }
+
+  test("Should work with nested hierarchies") {
+    given Configuration = Configuration.default
+    given Codec[HierarchicalEnum] = deriveEnumCodec
+    {
+      val value = HierarchicalEnum.A
+      val json = Json.fromString("A")
+      assertEquals(summon[Encoder[HierarchicalEnum]].apply(value), json)
+      assertEquals(summon[Decoder[HierarchicalEnum]].decodeJson(json), Right(value))
+    }
+
+    {
+      val value = HierarchicalEnum.C
+      val json = Json.fromString("C")
+      assertEquals(summon[Encoder[HierarchicalEnum]].apply(value), json)
+      assertEquals(summon[Decoder[HierarchicalEnum]].decodeJson(json), Right(value))
+    }
+  }
+
+  {
+    given Configuration = Configuration.default
+    given Codec[HierarchicalEnum] = deriveEnumCodec
+    checkAll("Codec[HierarchicalEnum] (default configuration)", CodecTests[HierarchicalEnum].codec)
+  }

--- a/compat/test/src/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/compat/test/src/io/circe/generic/SemiautoDerivedSuite.scala
@@ -77,6 +77,70 @@ object SemiautoDerivedSuite {
   case class OvergenerationExampleInner(i: Int)
   case class OvergenerationExampleOuter0(i: OvergenerationExampleInner)
   case class OvergenerationExampleOuter1(oi: Option[OvergenerationExampleInner])
+
+  // ADT variants matching circe's SemiautoDerivationSuite
+
+  sealed trait Adt1
+  object Adt1 {
+    case class Class1(int: Int) extends Adt1
+    object Class1 {
+      given decoder: Decoder[Class1] = deriveDecoder
+      given encoder: Encoder.AsObject[Class1] = deriveEncoder
+
+      given eq: Eq[Class1] = Eq.by(_.int)
+      given arbitrary: Arbitrary[Class1] = Arbitrary(Arbitrary.arbitrary[Int].map(Class1(_)))
+    }
+
+    case object Object1 extends Adt1
+
+    given decoder: Decoder[Adt1] = deriveDecoder
+    given encoder: Encoder.AsObject[Adt1] = deriveEncoder
+
+    given eq: Eq[Adt1] = Eq.instance {
+      case (x: Class1, y: Class1) => x === y
+      case (Object1, Object1)     => true
+      case _                      => false
+    }
+    given arbitrary: Arbitrary[Adt1] = Arbitrary(Gen.oneOf(Arbitrary.arbitrary[Class1], Gen.const(Object1)))
+  }
+
+  sealed trait Adt2
+  object Adt2 {
+    case object Object1 extends Adt2
+    case object Object2 extends Adt2
+
+    given decoder: Decoder[Adt2] = deriveDecoder
+    given encoder: Encoder.AsObject[Adt2] = deriveEncoder
+
+    given eq: Eq[Adt2] = Eq.fromUniversalEquals
+    given arbitrary: Arbitrary[Adt2] = Arbitrary(Gen.oneOf(Gen.const(Object1), Gen.const(Object2)))
+  }
+
+  sealed trait Adt3
+  object Adt3 {
+    case class Class1() extends Adt3
+    case object Object1 extends Adt3
+
+    given decoder: Decoder[Adt3] = deriveDecoder
+    given encoder: Encoder.AsObject[Adt3] = deriveEncoder
+
+    given eq: Eq[Adt3] = Eq.fromUniversalEquals
+    given arbitrary: Arbitrary[Adt3] = Arbitrary(Gen.oneOf(Gen.const(Class1()), Gen.const(Object1)))
+  }
+
+  sealed trait Adt4
+  object Adt4 {
+    sealed trait SubTrait1 extends Adt4
+    case class Class1() extends SubTrait1
+    sealed trait SubTrait2 extends Adt4
+    case object Object1 extends SubTrait2
+
+    given decoder: Decoder[Adt4] = deriveDecoder
+    given encoder: Encoder.AsObject[Adt4] = deriveEncoder
+
+    given eq: Eq[Adt4] = Eq.fromUniversalEquals
+    given arbitrary: Arbitrary[Adt4] = Arbitrary(Gen.oneOf(Gen.const(Class1()), Gen.const(Object1)))
+  }
 }
 
 class SemiautoDerivedSuite extends CirceMunitSuite {
@@ -137,6 +201,11 @@ class SemiautoDerivedSuite extends CirceMunitSuite {
     ).codec
   )
 
+  checkAll("Codec[Adt1]", CodecTests[Adt1].codec)
+  checkAll("Codec[Adt2]", CodecTests[Adt2].codec)
+  checkAll("Codec[Adt3]", CodecTests[Adt3].codec)
+  checkAll("Codec[Adt4]", CodecTests[Adt4].codec)
+
   property("A generically derived codec should not interfere with base instances") {
     Prop.forAll { (is: List[Int]) =>
       val json = Encoder[List[Int]].apply(is)
@@ -152,5 +221,14 @@ class SemiautoDerivedSuite extends CirceMunitSuite {
       assert(deriveDecoder[EmptyCc].decodeJson(j).isRight == j.isObject)
       assert(deriveCodec[EmptyCc].decodeJson(j).isRight == j.isObject)
     }
+  }
+
+  test("Decoder for ADT/Enum ignores superfluous keys") {
+    import io.circe.parser.decode
+    val expected = Right(Adt1.Class1(3))
+    assertEquals(decode[Adt1]("""{"Class1":{"int":3}}"""), expected)
+    assertEquals(decode[Adt1]("""{"extraField":true,"Class1":{"int":3}}"""), expected)
+    assertEquals(decode[Adt1]("""{"extraField":true,"extraField2":15,"Class1":{"int":3}}"""), expected)
+    assertEquals(decode[Adt1]("""{"Class1":{"int":3},"extraField":true}"""), expected)
   }
 }

--- a/sanely/package.mill
+++ b/sanely/package.mill
@@ -16,7 +16,7 @@ object `package` extends mill.Module {
   trait SharedModule extends PlatformScalaModule with SonatypeCentralPublishModule {
     def artifactName = "circe-sanely-auto"
     def scalaVersion = build.scala3Version
-    def publishVersion = "0.8.0"
+    def publishVersion = "0.9.0"
 
     def pomSettings = PomSettings(
       description = "Drop-in replacement for circe's auto-derivation using sanely-automatic Scala 3 macros",

--- a/sanely/src/sanely/SanelyEnumCodec.scala
+++ b/sanely/src/sanely/SanelyEnumCodec.scala
@@ -58,17 +58,24 @@ object SanelyEnumCodec:
     ): Expr[Codec[S]] =
       val typeName = Expr(Type.show[S])
 
+      // Deduplicate cases (diamond inheritance can produce the same singleton via multiple paths)
+      val deduped = cases.distinctBy(_._1)
+
       '{
-        val _valueToName: Map[Int, String] = ${
-          val mapEntries = cases.zipWithIndex.map { case ((label, valueExpr), idx) =>
+        // Use parallel arrays for encoding: match by reference equality (safe for singletons)
+        val _values: Array[AnyRef] = ${
+          val exprs = deduped.map { case (_, valueExpr) => '{ $valueExpr.asInstanceOf[AnyRef] } }
+          '{ Array(${Varargs(exprs)}*) }
+        }
+        val _names: Array[String] = ${
+          val exprs = deduped.map { case (label, _) =>
             val labelExpr = Expr(label)
-            '{ ($mirror.ordinal($valueExpr), $conf.transformConstructorNames($labelExpr)) }
+            '{ $conf.transformConstructorNames($labelExpr) }
           }
-          val listExpr = Expr.ofList(mapEntries)
-          '{ $listExpr.toMap }
+          '{ Array(${Varargs(exprs)}*) }
         }
         val _nameToValue: Map[String, S] = ${
-          val mapEntries = cases.map { case (label, valueExpr) =>
+          val mapEntries = deduped.map { case (label, valueExpr) =>
             val labelExpr = Expr(label)
             '{ ($conf.transformConstructorNames($labelExpr), $valueExpr) }
           }
@@ -85,5 +92,10 @@ object SanelyEnumCodec:
                   case None => Left(DecodingFailure(s"enum ${$typeName} does not contain case: " + name, c.history))
               case Left(e) => Left(e)
           def apply(a: S): Json =
-            Json.fromString(_valueToName($mirror.ordinal(a)))
+            val ref = a.asInstanceOf[AnyRef]
+            var i = 0
+            while i < _values.length do
+              if _values(i) eq ref then return Json.fromString(_names(i))
+              i += 1
+            Json.fromString(_names(0)) // unreachable for valid enums
       }


### PR DESCRIPTION
## Summary

- **Fix hierarchical enum codec bug** — `SanelyEnumCodec` now correctly handles diamond inheritance in sealed trait hierarchies. Previously, `mirror.ordinal()` returned the ordinal of the intermediate trait (not the leaf), causing B and D to collide at ordinal 1 when both extend NestedA. Now uses reference equality (`eq`) on singleton instances with deduplication.
- **Add ConfiguredDerivesSuite** (25 tests) — ported from circe's `ConfiguredDerivesSuite`, covering member name transforms, defaults, discriminator, constructor name transforms, strict decoding, multi-level hierarchies, and recursive types.
- **Add ConfiguredEnumDerivesSuites** (11 tests) — ported from circe's `ConfiguredEnumDerivesSuites`, covering codec property tests, constructor name transforms, and hierarchical enums with diamond inheritance.
- **Expand AutoDerivedSuite** — added recursive ADTs, nested sub-traits, nested case classes with Option, 33-field stress test, and encoding behavior tests.
- **Expand SemiautoDerivedSuite** — added Adt1–Adt4 variants (class+object, all-objects, sub-traits), and superfluous key handling test.
- **Compat test count: 160 → 253 (+93 tests)**
- **No performance regression** — macro profiling (2331ms, baseline ~2450ms) and JVM profiling both show no regression.

## Test plan
- [x] `./mill sanely.jvm.test` — 116 tests pass
- [x] `./mill sanely.js.test` — 116 tests pass
- [x] `./mill compat.test` — 253 tests pass
- [x] Macro profiling shows no regression
- [x] JVM profiling shows no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)