### PR TITLE
docs: show best-of-both usage — jsoniter for reading, circe for writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,25 @@ mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.38.9"
 mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-circe:2.38.9"
 ```
 
-```diff
-  // Before: circe's jawn parser
-- import io.circe.jawn._
-- val result = decodeByteArray[MyType](jsonBytes)
+Use jsoniter-scala's parser for reading (1.5x faster) and circe's default printer for writing (already optimal):
 
-  // After: jsoniter-scala's parser, same circe Decoder
-+ import com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec.given
-+ import com.github.plokhotnyuk.jsoniter_scala.core._
-+ val result = readFromArray[io.circe.Json](jsonBytes).as[MyType]
+```scala
+import io.circe.*
+import io.circe.syntax.*
+import sanely.auto.given  // fast compile-time derivation
+import com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec.given
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+
+case class User(name: String, age: Int)
+
+// Reading: use jsoniter-scala's parser (1.5x faster than jawn)
+val user = readFromArray[Json](jsonBytes).as[User].toOption.get
+
+// Writing: use circe's printer (faster than jsoniter bridge for writing)
+val bytes = Printer.noSpaces.print(user.asJson).getBytes("UTF-8")
 ```
 
-Your `Encoder`/`Decoder` instances (whether from sanely-auto, semi-auto, or hand-written) are untouched — only the parse/print layer changes.
+Your `Encoder`/`Decoder` instances (whether from sanely-auto, semi-auto, or hand-written) are untouched — only the reading parser changes.
 
 **Runtime benchmark** (1.2 KB JSON payload, M3 Max, JDK 25):
 
@@ -65,7 +72,7 @@ Your `Encoder`/`Decoder` instances (whether from sanely-auto, semi-auto, or hand
 | **circe + jsoniter parser** | 235,963 | **1.5x** | 135,512 | 0.9x |
 | **jsoniter-scala native** | 796,505 | **5.1x** | 739,119 | **4.9x** |
 
-The combo gives a **1.5x reading speedup** within the circe ecosystem. Writing doesn't benefit because the bottleneck is circe's `Encoder` building the `Json` AST, not the serialization step. For maximum runtime performance, use jsoniter-scala directly.
+The combo gives a **1.5x reading speedup** within the circe ecosystem — swap two imports and decoding gets 50% faster. For writing, stick with circe's default `Printer` — it's already optimized for circe's own `Json` AST and slightly outperforms the jsoniter bridge. For maximum runtime performance in both directions, use jsoniter-scala directly.
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- Replace diff-style example with a complete code snippet showing the optimal combo
- jsoniter-scala parser for reading (1.5x faster than jawn)
- circe's default `Printer` for writing (faster than jsoniter bridge for writing)
- Clarify that the combo benefits reading only, and writing should use circe's printer

## Test plan
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)