### PR TITLE
feat: strict decoding for sanely-jsoniter

### DIFF
--- a/sanely-jsoniter/ROADMAP.md
+++ b/sanely-jsoniter/ROADMAP.md
@@ -8,7 +8,7 @@ Core derivation engine is complete: products, sum types, enums, recursive types,
 
 **What works today**: semi-auto derivation (`deriveJsoniterCodec`, `deriveJsoniterConfiguredCodec`, `deriveJsoniterEnumCodec`) with all configuration options. Auto derivation for standard (non-configured) types.
 
-**What's missing**: auto-configured derivation, cross-codec tests for some config combos, Tapir integration guidance, strict decoding runtime, and REAL-WORLD.md accuracy for configured types.
+**What's missing**: Tapir integration guidance, strict decoding runtime, and migration guide for configured codebases.
 
 ## Completed
 
@@ -32,11 +32,11 @@ Real codebases use configured derivation for the vast majority of types (default
 
 - [x] **Auto-configured derivation** — `sanely.jsoniter.configured.auto.given` that auto-derives `JsonValueCodec[T]` using a `given JsoniterConfiguration` in scope. Without this, every configured type needs explicit `deriveJsoniterConfiguredCodec`. Pattern: `given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults; import sanely.jsoniter.configured.auto.given`. This covers ~500+ call sites in a typical codebase that all use the same base config (withDefaults).
 
-- [ ] **Cross-codec test: discriminator** — Prove that `JsoniterConfiguration.default.withDiscriminator("type")` produces identical JSON to circe's `Configuration.default.withDiscriminator("type")`. Encode with jsoniter → decode with circe and vice versa. ~45 call sites in a typical codebase use discriminator tagging.
+- [x] **Cross-codec test: discriminator** — Prove that `JsoniterConfiguration.default.withDiscriminator("type")` produces identical JSON to circe's `Configuration.default.withDiscriminator("type")`. Encode with jsoniter → decode with circe and vice versa. ~45 call sites in a typical codebase use discriminator tagging.
 
-- [ ] **Cross-codec test: drop-null** — Prove that `withDropNullValues` encoding matches circe's `.mapJsonObject(_.filter(!_._2.isNull))`. Encode with jsoniter → decode with circe. ~5+ call sites.
+- [x] **Cross-codec test: drop-null** — Prove that `withDropNullValues` encoding matches circe's `.mapJsonObject(_.filter(!_._2.isNull))`. Encode with jsoniter → decode with circe. ~5+ call sites.
 
-- [ ] **Cross-codec test: combined configs** — Test the real-world combos: defaults+discriminator, defaults+snake_case+drop-null. These are the actual configuration patterns used in production wrappers.
+- [x] **Cross-codec test: combined configs** — Test the real-world combos: defaults+discriminator, defaults+snake_case+drop-null. These are the actual configuration patterns used in production wrappers.
 
 - [x] **Fix REAL-WORLD.md migration path** — Updated Step 2 to show three paths: (a) auto for standard types, (b) semi-auto with matching config for configured types, (c) extend centralized wrapper for codebases with one. Honest about what the hot path swap requires.
 
@@ -52,7 +52,7 @@ Real codebases use configured derivation for the vast majority of types (default
 
   This is the strongest proof that the REAL-WORLD.md migration path actually works. Without it, the HTTP hot path swap is a theoretical claim.
 
-- [ ] **Strict decoding** — `JsoniterConfiguration.withStrictDecoding` config option exists but is not wired into the runtime. Implement: reject unknown fields during decoding. ~18 call sites in typical codebases use strict decoding via direct `ConfiguredCodec.derived`.
+- [x] **Strict decoding** — `JsoniterConfiguration.withStrictDecoding` config option exists but is not wired into the runtime. Implement: reject unknown fields during decoding. ~18 call sites in typical codebases use strict decoding via direct `ConfiguredCodec.derived`.
 
 - [ ] **Migration guide for configured codebases** — Document the pattern for codebases with centralized configuration wrappers: extend the wrapper to derive both circe and jsoniter codecs side by side. Show how `deriveCodecWithDefaults` gets a parallel `deriveJsoniterCodecWithDefaults`. One-time wrapper change, not per-type.
 

--- a/sanely-jsoniter/src/sanely/jsoniter/JsoniterRuntime.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/JsoniterRuntime.scala
@@ -142,7 +142,8 @@ object JsoniterRuntime:
     discriminator: Option[String],
     initDirectCodecs: () => Array[JsonValueCodec[Any]],
     rawAllLeafLabels: Array[String],
-    initAllLeafCodecs: () => Array[JsonValueCodec[Any]]
+    initAllLeafCodecs: () => Array[JsonValueCodec[Any]],
+    strictDecoding: Boolean = false
   ): JsonValueCodec[S] =
     val directLabels = rawDirectLabels.map(transformConstructorNames)
     val allLeafLabels = rawAllLeafLabels.map(transformConstructorNames)
@@ -186,7 +187,8 @@ object JsoniterRuntime:
     defaults: Array[Any],
     isOption: Array[Boolean],
     useDefaults: Boolean,
-    dropNullValues: Boolean
+    dropNullValues: Boolean,
+    strictDecoding: Boolean = false
   ): JsonValueCodec[P] =
     val names = rawNames.map(transformMemberNames)
     new InlineFieldsCodec[P]:
@@ -200,7 +202,7 @@ object JsoniterRuntime:
 
       def decodeValue(in: JsonReader, default: P): P =
         if in.isNextToken('{') then
-          decodeProductConfigured(in, mirror, names, _codecs, nullValues, hasDefaults, defaults, isOption, useDefaults)
+          decodeProductConfigured(in, mirror, names, _codecs, nullValues, hasDefaults, defaults, isOption, useDefaults, strictDecoding)
         else
           in.readNullOrTokenError(default, '{')
 
@@ -245,7 +247,10 @@ object JsoniterRuntime:
                 results(i) = _codecs(i).decodeValue(in, nullValues(i))
                 matched = true
               i += 1
-            if !matched then in.skip()
+            if !matched then
+              if strictDecoding then
+                in.decodeError(s"Strict decoding: unexpected field; valid fields: ${names.mkString(", ")}")
+              else in.skip()
             continue = in.isNextToken(',')
           if !in.isCurrentToken('}') then in.objectEndOrCommaError()
         else if !in.isCurrentToken('}') then
@@ -259,7 +264,8 @@ object JsoniterRuntime:
     rawLabels: Array[String],
     transformConstructorNames: String => String,
     discriminator: Option[String],
-    initCodecs: () => Array[JsonValueCodec[Any]]
+    initCodecs: () => Array[JsonValueCodec[Any]],
+    strictDecoding: Boolean = false
   ): JsonValueCodec[S] =
     val labels = rawLabels.map(transformConstructorNames)
     discriminator match
@@ -292,7 +298,11 @@ object JsoniterRuntime:
                 default
               else
                 val result = _codecs(idx).decodeValue(in, _codecs(idx).nullValue)
-                if !in.isNextToken('}') then in.objectEndOrCommaError()
+                if strictDecoding then
+                  if !in.isNextToken('}') then
+                    in.decodeError(s"Strict decoding: expected a single key object with one of: ${labels.mkString(", ")}")
+                else
+                  if !in.isNextToken('}') then in.objectEndOrCommaError()
                 result.asInstanceOf[S]
 
       case Some(disc) => // discriminator tagging (flat: fields inline with discriminator)
@@ -508,7 +518,8 @@ object JsoniterRuntime:
     names: Array[String], codecs: Array[JsonValueCodec[Any]],
     nullValues: Array[Any],
     hasDefaults: Array[Boolean], defaults: Array[Any],
-    isOption: Array[Boolean], useDefaults: Boolean
+    isOption: Array[Boolean], useDefaults: Boolean,
+    strictDecoding: Boolean = false
   ): P =
     val n = names.length
     val results = new Array[Any](n)
@@ -534,7 +545,10 @@ object JsoniterRuntime:
             results(i) = codecs(i).decodeValue(in, nullValues(i))
             matched = true
           i += 1
-        if !matched then in.skip()
+        if !matched then
+          if strictDecoding then
+            in.decodeError(s"Strict decoding: unexpected field; valid fields: ${names.mkString(", ")}")
+          else in.skip()
         continue = in.isNextToken(',')
       if !in.isCurrentToken('}') then in.objectEndOrCommaError()
     mirror.fromProduct(new ArrayProduct(results))

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
@@ -89,7 +89,7 @@ object SanelyJsoniterConfigured:
           $mirror, $namesExpr, $conf.transformMemberNames,
           () => $codecsArrayExpr, $nullValuesExpr,
           $hasDefaultArrayExpr, $defaultsArrayExpr, $isOptionArrayExpr,
-          $conf.useDefaults, $conf.dropNullValues)
+          $conf.useDefaults, $conf.dropNullValues, $conf.strictDecoding)
       }
 
     // === Sum derivation (configured) ===
@@ -118,7 +118,7 @@ object SanelyJsoniterConfigured:
             case '[t] => '{ ${codec.asInstanceOf[Expr[JsonValueCodec[t]]]}.asInstanceOf[JsonValueCodec[Any]] }
         }
         val codecsArrayExpr = '{ Array(${Varargs(codecExprs)}*) }
-        '{ JsoniterRuntime.configuredSumCodec[S]($mirror, $labelsExpr, $conf.transformConstructorNames, $conf.discriminator, () => $codecsArrayExpr) }
+        '{ JsoniterRuntime.configuredSumCodec[S]($mirror, $labelsExpr, $conf.transformConstructorNames, $conf.discriminator, () => $codecsArrayExpr, $conf.strictDecoding) }
       else
         val directLabelsExpr = Expr(cases.map(_._1).toArray)
         val isSubTraitExpr = Expr(casesWithSubTrait.map(_._4).toArray)
@@ -147,7 +147,7 @@ object SanelyJsoniterConfigured:
           $mirror, $directLabelsExpr, $isSubTraitExpr,
           $conf.transformConstructorNames, $conf.discriminator,
           () => $directCodecsArrayExpr,
-          $allLeafLabelsExpr, () => $allLeafCodecsArrayExpr) }
+          $allLeafLabelsExpr, () => $allLeafCodecsArrayExpr, $conf.strictDecoding) }
 
     // === Sub-trait leaf collection ===
 

--- a/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
+++ b/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
@@ -940,6 +940,46 @@ object SanelyJsoniterTest extends TestSuite:
       assert(caught.getMessage.contains("does not contain value"))
     }
 
+    // === Strict decoding tests ===
+
+    test("strict - product: unknown field rejected") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withStrictDecoding
+      given JsonValueCodec[WithDefaults] = deriveJsoniterConfiguredCodec
+      val json = """{"name":"Alice","age":25,"active":true,"extra":"bad"}"""
+      val caught =
+        try
+          readFromString[WithDefaults](json)
+          throw new RuntimeException("expected exception")
+        catch
+          case e: com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException => e
+      assert(caught.getMessage.contains("Strict decoding"))
+      assert(caught.getMessage.contains("unexpected field"))
+    }
+
+    test("strict - product: known fields pass") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withStrictDecoding
+      given JsonValueCodec[WithDefaults] = deriveJsoniterConfiguredCodec
+      val json = """{"name":"Alice","age":30,"active":false}"""
+      val decoded = readFromString[WithDefaults](json)
+      assert(decoded == WithDefaults("Alice", 30, false))
+    }
+
+    test("strict - product with defaults: unknown field rejected even with defaults") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults.withStrictDecoding
+      given JsonValueCodec[WithDefaults] = deriveJsoniterConfiguredCodec
+      val json = """{"name":"Alice","unknown":42}"""
+      val caught =
+        try
+          readFromString[WithDefaults](json)
+          throw new RuntimeException("expected exception")
+        catch
+          case e: com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException => e
+      assert(caught.getMessage.contains("Strict decoding"))
+    }
+
+    // Strict sum/discriminator tests are in StrictSumTest.scala
+    // (separate file to avoid Scala.js linker dispatch issue with circe Encoder.AsObject)
+
     // === Auto-configured derivation tests ===
 
     test("auto-configured - withDefaults: missing fields use defaults") {

--- a/sanely-jsoniter/test/src/sanely/jsoniter/StrictSumTest.scala
+++ b/sanely-jsoniter/test/src/sanely/jsoniter/StrictSumTest.scala
@@ -1,0 +1,52 @@
+package sanely.jsoniter
+
+import utest.*
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+
+// Strict sum type tests are in a separate file to avoid a Scala.js linker
+// dispatch issue when configured sum codecs coexist with circe enum codecs
+// in the same compilation unit.
+
+sealed trait StrictVehicle
+case class StrictCar(make: String, year: Int) extends StrictVehicle
+case class StrictBike(brand: String) extends StrictVehicle
+
+object StrictSumTest extends TestSuite:
+  import sanely.jsoniter.semiauto.*
+
+  val tests = Tests {
+    test("strict - sum external: multi-key object rejected") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withStrictDecoding
+      given JsonValueCodec[StrictVehicle] = deriveJsoniterConfiguredCodec
+      val json = """{"StrictCar":{"make":"Toyota","year":2024},"extra":true}"""
+      val caught =
+        try
+          readFromString[StrictVehicle](json)
+          throw new RuntimeException("expected exception")
+        catch
+          case e: com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException => e
+      assert(caught.getMessage.contains("Strict decoding"))
+      assert(caught.getMessage.contains("single key"))
+    }
+
+    test("strict - sum external: single key passes") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withStrictDecoding
+      given JsonValueCodec[StrictVehicle] = deriveJsoniterConfiguredCodec
+      val json = """{"StrictCar":{"make":"Toyota","year":2024}}"""
+      val decoded = readFromString[StrictVehicle](json)
+      assert(decoded == StrictCar("Toyota", 2024))
+    }
+
+    test("strict - discriminator: unknown field in variant rejected") {
+      given JsoniterConfiguration = JsoniterConfiguration.default.withStrictDecoding.withDiscriminator("type")
+      given JsonValueCodec[StrictVehicle] = deriveJsoniterConfiguredCodec
+      val json = """{"type":"StrictCar","make":"Toyota","year":2024,"extra":"bad"}"""
+      val caught =
+        try
+          readFromString[StrictVehicle](json)
+          throw new RuntimeException("expected exception")
+        catch
+          case e: com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException => e
+      assert(caught.getMessage.contains("Strict decoding"))
+    }
+  }


### PR DESCRIPTION
## Summary

- Wire `JsoniterConfiguration.withStrictDecoding` into the runtime — the config field existed but was unused
- Products: reject unknown/unexpected fields during decoding
- Sum types (external tagging): reject multi-key JSON objects
- Sum types (discriminator): reject unknown fields in variant payloads
- Mark remaining P0 cross-codec roadmap items as done (tests already existed from prior PR)

## Test plan

- [x] `./mill sanely-jsoniter.jvm.test` — 76/76 pass (3 + 73 across 2 suites)
- [x] `./mill sanely-jsoniter.js.test` — 76/76 pass

6 new tests: 3 product strict tests + 3 sum strict tests (in separate file to work around Scala.js linker dispatch issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)