### PR TITLE
feat: auto-configured derivation for sanely-jsoniter

### DIFF
--- a/sanely-jsoniter/ROADMAP.md
+++ b/sanely-jsoniter/ROADMAP.md
@@ -30,7 +30,7 @@ Core derivation engine is complete: products, sum types, enums, recursive types,
 
 Real codebases use configured derivation for the vast majority of types (defaults, discriminator, snake_case, drop-null). Auto derivation produces **wrong JSON** for these types. These items close the gap between what works today and what the HTTP hot path swap actually requires.
 
-- [ ] **Auto-configured derivation** — `sanely.jsoniter.configured.auto.given` that auto-derives `JsonValueCodec[T]` using a `given JsoniterConfiguration` in scope. Without this, every configured type needs explicit `deriveJsoniterConfiguredCodec`. Pattern: `given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults; import sanely.jsoniter.configured.auto.given`. This covers ~500+ call sites in a typical codebase that all use the same base config (withDefaults).
+- [x] **Auto-configured derivation** — `sanely.jsoniter.configured.auto.given` that auto-derives `JsonValueCodec[T]` using a `given JsoniterConfiguration` in scope. Without this, every configured type needs explicit `deriveJsoniterConfiguredCodec`. Pattern: `given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults; import sanely.jsoniter.configured.auto.given`. This covers ~500+ call sites in a typical codebase that all use the same base config (withDefaults).
 
 - [ ] **Cross-codec test: discriminator** — Prove that `JsoniterConfiguration.default.withDiscriminator("type")` produces identical JSON to circe's `Configuration.default.withDiscriminator("type")`. Encode with jsoniter → decode with circe and vice versa. ~45 call sites in a typical codebase use discriminator tagging.
 

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
@@ -396,6 +396,9 @@ object SanelyJsoniter:
       try
         buf += Symbol.requiredModule("sanely.jsoniter.auto").methodMember("autoCodec").head
       catch case _: Exception => ()
+      try
+        buf += Symbol.requiredModule("sanely.jsoniter.configured.auto").methodMember("autoConfiguredCodec").head
+      catch case _: Exception => ()
       buf.result()
 
     // === Utilities ===

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
@@ -453,6 +453,9 @@ object SanelyJsoniterConfigured:
       try
         buf += Symbol.requiredModule("sanely.jsoniter.auto").methodMember("autoCodec").head
       catch case _: Exception => ()
+      try
+        buf += Symbol.requiredModule("sanely.jsoniter.configured.auto").methodMember("autoConfiguredCodec").head
+      catch case _: Exception => ()
       buf.result()
 
     // === Utilities ===

--- a/sanely-jsoniter/src/sanely/jsoniter/configured/auto.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/configured/auto.scala
@@ -1,0 +1,9 @@
+package sanely.jsoniter.configured
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import sanely.jsoniter.{JsoniterConfiguration, SanelyJsoniterConfigured}
+import scala.deriving.Mirror
+
+object auto:
+  inline given autoConfiguredCodec[A](using inline conf: JsoniterConfiguration)(using inline m: Mirror.Of[A]): JsonValueCodec[A] =
+    SanelyJsoniterConfigured.derived[A]

--- a/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
+++ b/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
@@ -940,6 +940,110 @@ object SanelyJsoniterTest extends TestSuite:
       assert(caught.getMessage.contains("does not contain value"))
     }
 
+    // === Auto-configured derivation tests ===
+
+    test("auto-configured - withDefaults: missing fields use defaults") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults
+      import sanely.jsoniter.configured.auto.given
+      case class AutoCfgDefaults(name: String, age: Int = 25, active: Boolean = true)
+      val json = """{"name":"Alice"}"""
+      val decoded = readFromString[AutoCfgDefaults](json)
+      assert(decoded == AutoCfgDefaults("Alice", 25, true))
+    }
+
+    test("auto-configured - nested types auto-derived") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults
+      import sanely.jsoniter.configured.auto.given
+      case class Inner(x: Int, y: String = "default")
+      case class Outer(inner: Inner, label: String)
+      val json = """{"inner":{"x":42},"label":"test"}"""
+      val decoded = readFromString[Outer](json)
+      assert(decoded == Outer(Inner(42, "default"), "test"))
+    }
+
+    test("auto-configured - snake_case member names") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults.withSnakeCaseMemberNames
+      import sanely.jsoniter.configured.auto.given
+      case class AutoSnake(firstName: String, lastName: String, isActive: Boolean = true)
+      val original = AutoSnake("Alice", "Smith", true)
+      val json = writeToString(original)
+      assert(json.contains("\"first_name\""))
+      assert(json.contains("\"last_name\""))
+      assert(json.contains("\"is_active\""))
+      val decoded = readFromString[AutoSnake](json)
+      assert(decoded == original)
+    }
+
+    test("auto-configured - drop-null values") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDropNullValues
+      import sanely.jsoniter.configured.auto.given
+      case class AutoDropNull(name: String, nickname: Option[String], age: Int)
+      val original = AutoDropNull("Alice", None, 30)
+      val json = writeToString(original)
+      assert(!json.contains("nickname"))
+      assert(json.contains("\"name\":\"Alice\""))
+      assert(json.contains("\"age\":30"))
+    }
+
+    test("auto-configured - discriminator tagging") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDiscriminator("type")
+      import sanely.jsoniter.configured.auto.given
+      sealed trait AutoVehicle
+      case class AutoCar(make: String, year: Int) extends AutoVehicle
+      case class AutoBike(brand: String) extends AutoVehicle
+      val car: AutoVehicle = AutoCar("Toyota", 2024)
+      val json = writeToString(car)
+      assert(json.contains("\"type\":\"AutoCar\""))
+      assert(json.contains("\"make\":\"Toyota\""))
+      val decoded = readFromString[AutoVehicle](json)
+      assert(decoded == car)
+    }
+
+    test("auto-configured - round-trip encode then decode") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults.withSnakeCaseMemberNames
+      import sanely.jsoniter.configured.auto.given
+      case class AutoRoundTrip(firstName: String, age: Int = 25, tags: List[String] = Nil)
+      val original = AutoRoundTrip("Bob", 30, List("admin", "user"))
+      val json = writeToString(original)
+      val decoded = readFromString[AutoRoundTrip](json)
+      assert(decoded == original)
+    }
+
+    test("auto-configured - cross-codec with circe") {
+      import io.circe.derivation.Configuration
+      import io.circe.{Codec as CirceCodec, *}
+      import io.circe.syntax.*
+      import io.circe.parser.decode as circeDecode
+      import io.circe.generic.semiauto.deriveConfiguredCodec
+
+      case class AutoCrossCodec(firstName: String, lastName: String, age: Int = 25)
+
+      given Configuration = Configuration.default.withDefaults.withSnakeCaseMemberNames
+      given CirceCodec[AutoCrossCodec] = deriveConfiguredCodec
+
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults.withSnakeCaseMemberNames
+      import sanely.jsoniter.configured.auto.given
+
+      val original = AutoCrossCodec("Alice", "Smith", 30)
+
+      // jsoniter -> circe
+      val jJson = writeToString(original)
+      val cResult = circeDecode[AutoCrossCodec](jJson)
+      assert(cResult == Right(original))
+
+      // circe -> jsoniter
+      val cJson = original.asJson.noSpaces
+      val jResult = readFromString[AutoCrossCodec](cJson)
+      assert(jResult == original)
+
+      // Partial (missing defaults): both decode identically
+      val partial = """{"first_name":"Bob","last_name":"Jones"}"""
+      val cPartial = circeDecode[AutoCrossCodec](partial)
+      val jPartial = readFromString[AutoCrossCodec](partial)
+      assert(cPartial == Right(jPartial))
+      assert(jPartial == AutoCrossCodec("Bob", "Jones", 25))
+    }
+
     test("enum - circe format compatibility") {
       import io.circe.derivation.Configuration
       import io.circe.{Codec as CirceCodec, *}


### PR DESCRIPTION
## Summary

- Add `sanely.jsoniter.configured.auto.given` — auto-derives `JsonValueCodec[T]` for any type with `Mirror.Of` when a `given JsoniterConfiguration` is in scope
- Add `autoConfiguredCodec` to ignore symbols in both `SanelyJsoniter` and `SanelyJsoniterConfigured` to prevent infinite recursion during macro expansion
- 7 new tests: withDefaults, nested types, snake_case, drop-null, discriminator, round-trip, cross-codec with circe
- Mark P0 roadmap item `[x]` in `sanely-jsoniter/ROADMAP.md`

**Usage:**
```scala
given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults
import sanely.jsoniter.configured.auto.given
// All types with Mirror.Of now auto-derive configured JsonValueCodec
```

## Test plan

- [x] `./mill sanely-jsoniter.jvm.test` — 70/70 pass
- [x] `./mill sanely-jsoniter.js.test` — 70/70 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)