### PR TITLE
feat: add /benchmark slash command for PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,26 +18,82 @@ on:
       runtime_iterations:
         description: "Runtime benchmark measurement iterations"
         default: "5"
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: benchmark
+  group: benchmark-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 env:
   COMPILE_RUNS: ${{ inputs.compile_runs || '5' }}
   RUNTIME_WARMUP: ${{ inputs.runtime_warmup || '5' }}
   RUNTIME_ITERATIONS: ${{ inputs.runtime_iterations || '5' }}
-  BENCHMARK_REF: ${{ github.event.workflow_run.head_sha || github.sha }}
 
 jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+    # Run for: manual dispatch, successful release, or /benchmark comment from collaborators
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/benchmark') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    permissions:
+      pull-requests: read
+    outputs:
+      ref: ${{ steps.config.outputs.ref }}
+      version: ${{ steps.config.outputs.version }}
+      mode: ${{ steps.config.outputs.mode }}
+      pr_number: ${{ steps.config.outputs.pr_number }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure
+        id: config
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            PR="${{ github.event.issue.number }}"
+            REF=$(gh pr view "$PR" --json headRefOid --jq '.headRefOid')
+            echo "ref=$REF" >> "$GITHUB_OUTPUT"
+            echo "version=PR #$PR" >> "$GITHUB_OUTPUT"
+            echo "mode=pr" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$PR" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "ref=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+            echo "version=${{ github.event.workflow_run.head_branch }}" >> "$GITHUB_OUTPUT"
+            echo "mode=release" >> "$GITHUB_OUTPUT"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          else
+            REF="${{ github.sha }}"
+            VERSION="${{ inputs.version }}"
+            if [ -z "$VERSION" ]; then
+              VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo dev)
+            fi
+            echo "ref=$REF" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "mode=release" >> "$GITHUB_OUTPUT"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: React to comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions -f content=rocket
+
   compile-auto:
     name: compile-auto
+    needs: setup
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.BENCHMARK_REF }}
+          ref: ${{ needs.setup.outputs.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -51,12 +107,12 @@ jobs:
 
   compile-configured:
     name: compile-configured
+    needs: setup
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.BENCHMARK_REF }}
+          ref: ${{ needs.setup.outputs.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -70,12 +126,12 @@ jobs:
 
   runtime:
     name: runtime
+    needs: setup
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.BENCHMARK_REF }}
+          ref: ${{ needs.setup.outputs.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -89,12 +145,12 @@ jobs:
 
   macro-profile-auto:
     name: macro-profile-auto
+    needs: setup
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.BENCHMARK_REF }}
+          ref: ${{ needs.setup.outputs.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -112,12 +168,12 @@ jobs:
 
   macro-profile-configured:
     name: macro-profile-configured
+    needs: setup
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.BENCHMARK_REF }}
+          ref: ${{ needs.setup.outputs.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -133,9 +189,11 @@ jobs:
           name: macro-profile-configured
           path: macro-profile-configured.txt
 
+  # ── Post-release: accumulate results in BENCHMARK.md ──
   update-benchmark-md:
     name: Update BENCHMARK.md
-    needs: [compile-auto, compile-configured, runtime, macro-profile-auto, macro-profile-configured]
+    needs: [setup, compile-auto, compile-configured, runtime, macro-profile-auto, macro-profile-configured]
+    if: needs.setup.outputs.mode == 'release'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -150,22 +208,10 @@ jobs:
         with:
           path: results
 
-      - name: Determine version
-        id: version
-        run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            TAG="${{ inputs.version }}"
-          elif [ -n "${{ github.event.workflow_run.head_branch }}" ]; then
-            TAG="${{ github.event.workflow_run.head_branch }}"
-          else
-            TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo dev)"
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
       - name: Build new section
         run: |
-          VERSION="${{ steps.version.outputs.tag }}"
-          SHA="${{ env.BENCHMARK_REF }}"
+          VERSION="${{ needs.setup.outputs.version }}"
+          SHA="${{ needs.setup.outputs.ref }}"
           DATE="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
 
           {
@@ -229,7 +275,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="${{ steps.version.outputs.tag }}"
+          VERSION="${{ needs.setup.outputs.version }}"
           BRANCH="benchmark/$VERSION"
 
           git config user.name "github-actions[bot]"
@@ -240,7 +286,6 @@ jobs:
           git commit -m "docs: add benchmark results for $VERSION"
           git push -f -u origin "$BRANCH"
 
-          # Create PR only if one doesn't already exist for this branch
           EXISTING=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
           if [ -n "$EXISTING" ]; then
             echo "PR #$EXISTING already exists — updated via force push"
@@ -261,3 +306,72 @@ jobs:
               --body-file /tmp/pr-body.md \
               --base main
           fi
+
+  # ── PR comment: post results on the pull request ──
+  post-pr-comment:
+    name: Post PR comment
+    needs: [setup, compile-auto, compile-configured, runtime, macro-profile-auto, macro-profile-configured]
+    if: needs.setup.outputs.mode == 'pr'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download all results
+        uses: actions/download-artifact@v4
+        with:
+          path: results
+
+      - name: Post comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SHA="${{ needs.setup.outputs.ref }}"
+          PR="${{ needs.setup.outputs.pr_number }}"
+
+          {
+            echo "## Benchmark Results"
+            echo ""
+            echo "**SHA:** \`${SHA:0:7}\` | **Date:** $(date -u '+%Y-%m-%d %H:%M:%S UTC') | **Run:** [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            echo ""
+            echo "<details>"
+            echo "<summary>Compile Time — Auto Derivation</summary>"
+            echo ""
+            echo '```'
+            cat results/compile-auto/*.txt
+            echo '```'
+            echo "</details>"
+            echo ""
+            echo "<details>"
+            echo "<summary>Compile Time — Configured Derivation</summary>"
+            echo ""
+            echo '```'
+            cat results/compile-configured/*.txt
+            echo '```'
+            echo "</details>"
+            echo ""
+            echo "<details>"
+            echo "<summary>Runtime Performance</summary>"
+            echo ""
+            echo '```'
+            cat results/runtime/*.txt
+            echo '```'
+            echo "</details>"
+            echo ""
+            echo "<details>"
+            echo "<summary>Macro Profile — Auto</summary>"
+            echo ""
+            echo '```'
+            cat results/macro-profile-auto/*.txt
+            echo '```'
+            echo "</details>"
+            echo ""
+            echo "<details>"
+            echo "<summary>Macro Profile — Configured</summary>"
+            echo ""
+            echo '```'
+            cat results/macro-profile-configured/*.txt
+            echo '```'
+            echo "</details>"
+          } > /tmp/comment-body.md
+
+          gh pr comment "$PR" --body-file /tmp/comment-body.md

--- a/README.md
+++ b/README.md
@@ -369,6 +369,24 @@ python3 .claude/skills/macro-profile/scripts/analyze_profile.py /tmp/profile.txt
 
 `summonIgnoring` (the compiler's implicit search) dominates auto derivation at 49%. Builtin short-circuiting and container composition resolve ~706 type lookups without calling `summonIgnoring` at all. Sub-trait detection uses cached `summonedKeys` (O(1) set lookup) instead of re-calling `summonIgnoring`, reducing per-call time from 0.29ms to 0.04ms in configured derivation (-86%). For configured derivation, single-pass codec derivation halved the macro expansion count from 460 (separate CfgEncoder + CfgDecoder) to 230 (unified CfgCodec), while sharing one cache and one Mirror summon per type. The `summonIgnoring` call count stays at 294 (both encoder and decoder must still be summoned), but sub-trait detection halved from 138 to 69 calls. The intra-expansion cache achieves a 75% hit rate in auto derivation, avoiding redundant derivations for repeated types within a single macro call. Factory method consolidation reduced macro framework overhead from 359ms to 231ms (-36%) by generating simpler factory calls instead of full anonymous class definitions. The remaining 231ms is intrinsic to Scala 3's quote reflection (tuple type recursion at ~2ms/field, AST construction, quote splicing).
 
+## Automated benchmarks
+
+Every release automatically triggers a [benchmark workflow](.github/workflows/benchmark.yml) that runs five benchmarks in parallel on `ubuntu-latest`:
+
+| Job | What it measures |
+|---|---|
+| **compile-auto** | Compile time — auto derivation (~300 types), sanely vs circe-generic |
+| **compile-configured** | Compile time — configured derivation (~230 types), sanely vs circe-core |
+| **runtime** | Encoding/decoding throughput — circe-jawn vs circe+jsoniter vs jsoniter-scala |
+| **macro-profile-auto** | Macro expansion profiling — auto derivation (308 expansions) |
+| **macro-profile-configured** | Macro expansion profiling — configured derivation (230 expansions) |
+
+Results accumulate in [`BENCHMARK.md`](BENCHMARK.md) — each release adds a new section so you can track performance across versions. The workflow opens a PR with the updated results after each run.
+
+**Benchmarking a PR:** Maintainers can comment `/benchmark` on any pull request to run the full benchmark suite against that PR's code. Results are posted as a collapsible comment on the PR. Only repository collaborators can trigger this.
+
+You can also trigger it manually from the Actions tab with custom parameters (number of runs, warmup iterations, etc.).
+
 ## Building
 
 Requires [Mill](https://mill-build.org/) 1.1.2+.


### PR DESCRIPTION
## Summary
- Add `/benchmark` slash command — maintainers comment `/benchmark` on any PR to run the full benchmark suite against that PR's code
- Results posted as a collapsible comment on the PR (compile times, runtime, macro profiles)
- Only OWNER/MEMBER/COLLABORATOR can trigger (prevents abuse)
- Adds rocket reaction to acknowledge the command
- Add "Automated benchmarks" section to README documenting the workflow and slash command
- Release/manual dispatch behavior unchanged

## How it works
1. Collaborator comments `/benchmark` on a PR
2. Setup job validates permissions, extracts PR head SHA
3. All 5 benchmarks run in parallel against the PR's code
4. Results posted as a single comment with `<details>` sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)