### PR TITLE
feat: add value enum codecs for sanely-jsoniter

### DIFF
--- a/sanely-jsoniter/README.md
+++ b/sanely-jsoniter/README.md
@@ -182,7 +182,7 @@ These cover the most common circe derivation patterns in real-world codebases.
 ### P2 — Enables complete replacement
 
 - [ ] **Protobuf codec bridge**: Support ScalaPB `GeneratedMessage`/`GeneratedEnum` types (matching `scalapb_circe` JSON format)
-- [ ] **Value enum codecs**: Support custom value enum types (e.g. `StringEnum`/`IntEnum`) where the enum value is a raw string or int, not the case name. Currently requires manual `Codec.from(decoder.emap(...), encoder.contramap(...))` — could be macro-derived.
+- [x] **Value enum codecs**: `Codecs.stringValueEnum` and `Codecs.intValueEnum` — encode by associated value (not case name). E.g. `Status.Active` → `"active"`, `Priority.High` → `3`.
 
 ### Done
 

--- a/sanely-jsoniter/src/sanely/jsoniter/Codecs.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/Codecs.scala
@@ -213,6 +213,33 @@ object Codecs:
           if !in.isCurrentToken('}') then in.objectEndOrCommaError()
         buf.result()
 
+  // === Value enums ===
+
+  def stringValueEnum[E](values: Array[E], toValue: E => String): JsonValueCodec[E] =
+    val valueToEnum = values.map(e => toValue(e) -> e).toMap
+    val typeName = values.headOption.map(_.getClass.getSimpleName.stripSuffix("$")).getOrElse("?")
+    new JsonValueCodec[E]:
+      val nullValue: E = null.asInstanceOf[E]
+      def encodeValue(x: E, out: JsonWriter): Unit =
+        if (x: Any) == null then out.writeNull() else out.writeVal(toValue(x))
+      def decodeValue(in: JsonReader, default: E): E =
+        val s = in.readString(null)
+        if s == null then in.decodeError(s"expected string for $typeName")
+        valueToEnum.getOrElse(s, in.decodeError(s"$typeName does not contain value: $s"))
+
+  def intValueEnum[E](values: Array[E], toValue: E => Int): JsonValueCodec[E] =
+    val valueToEnum = values.map(e => toValue(e) -> e).toMap
+    val typeName = values.headOption.map(_.getClass.getSimpleName.stripSuffix("$")).getOrElse("?")
+    new JsonValueCodec[E]:
+      val nullValue: E = null.asInstanceOf[E]
+      def encodeValue(x: E, out: JsonWriter): Unit =
+        if (x: Any) == null then out.writeNull() else out.writeVal(toValue(x))
+      def decodeValue(in: JsonReader, default: E): E =
+        val v = in.readInt()
+        valueToEnum.getOrElse(v, in.decodeError(s"$typeName does not contain value: $v"))
+
+  // === Maps ===
+
   def stringMap[V](inner: JsonValueCodec[V]): JsonValueCodec[Map[String, V]] = new JsonValueCodec[Map[String, V]]:
     val nullValue: Map[String, V] = null
     def encodeValue(x: Map[String, V], out: JsonWriter): Unit =

--- a/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
+++ b/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
@@ -37,6 +37,17 @@ case object Chicken extends Farm
 // Recursive type
 case class Tree(value: String, children: List[Tree])
 
+// Value enum types
+enum Status(val value: String):
+  case Active extends Status("active")
+  case Inactive extends Status("inactive")
+  case Pending extends Status("pending")
+
+enum Priority(val value: Int):
+  case Low extends Priority(1)
+  case Medium extends Priority(2)
+  case High extends Priority(3)
+
 // Non-string map key types
 case class WithIntMap(scores: Map[Int, String])
 case class WithLongMap(ids: Map[Long, Boolean])
@@ -679,6 +690,64 @@ object SanelyJsoniterTest extends TestSuite:
       // circe -> jsoniter (Left)
       val cLeft = (left: WithEither).asJson.noSpaces
       assert(readFromString[WithEither](cLeft) == left)
+    }
+
+    // === Value enum tests ===
+
+    test("value enum - string value round-trip") {
+      given JsonValueCodec[Status] = Codecs.stringValueEnum(Status.values, _.value)
+      val json = writeToString(Status.Active)
+      assert(json == "\"active\"")
+      val decoded = readFromString[Status](json)
+      assert(decoded == Status.Active)
+    }
+
+    test("value enum - all string variants") {
+      given JsonValueCodec[Status] = Codecs.stringValueEnum(Status.values, _.value)
+      for s <- Status.values do
+        val json = writeToString(s)
+        assert(json == s"\"${s.value}\"")
+        val decoded = readFromString[Status](json)
+        assert(decoded == s)
+    }
+
+    test("value enum - int value round-trip") {
+      given JsonValueCodec[Priority] = Codecs.intValueEnum(Priority.values, _.value)
+      val json = writeToString(Priority.High)
+      assert(json == "3")
+      val decoded = readFromString[Priority](json)
+      assert(decoded == Priority.High)
+    }
+
+    test("value enum - all int variants") {
+      given JsonValueCodec[Priority] = Codecs.intValueEnum(Priority.values, _.value)
+      for p <- Priority.values do
+        val json = writeToString(p)
+        assert(json == p.value.toString)
+        val decoded = readFromString[Priority](json)
+        assert(decoded == p)
+    }
+
+    test("value enum - unknown string value decode error") {
+      given JsonValueCodec[Status] = Codecs.stringValueEnum(Status.values, _.value)
+      val caught =
+        try
+          readFromString[Status]("\"unknown\"")
+          throw new RuntimeException("expected exception")
+        catch
+          case e: com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException => e
+      assert(caught.getMessage.contains("does not contain value"))
+    }
+
+    test("value enum - unknown int value decode error") {
+      given JsonValueCodec[Priority] = Codecs.intValueEnum(Priority.values, _.value)
+      val caught =
+        try
+          readFromString[Priority]("99")
+          throw new RuntimeException("expected exception")
+        catch
+          case e: com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException => e
+      assert(caught.getMessage.contains("does not contain value"))
     }
 
     test("enum - circe format compatibility") {


### PR DESCRIPTION
## Summary
- Add `Codecs.stringValueEnum[E](values, toValue)` — encodes enum by string value (e.g. `Active` → `"active"`)
- Add `Codecs.intValueEnum[E](values, toValue)` — encodes enum by int value (e.g. `High` → `3`)
- Mark P2 value enum item as done in roadmap

## Test plan
- [x] 6 new tests: string/int value round-trip, all variants, unknown value decode errors
- [x] All 58 tests pass on JVM
- [x] All 58 tests pass on Scala.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)