### PR TITLE
refactor: use hyperfine for compile-time benchmarks

### DIFF
--- a/.claude/skills/runtime-benchmark/SKILL.md
+++ b/.claude/skills/runtime-benchmark/SKILL.md
@@ -148,9 +148,9 @@ Before any release, run these in order to catch both compile-time and runtime re
 ./mill compat.jvm.test
 ./mill compat.js.test
 
-# 2. Compile-time benchmarks (derivation speed)
-bash bench.sh 5                    # auto derivation (~300 types)
-bash bench.sh --configured 5      # configured derivation (~230 types)
+# 2. Compile-time benchmarks (derivation speed, requires: brew install hyperfine)
+bash bench.sh 5                    # auto derivation via hyperfine (~300 types)
+bash bench.sh --configured 5      # configured derivation via hyperfine (~230 types)
 
 # 3. Runtime benchmark (encoding/decoding throughput)
 bash bench-runtime.sh 5 5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,11 @@ bash test-zinc.sh               # zinc incremental recompilation tests (5 scenar
 
 ### Benchmarks
 
+Compile-time benchmarks use [hyperfine](https://github.com/sharkdp/hyperfine) (`brew install hyperfine`).
+
 ```bash
-bash bench.sh 5                 # auto derivation timed comparison (~300 types)
-bash bench.sh --configured 5    # configured derivation timed comparison (~230 types)
+bash bench.sh 5                 # auto derivation via hyperfine (~300 types)
+bash bench.sh --configured 5    # configured derivation via hyperfine (~230 types)
 ./mill benchmark.sanely.compile # compile benchmark: our library (auto)
 ./mill benchmark.generic.compile # compile benchmark: circe-generic (auto)
 ./mill benchmark-configured.sanely.compile   # compile benchmark: our library (configured)

--- a/README.md
+++ b/README.md
@@ -210,14 +210,25 @@ bash bench.sh --configured 5 # configured derivation (~230 types)
 
 | Suite | circe-sanely-auto | circe baseline | Speedup |
 |---|---|---|---|
-| **Auto derivation** (~300 types) | **2.86s** | 6.43s (circe-generic) | **2.25x** |
-| **Configured derivation** (~230 types) | **1.45s** | 2.70s (circe-core) | **1.86x** |
+| **Auto derivation** (~300 types) | **2.75s** ± 0.50s | 6.32s ± 0.14s (circe-generic) | **2.30x** ± 0.42 |
+| **Configured derivation** (~230 types) | **1.45s** ± 0.04s | 2.66s ± 0.03s (circe-core) | **1.83x** ± 0.06 |
+
+### Benchmark method
+
+Measurements use [hyperfine](https://github.com/sharkdp/hyperfine) for statistical rigor. The harness (`bench.sh`) works as follows:
+
+1. **Dependency warm-up** — `sanely.jvm` (and the configured compat shim for `--configured`) are compiled via the Mill daemon before any timed run, so dependency compilation is never included in the measurement.
+2. **`--warmup 1`** — one untimed warmup round ensures the Mill daemon JVM is JIT-warm and OS file caches are hot.
+3. **`--prepare 'rm -rf out/…'`** — before each timed run, the benchmark module's output is deleted so every measurement is a clean recompilation of only the benchmark sources.
+4. **`--runs N`** — N timed runs per command. Hyperfine randomizes execution order across runs to prevent systematic ordering bias, and reports mean ± σ with min/max range.
+
+This measures what users actually experience: warm-daemon, incremental-dependency compilation of the benchmark types only.
 
 ### Why the difference?
 
-**Auto derivation** (2.25x faster): With `import io.circe.generic.auto.given`, the compiler must implicitly search for and synthesize codecs at every use site — each nested type triggers another round of implicit resolution. Sanely avoids this by deriving everything in a single macro expansion.
+**Auto derivation** (2.30x faster): With `import io.circe.generic.auto.given`, the compiler must implicitly search for and synthesize codecs at every use site — each nested type triggers another round of implicit resolution. Sanely avoids this by deriving everything in a single macro expansion.
 
-**Configured derivation** (1.86x faster): Even though configured derivation uses explicit semi-auto calls (`deriveConfiguredCodec` in each companion object) with no implicit search chain to eliminate, our optimizations reduce both macro expansion time and generated AST size.
+**Configured derivation** (1.83x faster): Even though configured derivation uses explicit semi-auto calls (`deriveConfiguredCodec` in each companion object) with no implicit search chain to eliminate, our optimizations reduce both macro expansion time and generated AST size.
 
 Six optimizations drive this:
 
@@ -382,6 +393,8 @@ Every release automatically triggers a [benchmark workflow](.github/workflows/be
 | **macro-profile-configured** | Macro expansion profiling — configured derivation (230 expansions) |
 
 Results accumulate in [`BENCHMARK.md`](BENCHMARK.md) — each release adds a new section so you can track performance across versions. The workflow opens a PR with the updated results after each run.
+
+Compile-time benchmark entries include hyperfine's statistical output (mean ± σ, min, max) so you can see exactly how the numbers were produced.
 
 **Benchmarking a PR:** Maintainers can comment `/benchmark` on any pull request to run the full benchmark suite against that PR's code. Results are posted as a collapsible comment on the PR. Only repository collaborators can trigger this.
 

--- a/bench.sh
+++ b/bench.sh
@@ -12,24 +12,56 @@ for arg in "$@"; do
 done
 N=${N:-5}
 
-echo "Compile-time benchmark: circe-sanely-auto vs circe-generic (N=$N)"
+if ! [[ "$N" =~ ^[0-9]+$ ]] || [ "$N" -lt 1 ]; then
+  echo "Expected a positive integer run count, got: $N" >&2
+  exit 1
+fi
+
+if ! command -v hyperfine &>/dev/null; then
+  echo "hyperfine is required: brew install hyperfine" >&2
+  exit 1
+fi
+
+case "$BENCH_TYPE" in
+  benchmark)
+    BASELINE_LABEL="circe-generic"
+    PREP_TARGETS=(
+      "sanely.jvm.compile"
+    )
+    ;;
+  benchmark-configured)
+    BASELINE_LABEL="circe-core configured derivation"
+    PREP_TARGETS=(
+      "sanely.jvm.compile"
+      "benchmark-configured.generic-compat.compile"
+    )
+    ;;
+  *)
+    echo "Unknown benchmark suite: $BENCH_TYPE" >&2
+    exit 1
+    ;;
+esac
+
+echo "Compile-time benchmark: circe-sanely-auto vs $BASELINE_LABEL (N=$N)"
 echo "Benchmark suite: $BENCH_TYPE"
+echo "Method: Mill daemon, hyperfine with --warmup 1, --runs $N"
 echo "================================================================"
 
-for module in sanely generic; do
-  times=()
-  for i in $(seq 1 "$N"); do
-    rm -rf "out/$BENCH_TYPE/$module"
-    start=$(python3 -c 'import time; print(time.time())')
-    ./mill "$BENCH_TYPE.$module.compile" 2>/dev/null 1>/dev/null
-    end=$(python3 -c 'import time; print(time.time())')
-    elapsed=$(python3 -c "print(f'{$end - $start:.2f}')")
-    times+=("$elapsed")
-    echo "  $BENCH_TYPE.$module run $i: ${elapsed}s"
-  done
-
-  # compute median
-  median=$(printf '%s\n' "${times[@]}" | sort -n | awk -v n="$N" 'NR==int((n+1)/2){print}')
-  echo "$BENCH_TYPE.$module median: ${median}s (of ${times[*]})"
-  echo ""
+# Warm up Mill daemon + compile source dependencies (untimed)
+echo "Warming up Mill daemon and source dependencies..."
+for target in "${PREP_TARGETS[@]}"; do
+  ./mill "$target" >/dev/null 2>/dev/null
 done
+
+echo "Running hyperfine benchmark..."
+echo ""
+
+hyperfine \
+  --warmup 1 \
+  --runs "$N" \
+  --prepare "rm -rf out/$BENCH_TYPE/sanely" \
+  --command-name "$BENCH_TYPE.sanely" \
+  "./mill $BENCH_TYPE.sanely.compile" \
+  --prepare "rm -rf out/$BENCH_TYPE/generic" \
+  --command-name "$BENCH_TYPE.generic" \
+  "./mill $BENCH_TYPE.generic.compile"


### PR DESCRIPTION
## Summary

- Replace hand-rolled timing loop in `bench.sh` with [hyperfine](https://github.com/sharkdp/hyperfine) for statistically rigorous benchmarking (mean ± σ, min/max, randomized execution order)
- Switch from `--no-server` to Mill daemon mode — measures what users actually experience without ~7s JVM cold-start overhead diluting the ratio
- Add "Benchmark method" section to README explaining the harness methodology
- Update results table with mean ± σ format from hyperfine output

## Test plan

- [x] `bash bench.sh 5` — auto derivation benchmark runs successfully
- [x] `bash bench.sh --configured 5` — configured derivation benchmark runs successfully
- [x] Results match previous numbers closely (2.30x auto, 1.83x configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)