### PR TITLE
feat: add non-string map key support for sanely-jsoniter

### DIFF
--- a/sanely-jsoniter/README.md
+++ b/sanely-jsoniter/README.md
@@ -177,7 +177,7 @@ These cover the most common circe derivation patterns in real-world codebases.
 
 - [x] **Sub-trait support**: Sealed trait variants that are nested sealed traits (currently must be case classes or case objects)
 - [x] **Either codec**: Support `Either[L, R]` with `{"Left": value}` / `{"Right": value}` format (matching circe's `disjunctionCodecs`)
-- [ ] **Non-string map keys**: Support `Map[K, V]` where K is not String (encode as array of pairs, matching circe's `MapCodecs` pattern)
+- [x] **Non-string map keys**: Support `Map[K, V]` where K is not String — keys stringified via `KeyCodec[K]` (matching circe's `KeyEncoder`/`KeyDecoder` pattern)
 
 ### P2 — Enables complete replacement
 

--- a/sanely-jsoniter/src/sanely/jsoniter/Codecs.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/Codecs.scala
@@ -189,6 +189,30 @@ object Codecs:
           if !in.isNextToken('}') then in.objectEndOrCommaError()
           result
 
+  def map[K, V](keyCodec: KeyCodec[K], valueCodec: JsonValueCodec[V]): JsonValueCodec[Map[K, V]] = new JsonValueCodec[Map[K, V]]:
+    val nullValue: Map[K, V] = null
+    def encodeValue(x: Map[K, V], out: JsonWriter): Unit =
+      if x == null then out.writeNull()
+      else
+        out.writeObjectStart()
+        x.foreach { (k, v) =>
+          out.writeKey(keyCodec.encode(k))
+          valueCodec.encodeValue(v, out)
+        }
+        out.writeObjectEnd()
+    def decodeValue(in: JsonReader, default: Map[K, V]): Map[K, V] =
+      if !in.isNextToken('{') then
+        in.readNullOrTokenError(default, '{')
+      else
+        val buf = Map.newBuilder[K, V]
+        if !in.isNextToken('}') then
+          in.rollbackToken()
+          buf += (keyCodec.decode(in.readKeyAsString()) -> valueCodec.decodeValue(in, valueCodec.nullValue))
+          while in.isNextToken(',') do
+            buf += (keyCodec.decode(in.readKeyAsString()) -> valueCodec.decodeValue(in, valueCodec.nullValue))
+          if !in.isCurrentToken('}') then in.objectEndOrCommaError()
+        buf.result()
+
   def stringMap[V](inner: JsonValueCodec[V]): JsonValueCodec[Map[String, V]] = new JsonValueCodec[Map[String, V]]:
     val nullValue: Map[String, V] = null
     def encodeValue(x: Map[String, V], out: JsonWriter): Unit =

--- a/sanely-jsoniter/src/sanely/jsoniter/KeyCodec.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/KeyCodec.scala
@@ -1,0 +1,56 @@
+package sanely.jsoniter
+
+/** Converts map keys to/from strings for JSON object encoding.
+  * Mirrors circe's KeyEncoder/KeyDecoder — maps are always JSON objects with stringified keys.
+  */
+trait KeyCodec[K]:
+  def encode(key: K): String
+  def decode(key: String): K
+
+object KeyCodec:
+
+  def apply[K](using k: KeyCodec[K]): KeyCodec[K] = k
+
+  given KeyCodec[String] with
+    def encode(key: String): String = key
+    def decode(key: String): String = key
+
+  given KeyCodec[Int] with
+    def encode(key: Int): String = java.lang.Integer.toString(key)
+    def decode(key: String): Int = java.lang.Integer.parseInt(key)
+
+  given KeyCodec[Long] with
+    def encode(key: Long): String = java.lang.Long.toString(key)
+    def decode(key: String): Long = java.lang.Long.parseLong(key)
+
+  given KeyCodec[Short] with
+    def encode(key: Short): String = java.lang.Short.toString(key)
+    def decode(key: String): Short = java.lang.Short.parseShort(key)
+
+  given KeyCodec[Byte] with
+    def encode(key: Byte): String = java.lang.Byte.toString(key)
+    def decode(key: String): Byte = java.lang.Byte.parseByte(key)
+
+  given KeyCodec[Double] with
+    def encode(key: Double): String = java.lang.Double.toString(key)
+    def decode(key: String): Double = java.lang.Double.parseDouble(key)
+
+  given KeyCodec[Float] with
+    def encode(key: Float): String = java.lang.Float.toString(key)
+    def decode(key: String): Float = java.lang.Float.parseFloat(key)
+
+  given KeyCodec[Boolean] with
+    def encode(key: Boolean): String = java.lang.Boolean.toString(key)
+    def decode(key: String): Boolean = java.lang.Boolean.parseBoolean(key)
+
+  given KeyCodec[BigDecimal] with
+    def encode(key: BigDecimal): String = key.toString
+    def decode(key: String): BigDecimal = BigDecimal(key)
+
+  given KeyCodec[BigInt] with
+    def encode(key: BigInt): String = key.toString
+    def decode(key: String): BigInt = BigInt(key)
+
+  given KeyCodec[java.util.UUID] with
+    def encode(key: java.util.UUID): String = key.toString
+    def decode(key: String): java.util.UUID = java.util.UUID.fromString(key)

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
@@ -255,8 +255,7 @@ object SanelyJsoniter:
                   buildContainerCodec[T, a](tycon, inner)
             }
           case AppliedType(tycon, List(keyArg, valArg))
-            if tycon.typeSymbol.fullName.endsWith(".Map") &&
-               keyArg =:= TypeRepr.of[String] =>
+            if tycon.typeSymbol.fullName.endsWith(".Map") =>
             val valKey = cheapTypeKey(valArg)
             val valOpt = (if negativeBuiltinCache.contains(valKey) then exprCache.get(valKey)
                          else resolvePrimCodec(valArg.dealias).orElse(exprCache.get(valKey)))
@@ -267,13 +266,26 @@ object SanelyJsoniter:
                     exprCache(valKey) = codec
                     codec
                   }
+            }.orElse {
+              valArg.asType match
+                case '[v] =>
+                  tryResolveBuiltin[v](valArg.dealias).map { codec =>
+                    exprCache(valKey) = codec
+                    codec
+                  }
             }
             valResolved.flatMap { valCodec =>
               valArg.asType match
                 case '[v] =>
                   val vc = valCodec.asInstanceOf[Expr[JsonValueCodec[v]]]
-                  Some('{ Codecs.stringMap[v]($vc) }.asInstanceOf[Expr[JsonValueCodec[T]]])
-                case _ => None
+                  if keyArg =:= TypeRepr.of[String] then
+                    Some('{ Codecs.stringMap[v]($vc) }.asInstanceOf[Expr[JsonValueCodec[T]]])
+                  else
+                    keyArg.asType match
+                      case '[k] =>
+                        Expr.summon[KeyCodec[k]].map { kc =>
+                          '{ Codecs.map[k, v]($kc, $vc) }.asInstanceOf[Expr[JsonValueCodec[T]]]
+                        }
             }
           case AppliedType(tycon, List(leftArg, rightArg))
             if tycon.typeSymbol.fullName == "scala.util.Either" =>

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
@@ -312,8 +312,7 @@ object SanelyJsoniterConfigured:
                   buildContainerCodec[T, a](tycon, inner)
             }
           case AppliedType(tycon, List(keyArg, valArg))
-            if tycon.typeSymbol.fullName.endsWith(".Map") &&
-               keyArg =:= TypeRepr.of[String] =>
+            if tycon.typeSymbol.fullName.endsWith(".Map") =>
             val valKey = cheapTypeKey(valArg)
             val valOpt = (if negativeBuiltinCache.contains(valKey) then exprCache.get(valKey)
                          else resolvePrimCodec(valArg.dealias).orElse(exprCache.get(valKey)))
@@ -324,13 +323,26 @@ object SanelyJsoniterConfigured:
                     exprCache(valKey) = codec
                     codec
                   }
+            }.orElse {
+              valArg.asType match
+                case '[v] =>
+                  tryResolveBuiltin[v](valArg.dealias).map { codec =>
+                    exprCache(valKey) = codec
+                    codec
+                  }
             }
             valResolved.flatMap { valCodec =>
               valArg.asType match
                 case '[v] =>
                   val vc = valCodec.asInstanceOf[Expr[JsonValueCodec[v]]]
-                  Some('{ Codecs.stringMap[v]($vc) }.asInstanceOf[Expr[JsonValueCodec[T]]])
-                case _ => None
+                  if keyArg =:= TypeRepr.of[String] then
+                    Some('{ Codecs.stringMap[v]($vc) }.asInstanceOf[Expr[JsonValueCodec[T]]])
+                  else
+                    keyArg.asType match
+                      case '[k] =>
+                        Expr.summon[KeyCodec[k]].map { kc =>
+                          '{ Codecs.map[k, v]($kc, $vc) }.asInstanceOf[Expr[JsonValueCodec[T]]]
+                        }
             }
           case AppliedType(tycon, List(leftArg, rightArg))
             if tycon.typeSymbol.fullName == "scala.util.Either" =>

--- a/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
+++ b/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
@@ -37,6 +37,10 @@ case object Chicken extends Farm
 // Recursive type
 case class Tree(value: String, children: List[Tree])
 
+// Non-string map key types
+case class WithIntMap(scores: Map[Int, String])
+case class WithLongMap(ids: Map[Long, Boolean])
+
 // Either types
 case class WithEither(result: Either[String, Int])
 case class WithNestedEither(data: Either[String, List[Int]])
@@ -97,6 +101,8 @@ object SanelyJsoniterTest extends TestSuite:
   given JsonValueCodec[Color] = deriveJsoniterEnumCodec
   given JsonValueCodec[Direction] = deriveJsoniterEnumCodec
   given JsonValueCodec[Animal] = deriveJsoniterEnumCodec
+  given JsonValueCodec[WithIntMap] = deriveJsoniterCodec
+  given JsonValueCodec[WithLongMap] = deriveJsoniterCodec
   given JsonValueCodec[WithEither] = deriveJsoniterCodec
   given JsonValueCodec[WithNestedEither] = deriveJsoniterCodec
 
@@ -164,6 +170,44 @@ object SanelyJsoniterTest extends TestSuite:
       val w = WithMap(Map("k1" -> "v1", "k2" -> "v2"), Map("a" -> 1, "b" -> 2))
       val decoded = roundtrip(w)
       assert(decoded == w)
+    }
+
+    test("map - int keys") {
+      val w = WithIntMap(Map(1 -> "one", 2 -> "two"))
+      val json = writeToString(w)
+      assert(json.contains("\"1\":\"one\""))
+      assert(json.contains("\"2\":\"two\""))
+      val decoded = readFromString[WithIntMap](json)
+      assert(decoded == w)
+    }
+
+    test("map - long keys") {
+      val w = WithLongMap(Map(100L -> true, 200L -> false))
+      val json = writeToString(w)
+      assert(json.contains("\"100\":true"))
+      assert(json.contains("\"200\":false"))
+      val decoded = readFromString[WithLongMap](json)
+      assert(decoded == w)
+    }
+
+    test("map - int keys circe format compatibility") {
+      import io.circe.generic.semiauto.{deriveEncoder, deriveDecoder}
+      import io.circe.{Encoder, Decoder, *}
+      import io.circe.syntax.*
+      import io.circe.parser.decode as circeDecode
+
+      given Encoder[WithIntMap] = deriveEncoder
+      given Decoder[WithIntMap] = deriveDecoder
+
+      val v = WithIntMap(Map(1 -> "one", 2 -> "two"))
+
+      // jsoniter -> circe
+      val jJson = writeToString(v)
+      assert(circeDecode[WithIntMap](jJson) == Right(v))
+
+      // circe -> jsoniter
+      val cJson = (v: WithIntMap).asJson.noSpaces
+      assert(readFromString[WithIntMap](cJson) == v)
     }
 
     test("sum - circle") {


### PR DESCRIPTION
## Summary
- Add `KeyCodec[K]` trait with built-in instances for `Int`, `Long`, `Short`, `Byte`, `Double`, `Float`, `Boolean`, `BigDecimal`, `BigInt`, `UUID`, `String`
- Add `Codecs.map[K, V]` runtime codec using `KeyCodec[K]` for key stringification
- Broaden `Map` detection in both standard and configured macros to handle any `Map[K, V]` (was previously restricted to `Map[String, V]`)
- Matches circe's `KeyEncoder`/`KeyDecoder` format — maps are always JSON objects with stringified keys

## Test plan
- [x] 3 new tests: `Map[Int, String]` round-trip, `Map[Long, Boolean]` round-trip, circe format compatibility
- [x] All 52 tests pass on JVM
- [x] All 52 tests pass on Scala.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)