### PR TITLE
feat: full circe compat test coverage and circe-compatible error messages

### DIFF
--- a/compat/test/src/io/circe/generic/AutoDerivedSuite.scala
+++ b/compat/test/src/io/circe/generic/AutoDerivedSuite.scala
@@ -131,6 +131,139 @@ object AutoDerivedSuite {
         s31, s32, s33)
     }
   }
+
+  // Enum with mixed singleton and data cases (from circe DerivesSuite)
+  enum Vegetable:
+    case Potato(species: String)
+    case Carrot(length: Double)
+    case Onion(layers: Int)
+    case Turnip
+  object Vegetable:
+    given Eq[Vegetable] = Eq.fromUniversalEquals
+    given Arbitrary[Vegetable.Potato] = Arbitrary(
+      Arbitrary.arbitrary[String].map(Vegetable.Potato.apply)
+    )
+    given Arbitrary[Vegetable.Carrot] = Arbitrary(
+      Arbitrary.arbitrary[Double].map(Vegetable.Carrot.apply)
+    )
+    given Arbitrary[Vegetable.Onion] = Arbitrary(
+      Arbitrary.arbitrary[Int].map(Vegetable.Onion.apply)
+    )
+    given Arbitrary[Vegetable.Turnip.type] = Arbitrary(Gen.const(Vegetable.Turnip))
+    given Arbitrary[Vegetable] = Arbitrary(
+      Gen.oneOf(
+        Arbitrary.arbitrary[Vegetable.Potato],
+        Arbitrary.arbitrary[Vegetable.Carrot],
+        Arbitrary.arbitrary[Vegetable.Onion],
+        Arbitrary.arbitrary[Vegetable.Turnip.type]
+      )
+    )
+
+  // Recursive enum ADT (from circe DerivesSuite)
+  enum RecursiveEnumAdt:
+    case BaseAdtExample(a: String)
+    case NestedAdtExample(r: RecursiveEnumAdt)
+  object RecursiveEnumAdt:
+    given Eq[RecursiveEnumAdt] = Eq.fromUniversalEquals
+
+    private def atDepth(depth: Int): Gen[RecursiveEnumAdt] = if (depth < 3)
+      Gen.oneOf(
+        Arbitrary.arbitrary[String].map(RecursiveEnumAdt.BaseAdtExample(_)),
+        atDepth(depth + 1).map(RecursiveEnumAdt.NestedAdtExample(_))
+      )
+    else Arbitrary.arbitrary[String].map(RecursiveEnumAdt.BaseAdtExample(_))
+
+    given Arbitrary[RecursiveEnumAdt] = Arbitrary(atDepth(0))
+
+  // Phantom type tagging (from circe DerivesSuite #2135)
+  case class ProductWithTaggedMember(x: ProductWithTaggedMember.TaggedString)
+
+  object ProductWithTaggedMember:
+    sealed trait Tag
+
+    type TaggedString = String & Tag
+
+    object TaggedString:
+      val decoder: Decoder[TaggedString] =
+        summon[Decoder[String]].map(_.asInstanceOf[TaggedString])
+      val encoder: Encoder[TaggedString] =
+        summon[Encoder[String]].contramap(x => x)
+
+    given Codec[TaggedString] =
+      Codec.from(TaggedString.decoder, TaggedString.encoder)
+
+    def fromUntagged(x: String): ProductWithTaggedMember =
+      ProductWithTaggedMember(x.asInstanceOf[TaggedString])
+
+    given Arbitrary[ProductWithTaggedMember] =
+      Arbitrary {
+        Arbitrary.arbitrary[String].map(fromUntagged)
+      }
+    given Eq[ProductWithTaggedMember] = Eq.fromUniversalEquals
+
+  // 33-variant singleton enum (from circe DerivesSuite)
+  enum LongEnum:
+    case v1, v2, v3, v4, v5, v6, v7, v8, v9, v10,
+      v11, v12, v13, v14, v15, v16, v17, v18, v19, v20,
+      v21, v22, v23, v24, v25, v26, v27, v28, v29, v30,
+      v31, v32, v33
+
+  object LongEnum:
+    given Eq[LongEnum] = Eq.fromUniversalEquals
+    given Arbitrary[LongEnum] = Arbitrary(Gen.oneOf(LongEnum.values.toSeq))
+
+  // 33-variant sum enum with data fields (from circe DerivesSuite)
+  enum LongSum:
+    case v1(str: String)
+    case v2(str: String)
+    case v3(str: String)
+    case v4(str: String)
+    case v5(str: String)
+    case v6(str: String)
+    case v7(str: String)
+    case v8(str: String)
+    case v9(str: String)
+    case v10(str: String)
+    case v11(str: String)
+    case v12(str: String)
+    case v13(str: String)
+    case v14(str: String)
+    case v15(str: String)
+    case v16(str: String)
+    case v17(str: String)
+    case v18(str: String)
+    case v19(str: String)
+    case v20(str: String)
+    case v21(str: String)
+    case v22(str: String)
+    case v23(str: String)
+    case v24(str: String)
+    case v25(str: String)
+    case v26(str: String)
+    case v27(str: String)
+    case v28(str: String)
+    case v29(str: String)
+    case v30(str: String)
+    case v31(str: String)
+    case v32(str: String)
+    case v33(str: String)
+
+  object LongSum:
+    given Eq[LongSum] = Eq.fromUniversalEquals
+    given Arbitrary[LongSum] = Arbitrary(
+      for
+        v <- Arbitrary.arbitrary[String]
+        res <- Gen.oneOf(Seq(
+          LongSum.v1(v), LongSum.v2(v), LongSum.v3(v), LongSum.v4(v), LongSum.v5(v),
+          LongSum.v6(v), LongSum.v7(v), LongSum.v8(v), LongSum.v9(v), LongSum.v10(v),
+          LongSum.v11(v), LongSum.v12(v), LongSum.v13(v), LongSum.v14(v), LongSum.v15(v),
+          LongSum.v16(v), LongSum.v17(v), LongSum.v18(v), LongSum.v19(v), LongSum.v20(v),
+          LongSum.v21(v), LongSum.v22(v), LongSum.v23(v), LongSum.v24(v), LongSum.v25(v),
+          LongSum.v26(v), LongSum.v27(v), LongSum.v28(v), LongSum.v29(v), LongSum.v30(v),
+          LongSum.v31(v), LongSum.v32(v), LongSum.v33(v)
+        ))
+      yield res
+    )
 }
 
 class AutoDerivedSuite extends CirceMunitSuite {
@@ -138,6 +271,8 @@ class AutoDerivedSuite extends CirceMunitSuite {
 
   checkAll("Codec[Tuple1[Int]]", CodecTests[Tuple1[Int]].codec)
   checkAll("Codec[(Int, Int, Foo)]", CodecTests[(Int, Int, Foo)].codec)
+  checkAll("Codec[Box[Wub]]", CodecTests[Box[Wub]].codec)
+  checkAll("Codec[Box[Long]]", CodecTests[Box[Long]].codec)
   checkAll("Codec[Qux[Int]]", CodecTests[Qux[Int]].codec)
   checkAll("Codec[Seq[Foo]]", CodecTests[Seq[Foo]].codec)
   checkAll("Codec[Baz]", CodecTests[Baz].codec)
@@ -145,9 +280,14 @@ class AutoDerivedSuite extends CirceMunitSuite {
   checkAll("Codec[OuterCaseClassExample]", CodecTests[OuterCaseClassExample].codec)
   checkAll("Codec[RecursiveAdtExample]", CodecTests[RecursiveAdtExample].unserializableCodec)
   checkAll("Codec[RecursiveWithOptionExample]", CodecTests[RecursiveWithOptionExample].unserializableCodec)
+  checkAll("Codec[Vegetable]", CodecTests[Vegetable].unserializableCodec)
+  checkAll("Codec[RecursiveEnumAdt]", CodecTests[RecursiveEnumAdt].unserializableCodec)
   checkAll("Codec[ADTWithSubTraitExample]", CodecTests[ADTWithSubTraitExample].codec)
+  checkAll("Codec[ProductWithTaggedMember]", CodecTests[ProductWithTaggedMember].codec)
   checkAll("Codec[Outer]", CodecTests[Outer].codec)
   checkAll("Codec[LongClass]", CodecTests[LongClass].codec)
+  checkAll("Codec[LongSum]", CodecTests[LongSum].unserializableCodec)
+  checkAll("Codec[LongEnum]", CodecTests[LongEnum].codec)
 
   property("A generically derived codec should not interfere with base instances") {
     Prop.forAll { (is: List[Int]) =>

--- a/compat/test/src/io/circe/generic/ConfiguredDerivesSuite.scala
+++ b/compat/test/src/io/circe/generic/ConfiguredDerivesSuite.scala
@@ -5,6 +5,7 @@ import cats.kernel.instances.all.*
 import cats.syntax.eq.*
 import cats.data.{NonEmptyList, Validated}
 import io.circe.{Codec, Decoder, DecodingFailure, Encoder, Json}
+import io.circe.DecodingFailure.Reason.WrongTypeExpectation
 import io.circe.CursorOp.DownField
 import io.circe.derivation.Configuration
 import io.circe.generic.semiauto.*
@@ -22,12 +23,12 @@ object ConfiguredDerivesSuite:
   object GrandParent:
     given Eq[GrandParent] = Eq.fromUniversalEquals
 
-  // Hierarchy of 2+ levels
+  // Hierarchy of 2+ levels with field name collision
   sealed trait GreatGrandParent
   sealed trait GrandParent2 extends GreatGrandParent
-  case class Uncle(Child: Int) extends GrandParent2
+  case class Uncle(Child: Int) extends GrandParent2 // Field name `Child` matches case class `Child` below
   sealed trait Parent2 extends GrandParent2
-  case class Child2(a: Int, b: String) extends Parent2
+  case class Child(a: Int, b: String) extends Parent2
   object GreatGrandParent:
     given Eq[GreatGrandParent] = Eq.fromUniversalEquals
 
@@ -187,14 +188,19 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
 
     test("Option[T] with default should fail to decode if type in json is not correct") {
       val json = Json.obj("a" -> "NotAnInt".asJson)
-      assert(Decoder[FooWithDefault].decodeJson(json).isLeft)
-      assert(Decoder[FooWithDefault].decodeAccumulating(json.hcursor).isInvalid)
+      assert(Decoder[FooWithDefault].decodeJson(json) === Left(DecodingFailure("Int", List(DownField("a")))))
+      assert(
+        Decoder[FooWithDefault].decodeAccumulating(json.hcursor)
+          === Validated.invalidNel(DecodingFailure("Int", List(DownField("a"))))
+      )
     }
 
     test("Field with default should fail to decode if type in json is not correct") {
       val json = Json.obj("b" -> 25.asJson)
-      assert(Decoder[FooWithDefault].decodeJson(json).isLeft)
-      assert(Decoder[FooWithDefault].decodeAccumulating(json.hcursor).isInvalid)
+      val reason = DecodingFailure.Reason.WrongTypeExpectation("string", 25.asJson)
+      val failure = DecodingFailure(reason, List(DownField("b")))
+      assert(Decoder[FooWithDefault].decodeJson(json) === Left(failure))
+      assert(Decoder[FooWithDefault].decodeAccumulating(json.hcursor) === Validated.invalidNel(failure))
     }
   }
 
@@ -212,12 +218,15 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
     }
   }
 
-  test("Fail when the json to be decoded is not a Json object (product)") {
+  test("Fail when the json to be decoded is not a Json object") {
     given Configuration = Configuration.default
+    given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
     given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
 
     val json = Json.fromString("a string")
-    assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json).isLeft)
+    val failure = DecodingFailure(WrongTypeExpectation("object", json), List())
+    assert(Decoder[ConfigExampleBase].decodeJson(json) === Left(failure)) // sum type
+    assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json) === Left(failure)) // product type
   }
 
   test("Fail to decode if case name does not exist") {
@@ -231,8 +240,12 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
         "b" -> 2.5.asJson
       )
     )
-    assert(Decoder[ConfigExampleBase].decodeJson(json).isLeft)
-    assert(Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor).isInvalid)
+    val failure = DecodingFailure(
+      "type ConfigExampleBase has no class/object/case named 'invalid-name'.",
+      List(DownField("invalid-name"))
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json) === Left(failure))
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor) === Validated.invalidNel(failure))
   }
 
   test("Fail to decode if case name does not exist when constructor names are being transformed") {
@@ -246,8 +259,12 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
         "b" -> 2.5.asJson
       )
     )
-    assert(Decoder[ConfigExampleBase].decodeJson(json).isLeft)
-    assert(Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor).isInvalid)
+    val failure = DecodingFailure(
+      "type ConfigExampleBase has no class/object/case named 'ConfigExampleFoo'.",
+      List(DownField("ConfigExampleFoo"))
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json) === Left(failure))
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor) === Validated.invalidNel(failure))
   }
 
   test(
@@ -256,14 +273,19 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
     given Configuration = Configuration.default.withDiscriminator("type")
     given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
 
+    val failure = DecodingFailure(
+      "ConfigExampleBase: could not find discriminator field 'type' or its null.",
+      List(DownField("type"))
+    )
+
     val json1 = Json.obj(
       "_notType" -> "ConfigExampleFoo".asJson,
       "thisIsAField" -> "not used".asJson,
       "a" -> 0.asJson,
       "b" -> 2.5.asJson
     )
-    assert(Decoder[ConfigExampleBase].decodeJson(json1).isLeft)
-    assert(Decoder[ConfigExampleBase].decodeAccumulating(json1.hcursor).isInvalid)
+    assert(Decoder[ConfigExampleBase].decodeJson(json1) === Left(failure))
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json1.hcursor) === Validated.invalidNel(failure))
 
     val json2 = Json.obj(
       "_notType" -> Json.Null,
@@ -271,8 +293,8 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
       "a" -> 0.asJson,
       "b" -> 2.5.asJson
     )
-    assert(Decoder[ConfigExampleBase].decodeJson(json2).isLeft)
-    assert(Decoder[ConfigExampleBase].decodeAccumulating(json2.hcursor).isInvalid)
+    assert(Decoder[ConfigExampleBase].decodeJson(json2) === Left(failure))
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json2.hcursor) === Validated.invalidNel(failure))
   }
 
   property("Configuration#discriminator should support a field indicating constructor") {
@@ -393,48 +415,67 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
       ),
       "anotherField" -> "some value".asJson
     )
-    assert(Decoder[ConfigExampleBase].decodeJson(json).isLeft)
-    assert(Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor).isInvalid)
+    val failure = DecodingFailure(
+      s"Strict decoding ConfigExampleBase - expected a single key json object with one of: ConfigExampleFoo, ConfigExampleBar.",
+      List()
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json) === Left(failure))
+    assert(Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor) === Validated.invalidNel(failure))
   }
 
   test(
     "Configuration#strictDecoding should fail for product types when the json object has more fields than expected"
   ) {
     given Configuration = Configuration.default.withStrictDecoding
-    given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+    given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
 
     val json = Json.obj(
-      "thisIsAField" -> "not used".asJson,
-      "a" -> 0.asJson,
-      "b" -> 2.5.asJson,
-      "anotherField" -> "some value".asJson
+      "ConfigExampleFoo" -> Json.obj(
+        "thisIsAField" -> "not used".asJson,
+        "a" -> 0.asJson,
+        "b" -> 2.5.asJson,
+        "anotherField" -> "some value".asJson
+      )
     )
-    assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json).isLeft)
-    assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeAccumulating(json.hcursor).isInvalid)
+    def failure(submessage: String) = DecodingFailure(
+      s"Strict decoding ConfigExampleFoo - $submessage; valid fields: thisIsAField, a, b.",
+      List(DownField("ConfigExampleFoo"))
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json) === Left(failure("unexpected fields: anotherField")))
+    assert(
+      Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor) === Validated.invalidNel(
+        failure("unexpected fields: anotherField")
+      )
+    )
   }
 
   test(
     "Configuration#strictDecoding on product types should not fail fast on decodeAccumulating if there are unexpected fields"
   ) {
     given Configuration = Configuration.default.withStrictDecoding
-    given Codec.AsObject[ConfigExampleBase.ConfigExampleFoo] = deriveConfiguredCodec
+    given Codec.AsObject[ConfigExampleBase] = deriveConfiguredCodec
 
     val json = Json.obj(
-      "thisIsAField" -> "not used".asJson,
-      "a" -> 0.asJson,
-      "b" -> "should be a double".asJson,
-      "invalidField" -> "some value".asJson
+      "ConfigExampleFoo" -> Json.obj(
+        "thisIsAField" -> "not used".asJson,
+        "a" -> 0.asJson,
+        "b" -> "should be a double".asJson,
+        "invalidField" -> "some value".asJson
+      )
     )
-    // decodeJson should fail (strict decoding error)
-    assert(Decoder[ConfigExampleBase.ConfigExampleFoo].decodeJson(json).isLeft)
-    // decodeAccumulating should collect both the strict error and the field type error
-    val accResult = Decoder[ConfigExampleBase.ConfigExampleFoo].decodeAccumulating(json.hcursor)
-    assert(accResult.isInvalid)
-    accResult match
-      case Validated.Invalid(errors) =>
-        // Should have at least 2 errors: strict decoding + type mismatch on "b"
-        assert(errors.size >= 2, s"Expected at least 2 errors but got ${errors.size}: $errors")
-      case _ => fail("Expected invalid result")
+    def strictFailure(submessage: String) = DecodingFailure(
+      s"Strict decoding ConfigExampleFoo - $submessage; valid fields: thisIsAField, a, b.",
+      List(DownField("ConfigExampleFoo"))
+    )
+    assert(Decoder[ConfigExampleBase].decodeJson(json) === Left(strictFailure("unexpected fields: invalidField")))
+    assert(
+      Decoder[ConfigExampleBase].decodeAccumulating(json.hcursor) === Validated.invalid(
+        NonEmptyList(
+          strictFailure("unexpected fields: invalidField"),
+          List(DecodingFailure("Double", List(DownField("b"), DownField("ConfigExampleFoo"))))
+        )
+      )
+    )
   }
 
   test("Codec for hierarchy of more than 1 level with discriminator should encode and decode correctly") {
@@ -448,12 +489,12 @@ class ConfiguredDerivesSuite extends CirceMunitSuite:
   }
 
   test(
-    "Codec for hierarchy of more than 2 levels with discriminator should encode and decode correctly"
+    "Codec for hierarchy of more than 2 levels with discriminator should encode and decode correctly, even if a parent's sibling has a field with the same name as a Child type"
   ) {
     given Configuration = Configuration.default.withDiscriminator("type")
     given Codec.AsObject[ConfiguredDerivesSuite.GreatGrandParent] = deriveConfiguredCodec
 
-    val child: ConfiguredDerivesSuite.GreatGrandParent = ConfiguredDerivesSuite.Child2(1, "a")
+    val child: ConfiguredDerivesSuite.GreatGrandParent = ConfiguredDerivesSuite.Child(1, "a")
     val json = Encoder.AsObject[ConfiguredDerivesSuite.GreatGrandParent].apply(child)
     val result = Decoder[ConfiguredDerivesSuite.GreatGrandParent].decodeJson(json)
     assert(result === Right(child), result.toString)

--- a/compat/test/src/io/circe/generic/ConfiguredEnumDerivesSuites.scala
+++ b/compat/test/src/io/circe/generic/ConfiguredEnumDerivesSuites.scala
@@ -14,6 +14,11 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Prop.forAll
 
 object ConfiguredEnumDerivesSuites:
+  // Enum with non-singleton case (for compile error test)
+  enum WithNonSingletonCase:
+    case SingletonCase
+    case NonSingletonCase(field: Int)
+
   enum IntercardinalDirections:
     case NorthEast, SouthEast, SouthWest, NorthWest
   object IntercardinalDirections:
@@ -50,6 +55,11 @@ object ConfiguredEnumDerivesSuites:
 class ConfiguredEnumDerivesSuites extends CirceMunitSuite:
   import ConfiguredEnumDerivesSuites.*
 
+  test("ConfiguredEnum derivation must fail to compile for enums with non singleton cases") {
+    given Configuration = Configuration.default
+    assert(compileErrors("deriveEnumCodec[ConfiguredEnumDerivesSuites.WithNonSingletonCase]").nonEmpty)
+  }
+
   {
     given Configuration = Configuration.default
     given Codec[IntercardinalDirections] = deriveEnumCodec
@@ -60,10 +70,9 @@ class ConfiguredEnumDerivesSuites extends CirceMunitSuite:
     given Configuration = Configuration.default
     given Codec[IntercardinalDirections] = deriveEnumCodec
     val json = Json.fromString("NorthNorth")
-    val result = Decoder[IntercardinalDirections].decodeJson(json)
-    assert(result.isLeft)
-    val accResult = Decoder[IntercardinalDirections].decodeAccumulating(json.hcursor)
-    assert(accResult.isInvalid)
+    val failure = DecodingFailure("enum IntercardinalDirections does not contain case: NorthNorth", List())
+    assert(Decoder[IntercardinalDirections].decodeJson(json) === Left(failure))
+    assert(Decoder[IntercardinalDirections].decodeAccumulating(json.hcursor) === Validated.invalidNel(failure))
   }
 
   test("Configuration#transformConstructorNames should support constructor name transformation with snake_case") {

--- a/compat/test/src/io/circe/generic/SemiautoDerivedSuite.scala
+++ b/compat/test/src/io/circe/generic/SemiautoDerivedSuite.scala
@@ -78,6 +78,38 @@ object SemiautoDerivedSuite {
   case class OvergenerationExampleOuter0(i: OvergenerationExampleInner)
   case class OvergenerationExampleOuter1(oi: Option[OvergenerationExampleInner])
 
+  // Semiauto composition types (from circe SemiautoDerivationSuite)
+  case class SFoo(int: Int)
+  object SFoo {
+    given decoder: Decoder[SFoo] = deriveDecoder
+    given encoder: Encoder.AsObject[SFoo] = deriveEncoder
+
+    given eq: Eq[SFoo] = Eq.by(_.int)
+    given arbitrary: Arbitrary[SFoo] = Arbitrary(Arbitrary.arbitrary[Int].map(SFoo(_)))
+  }
+
+  case class SBar(foo: Box[SFoo])
+  object SBar {
+    given decoder: Decoder[SBar] = deriveDecoder
+    given encoder: Encoder.AsObject[SBar] = deriveEncoder
+
+    given eq: Eq[SBar] = Eq.by(_.foo)
+    given arbitrary: Arbitrary[SBar] = Arbitrary(Arbitrary.arbitrary[Box[SFoo]].map(SBar(_)))
+  }
+
+  case class SBaz(str: String)
+
+  // Non-derivable: Box[SBaz] has no Decoder/Encoder for SBaz
+  case class SQuux(baz: Box[SBaz])
+
+  sealed trait Adt5
+  object Adt5 {
+    case class Nested()
+    case class Class1(nested: Nested) extends Adt5
+    case object Object1 extends Adt5
+    // Non-derivable: no instances for Nested
+  }
+
   // ADT variants matching circe's SemiautoDerivationSuite
 
   sealed trait Adt1
@@ -201,10 +233,102 @@ class SemiautoDerivedSuite extends CirceMunitSuite {
     ).codec
   )
 
+  checkAll("Codec[SFoo]", CodecTests[SFoo].codec)
+  checkAll("Codec[Box[SFoo]]", CodecTests[Box[SFoo]].codec)
+  checkAll("Codec[SBar]", CodecTests[SBar].codec)
+  checkAll("Codec[Box[SBar]]", CodecTests[Box[SBar]].codec)
   checkAll("Codec[Adt1]", CodecTests[Adt1].codec)
   checkAll("Codec[Adt2]", CodecTests[Adt2].codec)
   checkAll("Codec[Adt3]", CodecTests[Adt3].codec)
   checkAll("Codec[Adt4]", CodecTests[Adt4].codec)
+
+  // Note: Unlike circe's built-in derivation, our library CAN derive nested types
+  // that lack explicit instances (via recursive macro derivation with Expr.summonIgnoring).
+  // This is a deliberate feature, not a bug. Circe's SemiautoDerivationSuite tests that
+  // Decoder.derived[Quux] and Decoder.derived[Adt5] fail — but our deriveDecoder succeeds.
+
+  // Local classes use `implicit val` instead of `given` to ensure derivation is strictly evaluated
+  // `given`s are desugared to `lazy val`s and part of the point of these tests is to ensure that
+  // deriving with strict `val`s doesn't cause `StackOverflowError`s
+  // See https://github.com/circe/circe/pull/2278
+  def testLocalCaseClasses(): Unit = {
+    case class LocalCaseClass1(int: Int)
+    object LocalCaseClass1 {
+      implicit val decoder: Decoder[LocalCaseClass1] = deriveDecoder
+      implicit val encoder: Encoder.AsObject[LocalCaseClass1] = deriveEncoder
+
+      given eq: Eq[LocalCaseClass1] = Eq.by(_.int)
+      given arbitrary: Arbitrary[LocalCaseClass1] = Arbitrary(Arbitrary.arbitrary[Int].map(LocalCaseClass1(_)))
+    }
+
+    case class LocalCaseClass2(int: Int)
+    object LocalCaseClass2 {
+      implicit val decoder: Decoder[LocalCaseClass2] = deriveDecoder
+      implicit val encoder: Encoder.AsObject[LocalCaseClass2] = deriveEncoder
+
+      given eq: Eq[LocalCaseClass2] = Eq.by(_.int)
+      given arbitrary: Arbitrary[LocalCaseClass2] = Arbitrary(Arbitrary.arbitrary[Int].map(LocalCaseClass2(_)))
+    }
+
+    case class LocalCaseClass3(int: Int)
+    object LocalCaseClass3 {
+      implicit val codec: Codec.AsObject[LocalCaseClass3] = deriveCodec
+
+      given eq: Eq[LocalCaseClass3] = Eq.by(_.int)
+      given arbitrary: Arbitrary[LocalCaseClass3] = Arbitrary(Arbitrary.arbitrary[Int].map(LocalCaseClass3(_)))
+    }
+
+    checkAll("Codec[LocalCaseClass1]", CodecTests[LocalCaseClass1].unserializableCodec)
+    checkAll("Codec[LocalCaseClass2]", CodecTests[LocalCaseClass2].unserializableCodec)
+    checkAll("Codec[LocalCaseClass3]", CodecTests[LocalCaseClass3].unserializableCodec)
+  }
+
+  def testLocalAdts(): Unit = {
+    sealed trait LocalAdt1
+    object LocalAdt1 {
+      case class Class(int: Int) extends LocalAdt1
+      object Class {
+        given eq: Eq[Class] = Eq.by(_.int)
+        given arbitrary: Arbitrary[Class] = Arbitrary(Arbitrary.arbitrary[Int].map(Class(_)))
+      }
+      case object Object extends LocalAdt1
+
+      implicit val decoder: Decoder[LocalAdt1] = deriveDecoder
+      implicit val encoder: Encoder.AsObject[LocalAdt1] = deriveEncoder
+
+      given eq: Eq[LocalAdt1] = Eq.instance {
+        case (x: Class, y: Class) => x === y
+        case (Object, Object)     => true
+        case _                    => false
+      }
+      given arbitrary: Arbitrary[LocalAdt1] = Arbitrary(Gen.oneOf(Arbitrary.arbitrary[Class], Gen.const(Object)))
+    }
+
+    sealed trait LocalAdt2
+    object LocalAdt2 {
+      case class Class(int: Int) extends LocalAdt2
+      object Class {
+        given eq: Eq[Class] = Eq.by(_.int)
+        given arbitrary: Arbitrary[Class] = Arbitrary(Arbitrary.arbitrary[Int].map(Class(_)))
+      }
+      case object Object extends LocalAdt2
+
+      implicit val codec: Codec.AsObject[LocalAdt2] = deriveCodec
+
+      given eq: Eq[LocalAdt2] = Eq.instance {
+        case (x: Class, y: Class) => x === y
+        case (Object, Object)     => true
+        case _                    => false
+      }
+      given arbitrary: Arbitrary[LocalAdt2] = Arbitrary(Gen.oneOf(Arbitrary.arbitrary[Class], Gen.const(Object)))
+    }
+
+    checkAll("Codec[LocalAdt1]", CodecTests[LocalAdt1].unserializableCodec)
+    checkAll("Codec[LocalAdt2]", CodecTests[LocalAdt2].unserializableCodec)
+  }
+
+  testLocalCaseClasses()
+  testLocalAdts()
 
   property("A generically derived codec should not interfere with base instances") {
     Prop.forAll { (is: List[Int]) =>

--- a/sanely/src/sanely/SanelyConfiguredDecoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredDecoder.scala
@@ -44,6 +44,7 @@ object SanelyConfiguredDecoder:
     ): Expr[Decoder[P]] =
       val fields = resolveFields[Types, Labels](selfRef)
       val defaults = timer.time("resolveDefaults") { resolveDefaults[P] }
+      val productTypeName = Expr(TypeRepr.of[P].typeSymbol.name)
 
       val fieldsWithDefaults = fields.zipWithIndex.map { case ((label, tpe, dec), idx) =>
         (label, tpe, dec, defaults.lift(idx).flatten)
@@ -78,25 +79,26 @@ object SanelyConfiguredDecoder:
 
       '{
         val _fieldNames = $fieldLabelsExpr.map($conf.transformMemberNames).toArray
+        val _typeName = $productTypeName
         new Decoder[P]:
           private lazy val _decoders = $decodersArrayExpr
           private val _hasDefault = $hasDefaultArrayExpr
           private val _defaults = $defaultsArrayExpr
           private val _isOption = $isOptionArrayExpr
           def apply(c: HCursor): Decoder.Result[P] =
-            if !c.value.isObject then Left(DecodingFailure("Expected JSON object for product type", c.history))
+            if !c.value.isObject then Left(DecodingFailure(DecodingFailure.Reason.WrongTypeExpectation("object", c.value), c.history))
             else
               if $conf.strictDecoding then
-                SanelyRuntime.checkStrictDecoding(c, _fieldNames.toSet) match
+                SanelyRuntime.checkStrictDecoding(c, _fieldNames.toSet, _typeName, _fieldNames) match
                   case Left(err) => return Left(err)
                   case _ => ()
               SanelyRuntime.decodeProductFieldsConfigured(c, $mirror, _fieldNames, _decoders, _hasDefault, _defaults, _isOption, $conf.useDefaults)
           override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[P] =
-            if !c.value.isObject then cats.data.Validated.invalidNel(DecodingFailure("Expected JSON object for product type", c.history))
+            if !c.value.isObject then cats.data.Validated.invalidNel(DecodingFailure(DecodingFailure.Reason.WrongTypeExpectation("object", c.value), c.history))
             else
               val strictErrors: List[DecodingFailure] =
                 if $conf.strictDecoding then
-                  SanelyRuntime.checkStrictDecoding(c, _fieldNames.toSet) match
+                  SanelyRuntime.checkStrictDecoding(c, _fieldNames.toSet, _typeName, _fieldNames) match
                     case Left(err) => List(err)
                     case _ => Nil
                 else Nil
@@ -108,6 +110,7 @@ object SanelyConfiguredDecoder:
       selfRef: Expr[Decoder[A]]
     ): Expr[Decoder[S]] =
       val cases = resolveFields[Types, Labels](selfRef)
+      val sumTypeName = Expr(TypeRepr.of[S].typeSymbol.name)
 
       // Only flatten sub-traits when no user-provided decoder exists
       val ignoreSymbols = cachedIgnoreSymbols
@@ -133,21 +136,23 @@ object SanelyConfiguredDecoder:
       val decodersArrayExpr = '{ Array(${Varargs(decoderExprs)}*) }
 
       '{
+        val _typeName = $sumTypeName
         new Decoder[S]:
-          private val _transformedLabels: Set[String] = $directLabelsExpr.map(l => $conf.transformConstructorNames(l)).toSet
+          private val _allTransformedLabels: Array[String] = $directLabelsExpr.map(l => $conf.transformConstructorNames(l)).toArray
+          private val _transformedLabels: Set[String] = _allTransformedLabels.toSet
           private val _labels = $allLabelsExpr
           private lazy val _decoders = $decodersArrayExpr
           private val _isSubTrait = $isSubTraitExpr
           def apply(c: HCursor): Decoder.Result[S] =
-            SanelyRuntime.extractSumTypeInfo(c, $conf.discriminator, _transformedLabels, $conf.strictDecoding) match
+            SanelyRuntime.extractSumTypeInfo(c, $conf.discriminator, _transformedLabels, $conf.strictDecoding, _typeName, _allTransformedLabels) match
               case Left(err) => Left(err)
               case Right(pair) =>
-                SanelyRuntime.decodeSumConfigured(c, pair._1, pair._2, _labels, _decoders, _isSubTrait, $conf.transformConstructorNames, $conf.discriminator)
+                SanelyRuntime.decodeSumConfigured(c, pair._1, pair._2, _labels, _decoders, _isSubTrait, $conf.transformConstructorNames, $conf.discriminator, _typeName)
           override def decodeAccumulating(c: HCursor): Decoder.AccumulatingResult[S] =
-            SanelyRuntime.extractSumTypeInfo(c, $conf.discriminator, _transformedLabels, $conf.strictDecoding) match
+            SanelyRuntime.extractSumTypeInfo(c, $conf.discriminator, _transformedLabels, $conf.strictDecoding, _typeName, _allTransformedLabels) match
               case Left(err) => cats.data.Validated.invalidNel(err)
               case Right(pair) =>
-                SanelyRuntime.decodeSumConfiguredAccumulating(c, pair._1, pair._2, _labels, _decoders, _isSubTrait, $conf.transformConstructorNames, $conf.discriminator)
+                SanelyRuntime.decodeSumConfiguredAccumulating(c, pair._1, pair._2, _labels, _decoders, _isSubTrait, $conf.transformConstructorNames, $conf.discriminator, _typeName)
       }
 
     private def resolveFields[Types: Type, Labels: Type](
@@ -282,6 +287,22 @@ object SanelyConfiguredDecoder:
       }
 
     private def resolvePrimDecoder(tpe: TypeRepr): Option[Expr[Decoder[?]]] =
+      tpe match
+        case ConstantType(StringConstant(s)) =>
+          return Some('{ Decoder.decodeString.emap(v => if v == ${Expr(s)} then Right(v) else Left(${Expr(s"""String("$s")""")})) })
+        case ConstantType(IntConstant(i)) =>
+          return Some('{ Decoder.decodeInt.emap(v => if v == ${Expr(i)} then Right(v) else Left(${Expr(s"Int($i)")})) })
+        case ConstantType(LongConstant(l)) =>
+          return Some('{ Decoder.decodeLong.emap(v => if v == ${Expr(l)} then Right(v) else Left(${Expr(s"Long($l)")})) })
+        case ConstantType(DoubleConstant(d)) =>
+          return Some('{ Decoder.decodeDouble.emap(v => if java.lang.Double.compare(v, ${Expr(d)}) == 0 then Right(v) else Left(${Expr(s"Double($d)")})) })
+        case ConstantType(FloatConstant(f)) =>
+          return Some('{ Decoder.decodeFloat.emap(v => if java.lang.Float.compare(v, ${Expr(f)}) == 0 then Right(v) else Left(${Expr(s"Float($f)")})) })
+        case ConstantType(BooleanConstant(b)) =>
+          return Some('{ Decoder.decodeBoolean.emap(v => if v == ${Expr(b)} then Right(v) else Left(${Expr(s"Boolean($b)")})) })
+        case ConstantType(CharConstant(ch)) =>
+          return Some('{ Decoder.decodeChar.emap(v => if v == ${Expr(ch)} then Right(v) else Left(${Expr(s"Char($ch)")})) })
+        case _ => ()
       if tpe =:= TypeRepr.of[String] then Some('{ Decoder.decodeString })
       else if tpe =:= TypeRepr.of[Int] then Some('{ Decoder.decodeInt })
       else if tpe =:= TypeRepr.of[Long] then Some('{ Decoder.decodeLong })

--- a/sanely/src/sanely/SanelyConfiguredEncoder.scala
+++ b/sanely/src/sanely/SanelyConfiguredEncoder.scala
@@ -194,6 +194,22 @@ object SanelyConfiguredEncoder:
       }
 
     private def resolvePrimEncoder(tpe: TypeRepr): Option[Expr[Encoder[?]]] =
+      tpe match
+        case ConstantType(StringConstant(s)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromString(${Expr(s)})) })
+        case ConstantType(IntConstant(i)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromInt(${Expr(i)})) })
+        case ConstantType(LongConstant(l)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromLong(${Expr(l)})) })
+        case ConstantType(DoubleConstant(d)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromDoubleOrNull(${Expr(d)})) })
+        case ConstantType(FloatConstant(f)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromFloatOrNull(${Expr(f)})) })
+        case ConstantType(BooleanConstant(b)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromBoolean(${Expr(b)})) })
+        case ConstantType(CharConstant(ch)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromString(${Expr(ch.toString)})) })
+        case _ => ()
       if tpe =:= TypeRepr.of[String] then Some('{ Encoder.encodeString })
       else if tpe =:= TypeRepr.of[Int] then Some('{ Encoder.encodeInt })
       else if tpe =:= TypeRepr.of[Long] then Some('{ Encoder.encodeLong })

--- a/sanely/src/sanely/SanelyDecoder.scala
+++ b/sanely/src/sanely/SanelyDecoder.scala
@@ -214,6 +214,22 @@ object SanelyDecoder:
       }
 
     private def resolvePrimDecoder(tpe: TypeRepr): Option[Expr[Decoder[?]]] =
+      tpe match
+        case ConstantType(StringConstant(s)) =>
+          return Some('{ Decoder.decodeString.emap(v => if v == ${Expr(s)} then Right(v) else Left(${Expr(s"""String("$s")""")})) })
+        case ConstantType(IntConstant(i)) =>
+          return Some('{ Decoder.decodeInt.emap(v => if v == ${Expr(i)} then Right(v) else Left(${Expr(s"Int($i)")})) })
+        case ConstantType(LongConstant(l)) =>
+          return Some('{ Decoder.decodeLong.emap(v => if v == ${Expr(l)} then Right(v) else Left(${Expr(s"Long($l)")})) })
+        case ConstantType(DoubleConstant(d)) =>
+          return Some('{ Decoder.decodeDouble.emap(v => if java.lang.Double.compare(v, ${Expr(d)}) == 0 then Right(v) else Left(${Expr(s"Double($d)")})) })
+        case ConstantType(FloatConstant(f)) =>
+          return Some('{ Decoder.decodeFloat.emap(v => if java.lang.Float.compare(v, ${Expr(f)}) == 0 then Right(v) else Left(${Expr(s"Float($f)")})) })
+        case ConstantType(BooleanConstant(b)) =>
+          return Some('{ Decoder.decodeBoolean.emap(v => if v == ${Expr(b)} then Right(v) else Left(${Expr(s"Boolean($b)")})) })
+        case ConstantType(CharConstant(ch)) =>
+          return Some('{ Decoder.decodeChar.emap(v => if v == ${Expr(ch)} then Right(v) else Left(${Expr(s"Char($ch)")})) })
+        case _ => ()
       if tpe =:= TypeRepr.of[String] then Some('{ Decoder.decodeString })
       else if tpe =:= TypeRepr.of[Int] then Some('{ Decoder.decodeInt })
       else if tpe =:= TypeRepr.of[Long] then Some('{ Decoder.decodeLong })

--- a/sanely/src/sanely/SanelyEncoder.scala
+++ b/sanely/src/sanely/SanelyEncoder.scala
@@ -196,6 +196,22 @@ object SanelyEncoder:
       }
 
     private def resolvePrimEncoder(tpe: TypeRepr): Option[Expr[Encoder[?]]] =
+      tpe match
+        case ConstantType(StringConstant(s)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromString(${Expr(s)})) })
+        case ConstantType(IntConstant(i)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromInt(${Expr(i)})) })
+        case ConstantType(LongConstant(l)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromLong(${Expr(l)})) })
+        case ConstantType(DoubleConstant(d)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromDoubleOrNull(${Expr(d)})) })
+        case ConstantType(FloatConstant(f)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromFloatOrNull(${Expr(f)})) })
+        case ConstantType(BooleanConstant(b)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromBoolean(${Expr(b)})) })
+        case ConstantType(CharConstant(ch)) =>
+          return Some('{ Encoder.instance[Any]((_: Any) => Json.fromString(${Expr(ch.toString)})) })
+        case _ => ()
       if tpe =:= TypeRepr.of[String] then Some('{ Encoder.encodeString })
       else if tpe =:= TypeRepr.of[Int] then Some('{ Encoder.encodeInt })
       else if tpe =:= TypeRepr.of[Long] then Some('{ Encoder.encodeLong })

--- a/sanely/src/sanely/SanelyEnumCodec.scala
+++ b/sanely/src/sanely/SanelyEnumCodec.scala
@@ -56,7 +56,7 @@ object SanelyEnumCodec:
       mirror: Expr[Mirror.SumOf[S]],
       cases: List[(String, Expr[S])]
     ): Expr[Codec[S]] =
-      val typeName = Expr(Type.show[S])
+      val typeName = Expr(TypeRepr.of[S].typeSymbol.name)
 
       // Deduplicate cases (diamond inheritance can produce the same singleton via multiple paths)
       val deduped = cases.distinctBy(_._1)

--- a/sanely/src/sanely/SanelyRuntime.scala
+++ b/sanely/src/sanely/SanelyRuntime.scala
@@ -2,6 +2,7 @@ package sanely
 
 import cats.data.{NonEmptyList, Validated}
 import io.circe.{ACursor, Decoder, DecodingFailure, Encoder, HCursor, Json, JsonObject}
+import io.circe.CursorOp.DownField
 
 /** Runtime utility methods called by macro-generated code.
   * Reduces generated AST size by moving common patterns out of inline expansions.
@@ -122,7 +123,8 @@ object SanelyRuntime:
   def decodeSumConfigured[S](
     c: HCursor, matchValue: String, decodeCursor: ACursor,
     labels: Array[String], decoders: Array[Decoder[Any]], isSubTrait: Array[Boolean],
-    transformConstructorNames: String => String, discriminator: Option[String]
+    transformConstructorNames: String => String, discriminator: Option[String],
+    typeName: String
   ): Decoder.Result[S] =
     // Try sub-traits first (they need to attempt decode on full cursor)
     // Then try direct variants (key equality match)
@@ -137,17 +139,18 @@ object SanelyRuntime:
         if matchValue == transformConstructorNames(labels(i)) then
           return decoders(i).tryDecode(decodeCursor).asInstanceOf[Decoder.Result[S]]
       i += 1
-    discriminator match
-      case Some(_) => Left(DecodingFailure("Unknown variant: " + matchValue, c.history))
-      case None    => Left(DecodingFailure("Unknown variant", c.history))
+    if matchValue.isEmpty then
+      Left(DecodingFailure(s"type $typeName: could not find matching key.", c.history))
+    else
+      Left(DecodingFailure(s"type $typeName has no class/object/case named '$matchValue'.", List(DownField(matchValue))))
 
   /** Validate strict decoding: reject unexpected fields in the JSON object. */
-  def checkStrictDecoding(c: HCursor, expectedKeys: Set[String]): Decoder.Result[Unit] =
+  def checkStrictDecoding(c: HCursor, expectedKeys: Set[String], typeName: String, validFieldNames: Array[String]): Decoder.Result[Unit] =
     c.keys match
       case Some(keys) =>
         val unexpected = keys.filterNot(expectedKeys.contains).toList
         if unexpected.nonEmpty then
-          Left(DecodingFailure(s"Unexpected field(s): ${unexpected.mkString(", ")}", c.history))
+          Left(DecodingFailure(s"Strict decoding $typeName - unexpected fields: ${unexpected.mkString(", ")}; valid fields: ${validFieldNames.mkString(", ")}.", c.history))
         else Right(())
       case None => Right(())
 
@@ -158,24 +161,35 @@ object SanelyRuntime:
     c: HCursor,
     discriminator: Option[String],
     transformedLabels: Set[String],
-    strictDecoding: Boolean
+    strictDecoding: Boolean,
+    typeName: String,
+    allTransformedLabels: Array[String]
   ): Either[DecodingFailure, (String, ACursor)] =
     discriminator match
       case Some(discField) =>
         c.downField(discField).as[String] match
           case Right(typeName) => Right((typeName, c))
-          case Left(_) => Left(DecodingFailure(s"Missing discriminator field '$discField'", c.history))
+          case Left(_) => Left(DecodingFailure(s"$typeName: could not find discriminator field '$discField' or its null.", List(DownField(discField))))
       case None =>
-        c.keys match
-          case Some(keys) =>
-            val keysList = keys.toList
-            if strictDecoding && keysList.size > 1 then
-              Left(DecodingFailure("Expected single-key JSON object for sum type", c.history))
-            else
-              val key = keysList.find(transformedLabels.contains).getOrElse("")
-              Right((key, c.downField(key)))
-          case None =>
-            Left(DecodingFailure("Expected JSON object for sum type", c.history))
+        if !c.value.isObject then
+          Left(DecodingFailure(DecodingFailure.Reason.WrongTypeExpectation("object", c.value), c.history))
+        else
+          c.keys match
+            case Some(keys) =>
+              val keysList = keys.toList
+              if strictDecoding && keysList.size > 1 then
+                Left(DecodingFailure(s"Strict decoding $typeName - expected a single key json object with one of: ${allTransformedLabels.mkString(", ")}.", c.history))
+              else
+                keysList.find(transformedLabels.contains) match
+                  case Some(key) => Right((key, c.downField(key)))
+                  case None =>
+                    val triedKey = keysList.headOption.getOrElse("")
+                    if triedKey.isEmpty then
+                      Left(DecodingFailure(s"type $typeName: empty JSON object.", c.history))
+                    else
+                      Left(DecodingFailure(s"type $typeName has no class/object/case named '$triedKey'.", List(DownField(triedKey))))
+            case None =>
+              Left(DecodingFailure(DecodingFailure.Reason.WrongTypeExpectation("object", c.value), c.history))
 
   /** Decode a field with default value support (for non-Option types).
     * When useDefaults is true and the field is missing or null, returns the default.
@@ -277,7 +291,8 @@ object SanelyRuntime:
   def decodeSumConfiguredAccumulating[S](
     c: HCursor, matchValue: String, decodeCursor: ACursor,
     labels: Array[String], decoders: Array[Decoder[Any]], isSubTrait: Array[Boolean],
-    transformConstructorNames: String => String, discriminator: Option[String]
+    transformConstructorNames: String => String, discriminator: Option[String],
+    typeName: String
   ): Decoder.AccumulatingResult[S] =
     var i = 0
     while i < labels.length do
@@ -289,9 +304,10 @@ object SanelyRuntime:
         if matchValue == transformConstructorNames(labels(i)) then
           return decoders(i).tryDecodeAccumulating(decodeCursor).asInstanceOf[Decoder.AccumulatingResult[S]]
       i += 1
-    discriminator match
-      case Some(_) => Validated.invalidNel(DecodingFailure("Unknown variant: " + matchValue, c.history))
-      case None    => Validated.invalidNel(DecodingFailure("Unknown variant", c.history))
+    if matchValue.isEmpty then
+      Validated.invalidNel(DecodingFailure(s"type $typeName: could not find matching key.", c.history))
+    else
+      Validated.invalidNel(DecodingFailure(s"type $typeName has no class/object/case named '$matchValue'.", List(DownField(matchValue))))
 
   /** Accumulating version of tryDecodeFieldWithDefault. */
   def tryDecodeFieldWithDefaultAccumulating[T](

--- a/sanely/test/src/sanely/SanelyAutoSuite.scala
+++ b/sanely/test/src/sanely/SanelyAutoSuite.scala
@@ -179,6 +179,12 @@ object ProductWithTaggedMember:
     summon[Encoder[String]].contramap(x => x: String)
   )
 
+// Literal type fields
+case class LiteralStringField(tag: "hello", value: Int)
+case class LiteralIntField(version: 42, name: String)
+case class LiteralBooleanField(active: true, data: String)
+case class LiteralLongField(id: 100L, label: String)
+
 // Codec derivation test type
 case class CodecTestProduct(a: Int, b: String)
 object CodecTestProduct:
@@ -828,6 +834,54 @@ object SanelyAutoSuite extends TestSuite:
       assert(json == Json.obj("a" -> Json.fromInt(1), "b" -> Json.fromString("hi")))
       val decoded = decode[SemiAlias](json.noSpaces)
       assert(decoded == Right(v))
+    }
+
+    // --- Literal type fields ---
+
+    test("Literal string type field round-trip") {
+      val v = LiteralStringField("hello", 99)
+      val json = v.asJson
+      val expected = Json.obj("tag" -> Json.fromString("hello"), "value" -> Json.fromInt(99))
+      assert(json == expected)
+      val decoded = decode[LiteralStringField](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Literal int type field round-trip") {
+      val v = LiteralIntField(42, "test")
+      val json = v.asJson
+      val expected = Json.obj("version" -> Json.fromInt(42), "name" -> Json.fromString("test"))
+      assert(json == expected)
+      val decoded = decode[LiteralIntField](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Literal boolean type field round-trip") {
+      val v = LiteralBooleanField(true, "on")
+      val json = v.asJson
+      val expected = Json.obj("active" -> Json.fromBoolean(true), "data" -> Json.fromString("on"))
+      assert(json == expected)
+      val decoded = decode[LiteralBooleanField](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Literal long type field round-trip") {
+      val v = LiteralLongField(100L, "item")
+      val json = v.asJson
+      val expected = Json.obj("id" -> Json.fromLong(100L), "label" -> Json.fromString("item"))
+      assert(json == expected)
+      val decoded = decode[LiteralLongField](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Literal string decoder rejects wrong value") {
+      val result = decode[LiteralStringField]("""{"tag":"world","value":99}""")
+      assert(result.isLeft)
+    }
+
+    test("Literal int decoder rejects wrong value") {
+      val result = decode[LiteralIntField]("""{"version":99,"name":"test"}""")
+      assert(result.isLeft)
     }
 
     test("io.circe.generic.semiauto.deriveCodec works") {


### PR DESCRIPTION
## Summary
- Add all missing circe test cases to compat suite (253 → 318 tests), covering auto/semiauto/configured/enum derivation gaps identified by line-by-line comparison with circe's test suites
- Update error messages in `SanelyRuntime` and `SanelyConfiguredDecoder` to match circe's exact `DecodingFailure` format (`WrongTypeExpectation`, typed messages, `DownField` paths)
- Add literal type (`ConstantType`) support for encoder/decoder macro resolution
- Add literal type field round-trip and rejection tests

## Test plan
- [x] `./mill compat.test` — 318 tests passing (was 253)
- [x] `./mill sanely.jvm.test` — 63 tests passing
- [x] `./mill sanely.js.test` — 122 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)