### PR TITLE
feat: derives syntax support for sanely-jsoniter

### DIFF
--- a/REAL-WORLD.md
+++ b/REAL-WORLD.md
@@ -233,4 +233,4 @@ sanely-jsoniter's core derivation engine is complete — products, sum types, en
 
 **What's ready today**: semi-auto and auto derivation (both standard and configured), cross-codec tests proving format compatibility with circe across all configuration variants, and Tapir integration tests proving the HTTP codec swap works end-to-end.
 
-**What's remaining**: `derives` support and formal JMH benchmarks. See the [sanely-jsoniter ROADMAP](sanely-jsoniter/ROADMAP.md) for the full tracker.
+**What's remaining**: formal JMH benchmarks. See the [sanely-jsoniter ROADMAP](sanely-jsoniter/ROADMAP.md) for the full tracker.

--- a/sanely-jsoniter/README.md
+++ b/sanely-jsoniter/README.md
@@ -147,6 +147,38 @@ case class User(name: String, age: Int)
 val json = writeToString(User("Bob", 25))  // just works
 ```
 
+### `derives` syntax
+
+```scala
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import sanely.jsoniter.JsoniterCodec
+
+// Standard
+case class Point(x: Int, y: Int) derives JsoniterCodec
+
+// With defaults (missing fields use Scala defaults)
+case class Config(host: String, port: Int = 8080) derives JsoniterCodec.WithDefaults
+
+// Snake_case + defaults
+case class Profile(firstName: String, lastName: String) derives JsoniterCodec.WithSnakeCaseAndDefaults
+
+// Defaults + drop null
+case class Event(name: String, detail: Option[String] = None) derives JsoniterCodec.WithDefaultsDropNull
+
+// Enum string codec
+enum Color derives JsoniterCodec.Enum:
+  case Red, Green, Blue
+
+// Value enum
+enum Level(val value: Int) derives JsoniterCodec.ValueEnum:
+  case Low extends Level(1)
+  case High extends Level(3)
+```
+
+Each wrapper extends `JsonValueCodec[A]` directly, so `derives` makes the codec available without any additional imports or conversions.
+
+Available wrappers: `JsoniterCodec`, `WithDefaults`, `WithDefaultsDropNull`, `WithSnakeCaseAndDefaults`, `WithSnakeCaseAndDefaultsDropNull`, `Enum`, `ValueEnum`.
+
 ## Supported types
 
 - **Products**: Case classes with any number of fields

--- a/sanely-jsoniter/ROADMAP.md
+++ b/sanely-jsoniter/ROADMAP.md
@@ -60,6 +60,6 @@ Real codebases use configured derivation for the vast majority of types (default
 
 - [x] **Value enum macro derivation** — `deriveJsoniterValueEnumCodec` auto-detects String vs Int value field from the enum's constructor parameter. Replaces manual `Codecs.stringValueEnum(values, _.value)` / `Codecs.intValueEnum(values, _.value)`.
 
-- [ ] **`derives` support** — Companion objects like `JsoniterCodec.WithDefaults` that enable `case class Foo(...) derives JsoniterCodec.WithDefaults` syntax. Mirrors the `derives CirceCodec.WithDefaults` pattern used in some codebases (~336 call sites). This is a convenience layer — the underlying `deriveJsoniterConfiguredCodec` already works.
+- [x] **`derives` support** — `JsoniterCodec`, `JsoniterCodec.WithDefaults`, `WithDefaultsDropNull`, `WithSnakeCaseAndDefaults`, `WithSnakeCaseAndDefaultsDropNull`, `Enum`, `ValueEnum`. Each extends `JsonValueCodec[A]` directly so no import conversions needed.
 
 - [ ] **Performance benchmarks vs bridge** — Formal JMH benchmarks comparing sanely-jsoniter direct codecs vs the `jsoniter-scala-circe` bridge approach on realistic payloads (nested products, sum types, optional fields). Current 5x claim is from synthetic benchmarks — validate on real-world-shaped data.

--- a/sanely-jsoniter/src/sanely/jsoniter/JsoniterCodec.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/JsoniterCodec.scala
@@ -1,0 +1,77 @@
+package sanely.jsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonWriter, JsonValueCodec}
+import scala.deriving.Mirror
+
+/** Wrapper types enabling `derives` syntax for JsonValueCodec derivation.
+  *
+  * Each wrapper extends JsonValueCodec directly, so `derives JsoniterCodec.WithDefaults`
+  * makes `JsonValueCodec[A]` available in implicit scope with zero additional imports.
+  *
+  * {{{
+  * case class User(name: String, age: Int = 25) derives JsoniterCodec.WithDefaults
+  *
+  * // JsonValueCodec[User] is now available:
+  * writeToString(User("Alice"))  // just works
+  * }}}
+  */
+final class JsoniterCodec[A](inner: JsonValueCodec[A]) extends JsonValueCodec[A]:
+  def decodeValue(in: JsonReader, default: A): A = inner.decodeValue(in, default)
+  def encodeValue(x: A, out: JsonWriter): Unit = inner.encodeValue(x, out)
+  def nullValue: A = inner.nullValue
+
+object JsoniterCodec:
+  inline def derived[A](using inline m: Mirror.Of[A]): JsoniterCodec[A] =
+    new JsoniterCodec[A](SanelyJsoniter.derived[A])
+
+  final class WithDefaults[A](inner: JsonValueCodec[A]) extends JsonValueCodec[A]:
+    def decodeValue(in: JsonReader, default: A): A = inner.decodeValue(in, default)
+    def encodeValue(x: A, out: JsonWriter): Unit = inner.encodeValue(x, out)
+    def nullValue: A = inner.nullValue
+  object WithDefaults:
+    inline def derived[A](using inline m: Mirror.Of[A]): WithDefaults[A] =
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults
+      new WithDefaults[A](SanelyJsoniterConfigured.derived[A])
+
+  final class WithDefaultsDropNull[A](inner: JsonValueCodec[A]) extends JsonValueCodec[A]:
+    def decodeValue(in: JsonReader, default: A): A = inner.decodeValue(in, default)
+    def encodeValue(x: A, out: JsonWriter): Unit = inner.encodeValue(x, out)
+    def nullValue: A = inner.nullValue
+  object WithDefaultsDropNull:
+    inline def derived[A](using inline m: Mirror.Of[A]): WithDefaultsDropNull[A] =
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults.withDropNullValues
+      new WithDefaultsDropNull[A](SanelyJsoniterConfigured.derived[A])
+
+  final class WithSnakeCaseAndDefaults[A](inner: JsonValueCodec[A]) extends JsonValueCodec[A]:
+    def decodeValue(in: JsonReader, default: A): A = inner.decodeValue(in, default)
+    def encodeValue(x: A, out: JsonWriter): Unit = inner.encodeValue(x, out)
+    def nullValue: A = inner.nullValue
+  object WithSnakeCaseAndDefaults:
+    inline def derived[A](using inline m: Mirror.Of[A]): WithSnakeCaseAndDefaults[A] =
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults.withSnakeCaseMemberNames
+      new WithSnakeCaseAndDefaults[A](SanelyJsoniterConfigured.derived[A])
+
+  final class WithSnakeCaseAndDefaultsDropNull[A](inner: JsonValueCodec[A]) extends JsonValueCodec[A]:
+    def decodeValue(in: JsonReader, default: A): A = inner.decodeValue(in, default)
+    def encodeValue(x: A, out: JsonWriter): Unit = inner.encodeValue(x, out)
+    def nullValue: A = inner.nullValue
+  object WithSnakeCaseAndDefaultsDropNull:
+    inline def derived[A](using inline m: Mirror.Of[A]): WithSnakeCaseAndDefaultsDropNull[A] =
+      given JsoniterConfiguration = JsoniterConfiguration.default.withDefaults.withSnakeCaseMemberNames.withDropNullValues
+      new WithSnakeCaseAndDefaultsDropNull[A](SanelyJsoniterConfigured.derived[A])
+
+  final class Enum[A](inner: JsonValueCodec[A]) extends JsonValueCodec[A]:
+    def decodeValue(in: JsonReader, default: A): A = inner.decodeValue(in, default)
+    def encodeValue(x: A, out: JsonWriter): Unit = inner.encodeValue(x, out)
+    def nullValue: A = inner.nullValue
+  object Enum:
+    inline def derived[A](using inline m: Mirror.SumOf[A]): Enum[A] =
+      new Enum[A](SanelyJsoniterEnum.derived[A])
+
+  final class ValueEnum[A](inner: JsonValueCodec[A]) extends JsonValueCodec[A]:
+    def decodeValue(in: JsonReader, default: A): A = inner.decodeValue(in, default)
+    def encodeValue(x: A, out: JsonWriter): Unit = inner.encodeValue(x, out)
+    def nullValue: A = inner.nullValue
+  object ValueEnum:
+    inline def derived[A](using inline m: Mirror.SumOf[A]): ValueEnum[A] =
+      new ValueEnum[A](SanelyJsoniterValueEnum.derived[A])

--- a/sanely-jsoniter/test/src/sanely/jsoniter/DerivesTest.scala
+++ b/sanely-jsoniter/test/src/sanely/jsoniter/DerivesTest.scala
@@ -1,0 +1,77 @@
+package sanely.jsoniter
+
+import utest.*
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+
+// Test types using `derives` syntax — in a separate file to avoid
+// Scala.js linker interference with circe enum codecs in the main test file.
+case class DPoint(x: Int, y: Int) derives JsoniterCodec
+case class DConfig(host: String, port: Int = 8080, debug: Boolean = false) derives JsoniterCodec.WithDefaults
+case class DProfile(firstName: String, lastName: String, isActive: Boolean = true) derives JsoniterCodec.WithSnakeCaseAndDefaults
+case class DEvent(name: String, detail: Option[String] = None, count: Int = 0) derives JsoniterCodec.WithDefaultsDropNull
+case class DApiResp(requestId: String, errorMsg: Option[String] = None, retryCount: Int = 0) derives JsoniterCodec.WithSnakeCaseAndDefaultsDropNull
+enum DColor derives JsoniterCodec.Enum:
+  case Red, Green, Blue
+enum DLevel(val value: Int) derives JsoniterCodec.ValueEnum:
+  case Low extends DLevel(1)
+  case High extends DLevel(3)
+
+object DerivesTest extends TestSuite:
+
+  val tests = Tests {
+
+    test("derives JsoniterCodec - product round-trip") {
+      val p = DPoint(3, 4)
+      val json = writeToString(p)
+      assert(json == """{"x":3,"y":4}""")
+      assert(readFromString[DPoint](json) == p)
+    }
+
+    test("derives WithDefaults - missing fields use defaults") {
+      val json = """{"host":"localhost"}"""
+      val config = readFromString[DConfig](json)
+      assert(config == DConfig("localhost", 8080, false))
+    }
+
+    test("derives WithSnakeCaseAndDefaults - snake_case field names") {
+      val p = DProfile("Alice", "Smith")
+      val json = writeToString(p)
+      assert(json.contains("\"first_name\""))
+      assert(json.contains("\"last_name\""))
+      assert(json.contains("\"is_active\""))
+      assert(readFromString[DProfile](json) == p)
+    }
+
+    test("derives WithDefaultsDropNull - null fields omitted") {
+      val e = DEvent("click")
+      val json = writeToString(e)
+      assert(!json.contains("null"))
+      assert(json.contains("\"name\":\"click\""))
+      assert(readFromString[DEvent](json) == e)
+    }
+
+    test("derives WithSnakeCaseAndDefaultsDropNull - snake + drop null") {
+      val r = DApiResp("req-1")
+      val json = writeToString(r)
+      assert(json.contains("\"request_id\""))
+      assert(!json.contains("null"))
+      assert(readFromString[DApiResp](json) == r)
+    }
+
+    test("derives Enum - string round-trip") {
+      val json = writeToString(DColor.Red: DColor)
+      assert(json == "\"Red\"")
+      assert(readFromString[DColor](json) == DColor.Red)
+    }
+
+    test("derives ValueEnum - int value round-trip") {
+      val json = writeToString(DLevel.High: DLevel)
+      assert(json == "3")
+      assert(readFromString[DLevel](json) == DLevel.High)
+    }
+
+    test("derives - codec is JsonValueCodec subtype") {
+      val codec: JsonValueCodec[DPoint] = summon[JsoniterCodec[DPoint]]
+      assert(writeToString(DPoint(1, 2))(using codec) == """{"x":1,"y":2}""")
+    }
+  }


### PR DESCRIPTION
## Summary
- Add `JsoniterCodec` wrapper types enabling `case class Foo(...) derives JsoniterCodec.WithDefaults` syntax
- 7 wrappers: `JsoniterCodec`, `WithDefaults`, `WithDefaultsDropNull`, `WithSnakeCaseAndDefaults`, `WithSnakeCaseAndDefaultsDropNull`, `Enum`, `ValueEnum`
- Each wrapper **extends `JsonValueCodec[A]`** directly, so no import conversions needed — the codec is available in implicit scope automatically
- 8 new tests in a separate test file (avoids a Scala.js linker issue when `derives Enum` types coexist with circe enum codecs in the same file)

### Usage
```scala
case class Config(host: String, port: Int = 8080) derives JsoniterCodec.WithDefaults

// JsonValueCodec[Config] is now available:
writeToString(Config("localhost"))  // just works
```

## Test plan
- [x] `./mill sanely-jsoniter.jvm.test` — 90/90 pass (79 + 8 derives + 3 strict)
- [x] `./mill sanely-jsoniter.js.test` — 90/90 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)