### PR TITLE
docs: clarify sanely-jsoniter compatibility promise

### DIFF
--- a/sanely-jsoniter/README.md
+++ b/sanely-jsoniter/README.md
@@ -75,6 +75,10 @@ This means you can adopt sanely-jsoniter on the hot path and keep circe everywhe
 | Collections | JSON array | `[1,2,3]` |
 | Map[String, V] | JSON object | `{"k":"v"}` |
 
+### How the promise is enforced
+
+Cross-codec tests encode values with sanely-jsoniter and decode with circe (and vice versa), asserting identical results for products, sum types, options, and all primitive types. There are no upstream tests from jsoniter-scala — since we intentionally diverge from jsoniter-scala's format, their tests don't apply.
+
 ## Performance
 
 Compared to circe (encoding + decoding combined):


### PR DESCRIPTION
## Summary
- Rewrite "Format compatibility with circe" as "Compatibility promise" — makes it clear we match **circe's** format, not jsoniter-scala's
- Add "How the promise is enforced" subsection explaining cross-codec tests

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)