### PR TITLE
chore: add CLAUDE.local.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 .idea/
 .local/
 __pycache__/
+CLAUDE.local.md


### PR DESCRIPTION
## Summary
- Add `CLAUDE.local.md` to `.gitignore` so contributors can have private local Claude instructions without committing them to the repo

## Test plan
- [x] Verify `CLAUDE.local.md` is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)