### PR TITLE
test: add Either and Tuple field tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,8 +17,8 @@ Mill 1.1.2. Run from repo root:
 ```bash
 ./mill sanely.jvm.compile       # compile (JVM)
 ./mill sanely.js.compile        # compile (Scala.js)
-./mill sanely.jvm.test          # unit tests - JVM (124 tests, utest)
-./mill sanely.js.test           # unit tests - Scala.js (124 tests, utest)
+./mill sanely.jvm.test          # unit tests - JVM (129 tests, utest)
+./mill sanely.js.test           # unit tests - Scala.js (129 tests, utest)
 ./mill compat.test              # circe compat tests (318 tests, munit + discipline)
 ./mill demo.run                 # run demo
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Drop-in replacement for circe's auto/semi-auto/configured derivation for Scala 3. Faster compile times. No Shapeless. No circe-generic.
 
-**Scala 3.8.2+ | JVM + Scala.js | ✅ 442 tests**
+**Scala 3.8.2+ | JVM + Scala.js | ✅ 447 tests**
 
 ## Motivation
 
@@ -34,7 +34,7 @@ We maintain two layers of tests:
 
 **✅ 318 compatibility tests** (munit + discipline) ported directly from circe's own test suite — `DerivesSuite`, `SemiautoDerivationSuite`, and `ConfiguredDerivesSuite`. These use circe's `CodecTests` which runs property-based checks: roundtrip consistency, accumulating decoder consistency, and `Codec.from` consistency. Same test types, same Arbitrary instances, same assertions. If circe's tests pass with circe-generic, they pass with circe-sanely-auto.
 
-**✅ 442 tests total**, all green.
+**✅ 447 tests total**, all green.
 
 ## Features
 
@@ -278,7 +278,7 @@ This entire library — every macro, every test, every line of build config, and
 - [x] **Improved error messages** — when derivation fails, report what was tried and why each approach failed (builtin miss, summonIgnoring miss, no Mirror) instead of a single generic message.
 - [x] **Derive key encoders/decoders inline for built-in types** — resolve `KeyEncoder`/`KeyDecoder` directly for `String`, `Int`, `Long`, `Double`, `Short`, `Byte` instead of summoning via implicit search. Extends container+builtin composition from `Map[String, V]` to `Map[K, V]` for all builtin key types.
 - [x] **Enable `-Werror` in CI** — all modules compile with `-Werror` (Scala 3's replacement for `-Xfatal-warnings`), ensuring macro-generated code produces zero compiler warnings. Users with strict linting never need `@nowarn` annotations for code they didn't write.
-- [ ] **Test coverage gaps** — add tests for: generic context derivation (type params not yet known), semiauto `derived` inside companion not causing infinite recursion, Tuple/Either fields.
+- [x] **Test coverage gaps** — added tests for: generic context derivation (type params not yet known), semiauto `derived` inside companion not causing infinite recursion, Tuple/Either fields.
 
 ## Contributing
 

--- a/sanely/test/src/sanely/SanelyAutoSuite.scala
+++ b/sanely/test/src/sanely/SanelyAutoSuite.scala
@@ -200,6 +200,12 @@ case object CodecObj extends CodecTestAdt
 object CodecTestAdt:
   given Codec.AsObject[CodecTestAdt] = SanelyCodec.derived
 
+// Phase 10 types — Either and Tuple fields
+case class WithEither(label: String, value: Either[String, Int])
+case class WithTuple2(name: String, pair: (Int, String))
+case class WithTuple3(data: (Boolean, Int, String))
+case class WithTuple1(wrapped: Tuple1[Double])
+
 // Phase 9 types — semiauto (explicit derived) in companion objects
 case class SemiAutoProduct(x: Int, y: String)
 object SemiAutoProduct:
@@ -573,6 +579,68 @@ object SanelyAutoSuite extends TestSuite:
       assert(decode[Adt1]("""{"extraField":true,"Adt1Class1":{"int":3}}""") == expected)
       assert(decode[Adt1]("""{"extraField":true,"extraField2":15,"Adt1Class1":{"int":3}}""") == expected)
       assert(decode[Adt1]("""{"Adt1Class1":{"int":3},"extraField":true}""") == expected)
+    }
+
+    // --- Phase 10: Either and Tuple Fields ---
+
+    test("Either[String, Int] field round-trip (Right)") {
+      import io.circe.disjunctionCodecs.given
+      val v = WithEither("test", Right(42))
+      val json = v.asJson
+      val expected = Json.obj(
+        "label" -> Json.fromString("test"),
+        "value" -> Json.obj("Right" -> Json.fromInt(42))
+      )
+      assert(json == expected)
+      val decoded = decode[WithEither](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Either[String, Int] field round-trip (Left)") {
+      import io.circe.disjunctionCodecs.given
+      val v = WithEither("err", Left("oops"))
+      val json = v.asJson
+      val expected = Json.obj(
+        "label" -> Json.fromString("err"),
+        "value" -> Json.obj("Left" -> Json.fromString("oops"))
+      )
+      assert(json == expected)
+      val decoded = decode[WithEither](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Tuple2 field round-trip") {
+      val v = WithTuple2("pair", (1, "hello"))
+      val json = v.asJson
+      val expected = Json.obj(
+        "name" -> Json.fromString("pair"),
+        "pair" -> Json.arr(Json.fromInt(1), Json.fromString("hello"))
+      )
+      assert(json == expected)
+      val decoded = decode[WithTuple2](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Tuple3 field round-trip") {
+      val v = WithTuple3((true, 42, "x"))
+      val json = v.asJson
+      val expected = Json.obj(
+        "data" -> Json.arr(Json.fromBoolean(true), Json.fromInt(42), Json.fromString("x"))
+      )
+      assert(json == expected)
+      val decoded = decode[WithTuple3](json.noSpaces)
+      assert(decoded == Right(v))
+    }
+
+    test("Tuple1 field round-trip") {
+      val v = WithTuple1(Tuple1(3.14))
+      val json = v.asJson
+      val expected = Json.obj(
+        "wrapped" -> Json.arr(Json.fromDoubleOrNull(3.14))
+      )
+      assert(json == expected)
+      val decoded = decode[WithTuple1](json.noSpaces)
+      assert(decoded == Right(v))
     }
 
     // --- Phase 9: Semiauto API ---


### PR DESCRIPTION
## Summary
- Add 5 new unit tests for `Either` and `Tuple` fields in auto-derived case classes
  - `Either[String, Int]` round-trip (Right and Left, via `disjunctionCodecs`)
  - `Tuple1[Double]`, `(Int, String)`, `(Boolean, Int, String)` round-trips
- Check off the last roadmap item: **Test coverage gaps** (all 3 sub-items now covered)
- Update test counts: 129 unit tests, 447 total

## Test plan
- [x] `./mill sanely.jvm.test` — 129 passed
- [x] `./mill sanely.js.test` — 129 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)