### PR TITLE
feat: value enum macro derivation for sanely-jsoniter

### DIFF
--- a/REAL-WORLD.md
+++ b/REAL-WORLD.md
@@ -233,4 +233,4 @@ sanely-jsoniter's core derivation engine is complete — products, sum types, en
 
 **What's ready today**: semi-auto and auto derivation (both standard and configured), cross-codec tests proving format compatibility with circe across all configuration variants, and Tapir integration tests proving the HTTP codec swap works end-to-end.
 
-**What's remaining**: value enum macro derivation, `derives` support, and formal JMH benchmarks. See the [sanely-jsoniter ROADMAP](sanely-jsoniter/ROADMAP.md) for the full tracker.
+**What's remaining**: `derives` support and formal JMH benchmarks. See the [sanely-jsoniter ROADMAP](sanely-jsoniter/ROADMAP.md) for the full tracker.

--- a/sanely-jsoniter/README.md
+++ b/sanely-jsoniter/README.md
@@ -117,6 +117,26 @@ val json = writeToString(Color.Red)        // "Red"
 val back = readFromString[Color](json)     // Color.Red
 ```
 
+### Value enum codec
+
+For enums with a value parameter (e.g., `val value: String` or `val value: Int`):
+
+```scala
+import sanely.jsoniter.semiauto.*
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+
+enum Status(val value: String):
+  case Active extends Status("active")
+  case Inactive extends Status("inactive")
+
+given JsonValueCodec[Status] = deriveJsoniterValueEnumCodec
+
+val json = writeToString(Status.Active)        // "active"
+val back = readFromString[Status](json)        // Status.Active
+```
+
+The macro auto-detects whether the value field is `String` or `Int`. For enums with multiple constructor parameters or other value types, use `Codecs.stringValueEnum` / `Codecs.intValueEnum` manually.
+
 ### Auto derivation
 
 ```scala

--- a/sanely-jsoniter/ROADMAP.md
+++ b/sanely-jsoniter/ROADMAP.md
@@ -58,7 +58,7 @@ Real codebases use configured derivation for the vast majority of types (default
 
 ## P2 — Polish
 
-- [ ] **Value enum macro derivation** — `deriveJsoniterValueEnumCodec` that generates codecs from a `ValueEnumCompanion` or similar pattern, instead of requiring manual `Codecs.stringValueEnum(values, _.value)`.
+- [x] **Value enum macro derivation** — `deriveJsoniterValueEnumCodec` auto-detects String vs Int value field from the enum's constructor parameter. Replaces manual `Codecs.stringValueEnum(values, _.value)` / `Codecs.intValueEnum(values, _.value)`.
 
 - [ ] **`derives` support** — Companion objects like `JsoniterCodec.WithDefaults` that enable `case class Foo(...) derives JsoniterCodec.WithDefaults` syntax. Mirrors the `derives CirceCodec.WithDefaults` pattern used in some codebases (~336 call sites). This is a convenience layer — the underlying `deriveJsoniterConfiguredCodec` already works.
 

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterValueEnum.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterValueEnum.scala
@@ -1,0 +1,57 @@
+package sanely.jsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import scala.deriving.Mirror
+import scala.quoted.*
+
+object SanelyJsoniterValueEnum:
+
+  inline def derived[A](using inline m: Mirror.SumOf[A]): JsonValueCodec[A] =
+    ${ deriveMacro[A] }
+
+  private def deriveMacro[A: Type](using Quotes): Expr[JsonValueCodec[A]] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[A]
+    val sym = tpe.typeSymbol
+
+    // Get constructor parameters (filter out type params)
+    val ctorParams = sym.primaryConstructor.paramSymss.flatten.filterNot(_.isType)
+    if ctorParams.size != 1 then
+      report.errorAndAbort(
+        s"deriveJsoniterValueEnumCodec requires an enum with exactly one constructor parameter, " +
+        s"but ${sym.name} has ${ctorParams.size}. " +
+        s"Use deriveJsoniterEnumCodec for pure enums, or Codecs.stringValueEnum/intValueEnum for custom patterns."
+      )
+
+    val param = ctorParams.head
+    val paramName = param.name
+    val paramType = tpe.memberType(param)
+
+    // companion.values
+    val companion = Ref(sym.companionModule)
+    val valuesMethod = sym.companionModule.methodMember("values")
+      .headOption
+      .getOrElse(report.errorAndAbort(s"${sym.name} companion has no 'values' method — is it a Scala 3 enum?"))
+    val valuesExpr = companion.select(valuesMethod).asExprOf[Array[A]]
+
+    if paramType =:= TypeRepr.of[String] then
+      val toValue = Lambda(
+        Symbol.spliceOwner,
+        MethodType(List("a"))(_ => List(tpe), _ => TypeRepr.of[String]),
+        { case (_, List(a: Term)) => Select.unique(a, paramName) }
+      ).asExprOf[A => String]
+      '{ Codecs.stringValueEnum[A]($valuesExpr, $toValue) }
+    else if paramType =:= TypeRepr.of[Int] then
+      val toValue = Lambda(
+        Symbol.spliceOwner,
+        MethodType(List("a"))(_ => List(tpe), _ => TypeRepr.of[Int]),
+        { case (_, List(a: Term)) => Select.unique(a, paramName) }
+      ).asExprOf[A => Int]
+      '{ Codecs.intValueEnum[A]($valuesExpr, $toValue) }
+    else
+      report.errorAndAbort(
+        s"deriveJsoniterValueEnumCodec supports String and Int value types, " +
+        s"but ${sym.name}.${paramName} has type ${paramType.show}. " +
+        s"Use Codecs.stringValueEnum or Codecs.intValueEnum manually."
+      )

--- a/sanely-jsoniter/src/sanely/jsoniter/semiauto.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/semiauto.scala
@@ -21,3 +21,6 @@ object semiauto:
 
   inline def deriveJsoniterEnumCodec[A](using inline m: Mirror.SumOf[A]): JsonValueCodec[A] =
     SanelyJsoniterEnum.derived[A]
+
+  inline def deriveJsoniterValueEnumCodec[A](using inline m: Mirror.SumOf[A]): JsonValueCodec[A] =
+    SanelyJsoniterValueEnum.derived[A]

--- a/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
+++ b/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
@@ -940,6 +940,64 @@ object SanelyJsoniterTest extends TestSuite:
       assert(caught.getMessage.contains("does not contain value"))
     }
 
+    // === Value enum macro derivation tests ===
+
+    test("value enum macro - string round-trip") {
+      given JsonValueCodec[Status] = deriveJsoniterValueEnumCodec
+      val json = writeToString(Status.Active)
+      assert(json == "\"active\"")
+      val decoded = readFromString[Status](json)
+      assert(decoded == Status.Active)
+    }
+
+    test("value enum macro - all string variants") {
+      given JsonValueCodec[Status] = deriveJsoniterValueEnumCodec
+      for s <- Status.values do
+        val json = writeToString(s)
+        assert(json == s"\"${s.value}\"")
+        val decoded = readFromString[Status](json)
+        assert(decoded == s)
+    }
+
+    test("value enum macro - int round-trip") {
+      given JsonValueCodec[Priority] = deriveJsoniterValueEnumCodec
+      val json = writeToString(Priority.High)
+      assert(json == "3")
+      val decoded = readFromString[Priority](json)
+      assert(decoded == Priority.High)
+    }
+
+    test("value enum macro - all int variants") {
+      given JsonValueCodec[Priority] = deriveJsoniterValueEnumCodec
+      for p <- Priority.values do
+        val json = writeToString(p)
+        assert(json == p.value.toString)
+        val decoded = readFromString[Priority](json)
+        assert(decoded == p)
+    }
+
+    test("value enum macro - unknown string value decode error") {
+      given JsonValueCodec[Status] = deriveJsoniterValueEnumCodec
+      val caught =
+        try
+          readFromString[Status]("\"unknown\"")
+          throw new RuntimeException("expected exception")
+        catch
+          case e: com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException => e
+      assert(caught.getMessage.contains("does not contain value"))
+    }
+
+    test("value enum macro - unknown int value decode error") {
+      given JsonValueCodec[Priority] = deriveJsoniterValueEnumCodec
+      val caught =
+        try
+          readFromString[Priority]("99")
+          throw new RuntimeException("expected exception")
+        catch
+          case e: com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException => e
+      assert(caught.getMessage.contains("does not contain value"))
+    }
+
     // === Strict decoding tests ===
 
     test("strict - product: unknown field rejected") {


### PR DESCRIPTION
## Summary
- Add `deriveJsoniterValueEnumCodec` macro that auto-detects String vs Int value field from the enum's single constructor parameter
- Generates codec by delegating to `Codecs.stringValueEnum` / `Codecs.intValueEnum` at compile time
- 6 new tests (string round-trip, int round-trip, all variants, error handling)
- All 79 JVM + 82 JS tests pass
- Mark P2 roadmap item as complete, update README with usage example

### Usage
```scala
enum Status(val value: String):
  case Active extends Status("active")
  case Inactive extends Status("inactive")

given JsonValueCodec[Status] = deriveJsoniterValueEnumCodec  // just works
```

## Test plan
- [x] `./mill sanely-jsoniter.jvm.test` — 79/79 pass
- [x] `./mill sanely-jsoniter.js.test` — 82/82 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)