### PR TITLE
docs: honest migration path for configured types + sanely-jsoniter ROADMAP

### DIFF
--- a/REAL-WORLD.md
+++ b/REAL-WORLD.md
@@ -137,7 +137,7 @@ The compatibility contract: encode with sanely-jsoniter, decode with circe (or v
 
 Every module that derives circe codecs compiles faster. No code changes beyond the import.
 
-### Step 2: Runtime hot path (one dependency + one file)
+### Step 2: Runtime hot path
 
 Add sanely-jsoniter alongside circe-sanely-auto:
 
@@ -145,7 +145,7 @@ Add sanely-jsoniter alongside circe-sanely-auto:
 + mvn"io.github.nguyenyou::sanely-jsoniter:0.14.0"
 ```
 
-Then in the central HTTP codec (the one file that all endpoints go through):
+Then swap the central HTTP codec (the one file that all endpoints go through) from circe's `Json` tree to direct jsoniter codecs:
 
 ```diff
 - val json = readFromString[io.circe.Json](s)  // still allocates Json tree
@@ -158,7 +158,52 @@ Then in the central HTTP codec (the one file that all endpoints go through):
 + writeToString(t)         // direct serialization
 ```
 
-With `sanely-jsoniter.auto.given` imported, `JsonValueCodec[T]` instances are auto-derived for all domain types. One import, one file change, 5x throughput on every API endpoint.
+For this to work, every domain type `T` needs a `JsonValueCodec[T]` in scope. How much work that takes depends on how the codebase derives its circe codecs:
+
+**Simple case — standard derivation (no configuration):**
+
+If types use plain `deriveCodec` or `import auto.given` without any `Configuration`, one import is enough:
+
+```scala
+import sanely.jsoniter.auto.given  // auto-derives JsonValueCodec for all types
+```
+
+**Common case — configured derivation (defaults, discriminator, snake_case):**
+
+Most real codebases use configured derivation — `withDefaults`, `withDiscriminator("type")`, `withSnakeCaseMemberNames`, drop-null encoding. These types need **matching** jsoniter configuration, because the JSON format differs from standard encoding:
+
+| Config | Standard JSON | Configured JSON |
+|---|---|---|
+| `withDiscriminator("type")` | `{"Car":{"make":"Toyota"}}` | `{"type":"Car","make":"Toyota"}` |
+| `withSnakeCaseMemberNames` | `{"firstName":"Alice"}` | `{"first_name":"Alice"}` |
+| `withDefaults` | Encoding identical, but decode must handle missing fields | |
+
+For configured types, derive jsoniter codecs with matching config using semi-auto derivation:
+
+```scala
+import sanely.jsoniter.semiauto.*
+import sanely.jsoniter.JsoniterConfiguration
+
+given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults
+given JsonValueCodec[User] = deriveJsoniterConfiguredCodec
+```
+
+**Practical case — centralized config wrapper:**
+
+Many large codebases already have a centralized derivation wrapper (e.g., `deriveCodecWithDefaults`, `deriveCodecWithSnakeCaseAndDefaults`). In that case, extend the wrapper once to derive both circe and jsoniter codecs:
+
+```scala
+// Before: wrapper derives only circe codec
+inline def deriveCodecWithDefaults[A](using inline m: Mirror.Of[A]): Codec.AsObject[A] = ...
+
+// After: add a parallel jsoniter method
+inline def deriveJsoniterCodecWithDefaults[A](using inline m: Mirror.Of[A]): JsonValueCodec[A] = {
+  given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults
+  deriveJsoniterConfiguredCodec
+}
+```
+
+This is a one-time change to the wrapper, not a per-type change. Types that need jsoniter codecs add one line alongside their existing circe codec.
 
 ### What stays on circe (everything else)
 
@@ -176,8 +221,16 @@ Both codec systems coexist — `JsonValueCodec[T]` and `Encoder[T]`/`Decoder[T]`
 |---|---|---|
 | **Compile time** | Slow implicit search chains | Single macro expansion (~2x faster) |
 | **Runtime (hot path)** | bytes -> Json tree -> T (1.0-1.5x) | bytes -> T directly (5x) |
-| **Migration cost** | — | 1 dep swap + 1 file for the hot path |
+| **Migration cost** | — | 1 dep swap for compile time; hot path requires matching jsoniter codecs per configuration variant |
 | **circe compatibility** | N/A | Same JSON format, coexists with circe |
-| **Risk** | — | Zero for compile time; hot path is opt-in |
+| **Risk** | — | Zero for compile time; hot path is opt-in and incremental |
 
 The goal is not to replace circe. It's to make circe fast where it matters — compile time across the board, and runtime on the serialization boundary — while leaving everything else untouched.
+
+## Current status (sanely-jsoniter)
+
+sanely-jsoniter's core derivation engine is complete — products, sum types, enums, recursive types, sub-trait hierarchies, Either, non-string map keys, and all configured derivation options (defaults, discriminator, snake_case, drop-null, arbitrary name transforms).
+
+**What's ready today**: semi-auto derivation with all configuration options, auto derivation for standard types, cross-codec tests proving format compatibility with circe for products, sums, enums, either, sub-traits, maps, defaults, and snake_case.
+
+**What's still in progress**: auto-configured derivation (so configured types don't need explicit semi-auto calls), cross-codec tests for discriminator and drop-null, Tapir integration tests, strict decoding, and a migration guide for configured codebases. See the [sanely-jsoniter ROADMAP](sanely-jsoniter/ROADMAP.md) for the full tracker.

--- a/sanely-jsoniter/ROADMAP.md
+++ b/sanely-jsoniter/ROADMAP.md
@@ -38,20 +38,21 @@ Real codebases use configured derivation for the vast majority of types (default
 
 - [ ] **Cross-codec test: combined configs** — Test the real-world combos: defaults+discriminator, defaults+snake_case+drop-null. These are the actual configuration patterns used in production wrappers.
 
-- [ ] **Fix REAL-WORLD.md migration path** — The current Step 2 says "one import, one file change" with `auto.given`, which only works for standard types. Update to show two paths: (a) auto for standard types, (b) configured semi-auto or auto-configured for types with custom encoding. Be honest about what "one file change" actually requires.
+- [x] **Fix REAL-WORLD.md migration path** — Updated Step 2 to show three paths: (a) auto for standard types, (b) semi-auto with matching config for configured types, (c) extend centralized wrapper for codebases with one. Honest about what the hot path swap requires.
 
 ## P1 — Enables smoother adoption
 
-- [ ] **Strict decoding** — `JsoniterConfiguration.withStrictDecoding` config option exists but is not wired into the runtime. Implement: reject unknown fields during decoding. ~18 call sites in typical codebases use strict decoding via direct `ConfiguredCodec.derived`.
+- [ ] **Tapir integration tests** — Add a test module with Tapir as a dependency that proves the HTTP codec swap works end-to-end. Test cases should cover:
+  - **Direct jsoniter codec**: `sttp.tapir.Codec.json[T]` using `readFromString[T]` / `writeToString[T]` with `JsonValueCodec[T]` — no circe `Json` tree in the pipeline
+  - **Standard types**: product types, sum types (external tagging), enums — verify Tapir roundtrip (encode → decode) produces identical results to the circe-based codec
+  - **Configured types**: types with defaults (missing fields decoded correctly), discriminator tagging, snake_case field names, drop-null encoding — verify wire format matches circe's configured codec output
+  - **Error handling**: malformed JSON, type mismatches, missing required fields — verify Tapir `DecodeResult.Error` is produced (not an unhandled exception)
+  - **Fallback pattern**: a codec that uses `JsonValueCodec[T]` when available, falls back to circe `Json` tree otherwise — for incremental migration where not all types have jsoniter codecs yet
+  - **Circe coexistence**: same type has both `Encoder[T]`/`Decoder[T]` and `JsonValueCodec[T]` in scope — verify no implicit conflicts and both can be used independently
 
-- [ ] **Tapir integration example** — Working example of a Tapir `JsonCodec[T]` that uses `JsonValueCodec[T]` directly (no circe `Json` tree). Show the central endpoint codec pattern:
-  ```scala
-  // Before: jsoniter parses to circe.Json, then circe decodes (1.5x)
-  val json = readFromString[io.circe.Json](s); json.as[T]
-  // After: jsoniter decodes directly (5x)
-  readFromString[T](s)
-  ```
-  Include a fallback pattern for incremental migration (use jsoniter when `JsonValueCodec[T]` is available, fall back to circe otherwise).
+  This is the strongest proof that the REAL-WORLD.md migration path actually works. Without it, the HTTP hot path swap is a theoretical claim.
+
+- [ ] **Strict decoding** — `JsoniterConfiguration.withStrictDecoding` config option exists but is not wired into the runtime. Implement: reject unknown fields during decoding. ~18 call sites in typical codebases use strict decoding via direct `ConfiguredCodec.derived`.
 
 - [ ] **Migration guide for configured codebases** — Document the pattern for codebases with centralized configuration wrappers: extend the wrapper to derive both circe and jsoniter codecs side by side. Show how `deriveCodecWithDefaults` gets a parallel `deriveJsoniterCodecWithDefaults`. One-time wrapper change, not per-type.
 


### PR DESCRIPTION
## Summary

Follow-up to #112. After reviewing the actual sanely-jsoniter implementation against real-world codebase needs:

- **REAL-WORLD.md**: Step 2 no longer claims "one import, one file change" for all types. Now shows three realistic paths: (a) auto for standard types, (b) semi-auto with matching config for configured types, (c) centralized wrapper pattern. Added "Current status" section acknowledging what's ready vs in progress
- **sanely-jsoniter ROADMAP**: Full rewrite based on gap analysis. P0: auto-configured derivation, missing cross-codec tests. P1: Tapir integration tests (6 specific test cases), strict decoding, migration guide. P2: value enum macros, `derives` support, real-world benchmarks

### Key finding

Auto derivation produces wrong JSON for configured types (different tagging, field names, no defaults on decode). Real codebases use configured derivation for 90%+ of their types. The ROADMAP now tracks closing this gap.

## Test plan

- [ ] Review REAL-WORLD.md migration path for accuracy
- [ ] Review sanely-jsoniter ROADMAP priorities and completeness
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)