### PR TITLE
feat: add sub-trait support for sanely-jsoniter

### DIFF
--- a/sanely-jsoniter/src/sanely/jsoniter/JsoniterRuntime.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/JsoniterRuntime.scala
@@ -74,6 +74,120 @@ object JsoniterRuntime:
             if !in.isNextToken('}') then in.objectEndOrCommaError()
             result.asInstanceOf[S]
 
+  // === Sum codec with sub-trait support (external tagging) ===
+
+  def sumCodecWithSubTraits[S](
+    mirror: => Mirror.SumOf[S],
+    directLabels: Array[String],
+    isSubTrait: Array[Boolean],
+    initDirectCodecs: () => Array[JsonValueCodec[Any]],
+    allLeafLabels: Array[String],
+    initAllLeafCodecs: () => Array[JsonValueCodec[Any]]
+  ): JsonValueCodec[S] =
+    new JsonValueCodec[S]:
+      private lazy val _directCodecs = initDirectCodecs()
+      private lazy val _allLeafCodecs = initAllLeafCodecs()
+      val nullValue: S = null.asInstanceOf[S]
+
+      def encodeValue(x: S, out: JsonWriter): Unit =
+        if (x: Any) == null then out.writeNull()
+        else
+          val ord = mirror.ordinal(x)
+          if isSubTrait(ord) then
+            // Sub-trait codec handles its own external tagging
+            _directCodecs(ord).encodeValue(x, out)
+          else
+            out.writeObjectStart()
+            out.writeKey(directLabels(ord))
+            _directCodecs(ord).encodeValue(x, out)
+            out.writeObjectEnd()
+
+      def decodeValue(in: JsonReader, default: S): S =
+        if !in.isNextToken('{') then
+          in.readNullOrTokenError(default, '{')
+        else
+          val key = in.readKeyAsString()
+          var idx = -1
+          var i = 0
+          while i < allLeafLabels.length && idx < 0 do
+            if key == allLeafLabels(i) then idx = i
+            i += 1
+          if idx < 0 then
+            in.decodeError(s"Unknown variant: $key")
+            default
+          else
+            val result = _allLeafCodecs(idx).decodeValue(in, _allLeafCodecs(idx).nullValue)
+            if !in.isNextToken('}') then in.objectEndOrCommaError()
+            result.asInstanceOf[S]
+
+  // === Configured sum codec with sub-trait support ===
+
+  def configuredSumCodecWithSubTraits[S](
+    mirror: => Mirror.SumOf[S],
+    rawDirectLabels: Array[String],
+    isSubTrait: Array[Boolean],
+    transformConstructorNames: String => String,
+    discriminator: Option[String],
+    initDirectCodecs: () => Array[JsonValueCodec[Any]],
+    rawAllLeafLabels: Array[String],
+    initAllLeafCodecs: () => Array[JsonValueCodec[Any]]
+  ): JsonValueCodec[S] =
+    val directLabels = rawDirectLabels.map(transformConstructorNames)
+    val allLeafLabels = rawAllLeafLabels.map(transformConstructorNames)
+    discriminator match
+      case None =>
+        sumCodecWithSubTraits[S](
+          mirror, directLabels, isSubTrait, initDirectCodecs,
+          allLeafLabels, initAllLeafCodecs)
+      case Some(disc) =>
+        // Discriminator with sub-traits: use flat leaf labels for lookup
+        new JsonValueCodec[S]:
+          private lazy val _directCodecs = initDirectCodecs()
+          private lazy val _allLeafCodecs = initAllLeafCodecs()
+          val nullValue: S = null.asInstanceOf[S]
+
+          def encodeValue(x: S, out: JsonWriter): Unit =
+            if (x: Any) == null then out.writeNull()
+            else
+              val ord = mirror.ordinal(x)
+              if isSubTrait(ord) then
+                _directCodecs(ord).encodeValue(x, out)
+              else
+                out.writeObjectStart()
+                out.writeKey(disc)
+                out.writeVal(directLabels(ord))
+                val product = x.asInstanceOf[Product]
+                if product.productArity > 0 then
+                  _directCodecs(ord).encodeValue(x, out)
+                out.writeObjectEnd()
+
+          def decodeValue(in: JsonReader, default: S): S =
+            if !in.isNextToken('{') then
+              in.readNullOrTokenError(default, '{')
+            else
+              if !in.isNextToken('}') then
+                in.rollbackToken()
+                val key = in.readKeyAsString()
+                if key == disc then
+                  val typeName = in.readString(null)
+                  var idx = -1
+                  var i = 0
+                  while i < allLeafLabels.length && idx < 0 do
+                    if typeName == allLeafLabels(i) then idx = i
+                    i += 1
+                  if idx < 0 then
+                    in.decodeError(s"Unknown variant: $typeName")
+                    return default
+                  val result = _allLeafCodecs(idx).decodeValue(in, _allLeafCodecs(idx).nullValue)
+                  if !in.isNextToken('}') then in.objectEndOrCommaError()
+                  result.asInstanceOf[S]
+                else
+                  in.decodeError(s"Expected discriminator field '$disc' but got '$key'")
+                  default
+              else
+                in.decodeError(s"Expected discriminator field '$disc' in empty object")
+                default
+
   // === Configured product codec ===
 
   def configuredProductCodec[P](

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
@@ -21,6 +21,7 @@ object SanelyJsoniter:
     val selfType: TypeRepr = TypeRepr.of[A]
     private val exprCache = mutable.Map.empty[String, Expr[?]]
     private val negativeBuiltinCache = mutable.Set.empty[String]
+    private val summonedKeys = mutable.Set.empty[String]
 
     def derive(mirror: Expr[Mirror.Of[A]]): Expr[JsonValueCodec[A]] =
       // Check if A is a known container type (Option, List, etc.) before Mirror derivation
@@ -67,14 +68,89 @@ object SanelyJsoniter:
       selfRef: Expr[JsonValueCodec[A]]
     ): Expr[JsonValueCodec[S]] =
       val cases = resolveFields[Types, Labels](selfRef)
-      val labelsExpr = Expr(cases.map(_._1).toArray)
-      val codecExprs = cases.map { case (_, tpe, codec) =>
-        tpe match
-          case '[t] => '{ ${codec.asInstanceOf[Expr[JsonValueCodec[t]]]}.asInstanceOf[JsonValueCodec[Any]] }
-      }
-      val codecsArrayExpr = '{ Array(${Varargs(codecExprs)}*) }
 
-      '{ JsoniterRuntime.sumCodec[S]($mirror, $labelsExpr, () => $codecsArrayExpr) }
+      // Detect sub-traits: variants that are themselves sealed traits (not user-provided)
+      val casesWithSubTrait = cases.map { case (label, tpe, codec) =>
+        val isSub = tpe match
+          case '[t] =>
+            val ck = cheapTypeKey(TypeRepr.of[t].dealias)
+            !summonedKeys.contains(ck) && Expr.summon[Mirror.SumOf[t]].isDefined
+        (label, tpe, codec, isSub)
+      }
+
+      val hasSubTraits = casesWithSubTrait.exists(_._4)
+
+      if !hasSubTraits then
+        val labelsExpr = Expr(cases.map(_._1).toArray)
+        val codecExprs = cases.map { case (_, tpe, codec) =>
+          tpe match
+            case '[t] => '{ ${codec.asInstanceOf[Expr[JsonValueCodec[t]]]}.asInstanceOf[JsonValueCodec[Any]] }
+        }
+        val codecsArrayExpr = '{ Array(${Varargs(codecExprs)}*) }
+        '{ JsoniterRuntime.sumCodec[S]($mirror, $labelsExpr, () => $codecsArrayExpr) }
+      else
+        // Build direct codec array (for encoding — includes sub-trait sum codecs)
+        val directLabelsExpr = Expr(cases.map(_._1).toArray)
+        val isSubTraitExpr = Expr(casesWithSubTrait.map(_._4).toArray)
+        val directCodecExprs = casesWithSubTrait.map { case (_, tpe, codec, _) =>
+          tpe match
+            case '[t] => '{ ${codec.asInstanceOf[Expr[JsonValueCodec[t]]]}.asInstanceOf[JsonValueCodec[Any]] }
+        }
+        val directCodecsArrayExpr = '{ Array(${Varargs(directCodecExprs)}*) }
+
+        // Flatten all leaf labels/codecs (for decoding)
+        val allLeaves = casesWithSubTrait.flatMap { case (label, tpe, codec, isSub) =>
+          if isSub then
+            tpe match
+              case '[t] => collectLeafVariants[t](selfRef)
+          else
+            List((label, tpe, codec))
+        }.distinctBy(_._1) // dedup diamond inheritance
+
+        val allLeafLabelsExpr = Expr(allLeaves.map(_._1).toArray)
+        val allLeafCodecExprs = allLeaves.map { case (_, tpe, codec) =>
+          tpe match
+            case '[t] => '{ ${codec.asInstanceOf[Expr[JsonValueCodec[t]]]}.asInstanceOf[JsonValueCodec[Any]] }
+        }
+        val allLeafCodecsArrayExpr = '{ Array(${Varargs(allLeafCodecExprs)}*) }
+
+        '{ JsoniterRuntime.sumCodecWithSubTraits[S](
+          $mirror, $directLabelsExpr, $isSubTraitExpr, () => $directCodecsArrayExpr,
+          $allLeafLabelsExpr, () => $allLeafCodecsArrayExpr) }
+
+    // === Sub-trait leaf collection ===
+
+    private def collectLeafVariants[T: Type](
+      selfRef: Expr[JsonValueCodec[A]]
+    ): List[(String, Type[?], Expr[JsonValueCodec[?]])] =
+      Expr.summon[Mirror.SumOf[T]] match
+        case Some(subMirror) =>
+          subMirror match
+            case '{ $sm: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+              collectLeaves[types, labels](selfRef)
+        case None =>
+          report.errorAndAbort(s"Expected Mirror.SumOf for sub-trait ${Type.show[T]}")
+
+    private def collectLeaves[Types: Type, Labels: Type](
+      selfRef: Expr[JsonValueCodec[A]]
+    ): List[(String, Type[?], Expr[JsonValueCodec[?]])] =
+      (Type.of[Types], Type.of[Labels]) match
+        case ('[EmptyTuple], '[EmptyTuple]) => Nil
+        case ('[t *: ts], '[label *: ls]) =>
+          val labelStr = Type.of[label] match
+            case '[l] =>
+              Type.valueOfConstant[l].getOrElse(
+                report.errorAndAbort(s"Expected literal string type")
+              ).toString
+          val ck = cheapTypeKey(TypeRepr.of[t].dealias)
+          val isNestedSub = !summonedKeys.contains(ck) && Expr.summon[Mirror.SumOf[t]].isDefined
+          val casesForThis =
+            if isNestedSub then collectLeafVariants[t](selfRef)
+            else
+              val codec = resolveOneCodec[t](selfRef)
+              List((labelStr, Type.of[t], codec))
+          casesForThis ++ collectLeaves[ts, ls](selfRef)
+        case _ => report.errorAndAbort("Mismatched Types and Labels tuple lengths")
 
     // === Field/variant resolution ===
 
@@ -128,7 +204,9 @@ object SanelyJsoniter:
       // Try summoning an existing instance (ignoring auto-given to prevent loops)
       val resolved: Expr[JsonValueCodec[T]] =
         Expr.summonIgnoring[JsonValueCodec[T]](cachedIgnoreSymbols*) match
-          case Some(codec) => codec
+          case Some(codec) =>
+            summonedKeys += cacheKey
+            codec
           case None =>
             // Try deriving via Mirror
             Expr.summon[Mirror.Of[T]] match

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
@@ -21,6 +21,7 @@ object SanelyJsoniterConfigured:
     val selfType: TypeRepr = TypeRepr.of[A]
     private val exprCache = mutable.Map.empty[String, Expr[?]]
     private val negativeBuiltinCache = mutable.Set.empty[String]
+    private val summonedKeys = mutable.Set.empty[String]
 
     def derive(mirror: Expr[Mirror.Of[A]]): Expr[JsonValueCodec[A]] =
       // Check if A is a known container type before Mirror derivation
@@ -98,14 +99,89 @@ object SanelyJsoniterConfigured:
       selfRef: Expr[JsonValueCodec[A]]
     ): Expr[JsonValueCodec[S]] =
       val cases = resolveFields[Types, Labels](selfRef)
-      val labelsExpr = Expr(cases.map(_._1).toArray)
-      val codecExprs = cases.map { case (_, tpe, codec) =>
-        tpe match
-          case '[t] => '{ ${codec.asInstanceOf[Expr[JsonValueCodec[t]]]}.asInstanceOf[JsonValueCodec[Any]] }
-      }
-      val codecsArrayExpr = '{ Array(${Varargs(codecExprs)}*) }
 
-      '{ JsoniterRuntime.configuredSumCodec[S]($mirror, $labelsExpr, $conf.transformConstructorNames, $conf.discriminator, () => $codecsArrayExpr) }
+      // Detect sub-traits
+      val casesWithSubTrait = cases.map { case (label, tpe, codec) =>
+        val isSub = tpe match
+          case '[t] =>
+            val ck = cheapTypeKey(TypeRepr.of[t].dealias)
+            !summonedKeys.contains(ck) && Expr.summon[Mirror.SumOf[t]].isDefined
+        (label, tpe, codec, isSub)
+      }
+
+      val hasSubTraits = casesWithSubTrait.exists(_._4)
+
+      if !hasSubTraits then
+        val labelsExpr = Expr(cases.map(_._1).toArray)
+        val codecExprs = cases.map { case (_, tpe, codec) =>
+          tpe match
+            case '[t] => '{ ${codec.asInstanceOf[Expr[JsonValueCodec[t]]]}.asInstanceOf[JsonValueCodec[Any]] }
+        }
+        val codecsArrayExpr = '{ Array(${Varargs(codecExprs)}*) }
+        '{ JsoniterRuntime.configuredSumCodec[S]($mirror, $labelsExpr, $conf.transformConstructorNames, $conf.discriminator, () => $codecsArrayExpr) }
+      else
+        val directLabelsExpr = Expr(cases.map(_._1).toArray)
+        val isSubTraitExpr = Expr(casesWithSubTrait.map(_._4).toArray)
+        val directCodecExprs = casesWithSubTrait.map { case (_, tpe, codec, _) =>
+          tpe match
+            case '[t] => '{ ${codec.asInstanceOf[Expr[JsonValueCodec[t]]]}.asInstanceOf[JsonValueCodec[Any]] }
+        }
+        val directCodecsArrayExpr = '{ Array(${Varargs(directCodecExprs)}*) }
+
+        val allLeaves = casesWithSubTrait.flatMap { case (label, tpe, codec, isSub) =>
+          if isSub then
+            tpe match
+              case '[t] => collectLeafVariants[t](selfRef)
+          else
+            List((label, tpe, codec))
+        }.distinctBy(_._1)
+
+        val allLeafLabelsExpr = Expr(allLeaves.map(_._1).toArray)
+        val allLeafCodecExprs = allLeaves.map { case (_, tpe, codec) =>
+          tpe match
+            case '[t] => '{ ${codec.asInstanceOf[Expr[JsonValueCodec[t]]]}.asInstanceOf[JsonValueCodec[Any]] }
+        }
+        val allLeafCodecsArrayExpr = '{ Array(${Varargs(allLeafCodecExprs)}*) }
+
+        '{ JsoniterRuntime.configuredSumCodecWithSubTraits[S](
+          $mirror, $directLabelsExpr, $isSubTraitExpr,
+          $conf.transformConstructorNames, $conf.discriminator,
+          () => $directCodecsArrayExpr,
+          $allLeafLabelsExpr, () => $allLeafCodecsArrayExpr) }
+
+    // === Sub-trait leaf collection ===
+
+    private def collectLeafVariants[T: Type](
+      selfRef: Expr[JsonValueCodec[A]]
+    ): List[(String, Type[?], Expr[JsonValueCodec[?]])] =
+      Expr.summon[Mirror.SumOf[T]] match
+        case Some(subMirror) =>
+          subMirror match
+            case '{ $sm: Mirror.SumOf[T] { type MirroredElemTypes = types; type MirroredElemLabels = labels } } =>
+              collectLeaves[types, labels](selfRef)
+        case None =>
+          report.errorAndAbort(s"Expected Mirror.SumOf for sub-trait ${Type.show[T]}")
+
+    private def collectLeaves[Types: Type, Labels: Type](
+      selfRef: Expr[JsonValueCodec[A]]
+    ): List[(String, Type[?], Expr[JsonValueCodec[?]])] =
+      (Type.of[Types], Type.of[Labels]) match
+        case ('[EmptyTuple], '[EmptyTuple]) => Nil
+        case ('[t *: ts], '[label *: ls]) =>
+          val labelStr = Type.of[label] match
+            case '[l] =>
+              Type.valueOfConstant[l].getOrElse(
+                report.errorAndAbort(s"Expected literal string type")
+              ).toString
+          val ck = cheapTypeKey(TypeRepr.of[t].dealias)
+          val isNestedSub = !summonedKeys.contains(ck) && Expr.summon[Mirror.SumOf[t]].isDefined
+          val casesForThis =
+            if isNestedSub then collectLeafVariants[t](selfRef)
+            else
+              val codec = resolveOneCodec[t](selfRef)
+              List((labelStr, Type.of[t], codec))
+          casesForThis ++ collectLeaves[ts, ls](selfRef)
+        case _ => report.errorAndAbort("Mismatched Types and Labels tuple lengths")
 
     // === Defaults resolution ===
 
@@ -188,7 +264,9 @@ object SanelyJsoniterConfigured:
 
       val resolved: Expr[JsonValueCodec[T]] =
         Expr.summonIgnoring[JsonValueCodec[T]](cachedIgnoreSymbols*) match
-          case Some(codec) => codec
+          case Some(codec) =>
+            summonedKeys += cacheKey
+            codec
           case None =>
             Expr.summon[Mirror.Of[T]] match
               case Some(mirrorExpr) =>

--- a/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
+++ b/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
@@ -54,6 +54,29 @@ case class SnakeCaseExample(firstName: String, lastName: String, isActive: Boole
 // Types for drop-null tests
 case class WithNullable(name: String, nickname: Option[String], age: Int)
 
+// Sub-trait hierarchy (ADT with nested sealed traits)
+sealed trait ADTWithSub
+sealed trait SubTraitA extends ADTWithSub
+case class LeafA1(x: Int) extends SubTraitA
+case class LeafA2(y: String) extends SubTraitA
+case class DirectCase(z: Boolean) extends ADTWithSub
+
+// Deep hierarchy (sub-sub-trait)
+sealed trait DeepADT
+sealed trait Mid extends DeepADT
+sealed trait Inner extends Mid
+case class DeepLeaf(v: Int) extends Inner
+case class MidLeaf(w: String) extends Mid
+case class TopLeaf(u: Boolean) extends DeepADT
+
+// Diamond hierarchy
+sealed trait DiamondADT
+sealed trait DiamondA extends DiamondADT
+sealed trait DiamondB extends DiamondADT
+case class DiamondLeaf(x: Int) extends DiamondA with DiamondB
+case class OnlyA(a: Int) extends DiamondA
+case class OnlyB(b: Int) extends DiamondB
+
 object SanelyJsoniterTest extends TestSuite:
   import sanely.jsoniter.semiauto.*
 
@@ -462,6 +485,91 @@ object SanelyJsoniterTest extends TestSuite:
       val circeJson = original.asJson.noSpaces
       val jsoniterResult = readFromString[SnakeCaseExample](circeJson)
       assert(jsoniterResult == original)
+    }
+
+    // === Sub-trait tests ===
+
+    test("sub-trait - encode flattens hierarchy") {
+      given JsonValueCodec[ADTWithSub] = deriveJsoniterCodec
+      val v: ADTWithSub = LeafA1(42)
+      val json = writeToString(v)
+      // Should be flat: {"LeafA1":{"x":42}}, NOT {"SubTraitA":{"LeafA1":{"x":42}}}
+      assert(json == """{"LeafA1":{"x":42}}""")
+    }
+
+    test("sub-trait - decode flattened key") {
+      given JsonValueCodec[ADTWithSub] = deriveJsoniterCodec
+      val json = """{"LeafA1":{"x":42}}"""
+      val decoded = readFromString[ADTWithSub](json)
+      assert(decoded == LeafA1(42))
+    }
+
+    test("sub-trait - all variants round-trip") {
+      given JsonValueCodec[ADTWithSub] = deriveJsoniterCodec
+      val values: List[ADTWithSub] = List(LeafA1(1), LeafA2("hello"), DirectCase(true))
+      for v <- values do
+        val json = writeToString(v)
+        val decoded = readFromString[ADTWithSub](json)
+        assert(decoded == v)
+    }
+
+    test("sub-trait - direct case works") {
+      given JsonValueCodec[ADTWithSub] = deriveJsoniterCodec
+      val v: ADTWithSub = DirectCase(true)
+      val json = writeToString(v)
+      assert(json == """{"DirectCase":{"z":true}}""")
+      val decoded = readFromString[ADTWithSub](json)
+      assert(decoded == v)
+    }
+
+    test("sub-trait - deep hierarchy (sub-sub-trait)") {
+      given JsonValueCodec[DeepADT] = deriveJsoniterCodec
+      val values: List[DeepADT] = List(DeepLeaf(1), MidLeaf("hi"), TopLeaf(false))
+      for v <- values do
+        val json = writeToString(v)
+        val decoded = readFromString[DeepADT](json)
+        assert(decoded == v)
+      // Verify flat encoding
+      assert(writeToString[DeepADT](DeepLeaf(1)) == """{"DeepLeaf":{"v":1}}""")
+    }
+
+    test("sub-trait - diamond inheritance dedup") {
+      given JsonValueCodec[DiamondADT] = deriveJsoniterCodec
+      val values: List[DiamondADT] = List(DiamondLeaf(1), OnlyA(2), OnlyB(3))
+      for v <- values do
+        val json = writeToString(v)
+        val decoded = readFromString[DiamondADT](json)
+        assert(decoded == v)
+    }
+
+    test("sub-trait - circe format compatibility") {
+      import io.circe.generic.auto.given
+      import io.circe.syntax.*
+      import io.circe.parser.decode as circeDecode
+
+      given JsonValueCodec[ADTWithSub] = deriveJsoniterCodec
+
+      val v: ADTWithSub = LeafA1(42)
+
+      // jsoniter -> circe
+      val jsoniterJson = writeToString(v)
+      val circeResult = circeDecode[ADTWithSub](jsoniterJson)
+      assert(circeResult == Right(v))
+
+      // circe -> jsoniter
+      val circeJson = (v: ADTWithSub).asJson.noSpaces
+      val jsoniterResult = readFromString[ADTWithSub](circeJson)
+      assert(jsoniterResult == v)
+    }
+
+    test("sub-trait - configured with external tagging") {
+      given JsoniterConfiguration = JsoniterConfiguration.default
+      given JsonValueCodec[ADTWithSub] = deriveJsoniterConfiguredCodec
+      val v: ADTWithSub = LeafA1(42)
+      val json = writeToString(v)
+      assert(json == """{"LeafA1":{"x":42}}""")
+      val decoded = readFromString[ADTWithSub](json)
+      assert(decoded == v)
     }
 
     test("enum - circe format compatibility") {


### PR DESCRIPTION
## Summary

- Sealed trait variants that are themselves sealed traits (sub-traits) are now flattened in JSON encoding/decoding
- Encoding produces `{"LeafName": {...}}` instead of `{"SubTraitName": {"LeafName": {...}}}`  
- Handles arbitrary nesting depth (sub-sub-traits) and diamond inheritance with dedup
- Works in both unconfigured (`deriveJsoniterCodec`) and configured (`deriveJsoniterConfiguredCodec`) derivation
- Implements P1 roadmap item: "Sub-trait support"

### Approach

- **Macro**: Detects sub-traits via `Mirror.SumOf`, recursively collects leaf labels/codecs into flat arrays
- **Encoding**: Sub-trait codecs called directly (no wrapping); they handle their own external tagging
- **Decoding**: Flat label lookup — all leaf labels mapped to leaf codecs, bypassing the streaming rewind problem

## Test plan

- [x] `./mill sanely-jsoniter.jvm.test` — 45/45 passed (8 new sub-trait tests)
- [x] `./mill sanely-jsoniter.js.test` — 45/45 passed
- [x] Cross-codec compatibility: encode with sanely-jsoniter, decode with circe (and vice versa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)