### PR TITLE
perf: inline encode with direct field access (P3.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Important Rules
 
 - **This is a purely open source project.** Never mention any company names, internal projects, proprietary codebases, or employer-related information anywhere — not in code, commit messages, PR descriptions, comments, changelogs, or documentation. All references must remain generic and public.
+- **No dead code.** When replacing an implementation, delete the old one entirely. No deprecation, no keeping old code "for backwards compatibility." The only contract that matters is 100% circe compatibility — internal APIs can change freely. Keep the codebase clean and current.
 
 ## Project
 

--- a/sanely-jsoniter/src/sanely/jsoniter/JsoniterRuntime.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/JsoniterRuntime.scala
@@ -32,7 +32,8 @@ object JsoniterRuntime:
     mirror: => Mirror.ProductOf[P],
     names: Array[String],
     initCodecs: () => Array[JsonValueCodec[Any]],
-    nullValues: Array[Any]
+    nullValues: Array[Any],
+    encodeFn: (P, Array[JsonValueCodec[Any]], JsonWriter) => Unit
   ): JsonValueCodec[P] =
     new JsonValueCodec[P]:
       private lazy val _codecs = initCodecs()
@@ -40,7 +41,10 @@ object JsoniterRuntime:
 
       def encodeValue(x: P, out: JsonWriter): Unit =
         if (x: Any) == null then out.writeNull()
-        else encodeProduct(x.asInstanceOf[Product], names, _codecs, out)
+        else
+          out.writeObjectStart()
+          encodeFn(x, _codecs, out)
+          out.writeObjectEnd()
 
       def decodeValue(in: JsonReader, default: P): P =
         if in.isNextToken('{') then
@@ -188,7 +192,9 @@ object JsoniterRuntime:
     isOption: Array[Boolean],
     useDefaults: Boolean,
     dropNullValues: Boolean,
-    strictDecoding: Boolean = false
+    strictDecoding: Boolean,
+    encodeFn: (P, Array[String], Array[JsonValueCodec[Any]], JsonWriter) => Unit,
+    encodeDropNullFn: (P, Array[String], Array[JsonValueCodec[Any]], JsonWriter) => Unit
   ): JsonValueCodec[P] =
     val names = rawNames.map(transformMemberNames)
     new InlineFieldsCodec[P]:
@@ -197,8 +203,11 @@ object JsoniterRuntime:
 
       def encodeValue(x: P, out: JsonWriter): Unit =
         if (x: Any) == null then out.writeNull()
-        else if dropNullValues then encodeProductDropNull(x.asInstanceOf[Product], names, _codecs, out)
-        else encodeProduct(x.asInstanceOf[Product], names, _codecs, out)
+        else
+          out.writeObjectStart()
+          if dropNullValues then encodeDropNullFn(x, names, _codecs, out)
+          else encodeFn(x, names, _codecs, out)
+          out.writeObjectEnd()
 
       def decodeValue(in: JsonReader, default: P): P =
         if in.isNextToken('{') then
@@ -208,20 +217,8 @@ object JsoniterRuntime:
 
       def encodeFields(x: P, out: JsonWriter): Unit =
         if (x: Any) != null then
-          val product = x.asInstanceOf[Product]
-          val n = names.length
-          var i = 0
-          while i < n do
-            val v = product.productElement(i)
-            if dropNullValues then
-              val isNull = v == null || (v.isInstanceOf[Option[?]] && v.asInstanceOf[Option[?]].isEmpty)
-              if !isNull then
-                out.writeNonEscapedAsciiKey(names(i))
-                _codecs(i).encodeValue(v, out)
-            else
-              out.writeNonEscapedAsciiKey(names(i))
-              _codecs(i).encodeValue(v, out)
-            i += 1
+          if dropNullValues then encodeDropNullFn(x, names, _codecs, out)
+          else encodeFn(x, names, _codecs, out)
 
       def decodeFieldsAfterDiscriminator(in: JsonReader): P =
         val n = names.length
@@ -235,7 +232,6 @@ object JsoniterRuntime:
             i += 1
         else
           System.arraycopy(nullValues, 0, results, 0, n)
-        // After discriminator value, next token is ',' (more fields) or '}' (done)
         if in.isNextToken(',') then
           var continue = true
           while continue do
@@ -460,33 +456,6 @@ object JsoniterRuntime:
       i += 1
 
   // === Internal helpers ===
-
-  private def encodeProduct(
-    x: Product, names: Array[String],
-    codecs: Array[JsonValueCodec[Any]], out: JsonWriter
-  ): Unit =
-    out.writeObjectStart()
-    var i = 0
-    while i < names.length do
-      out.writeNonEscapedAsciiKey(names(i))
-      codecs(i).encodeValue(x.productElement(i), out)
-      i += 1
-    out.writeObjectEnd()
-
-  private def encodeProductDropNull(
-    x: Product, names: Array[String],
-    codecs: Array[JsonValueCodec[Any]], out: JsonWriter
-  ): Unit =
-    out.writeObjectStart()
-    var i = 0
-    while i < names.length do
-      val v = x.productElement(i)
-      val isNull = v == null || (v.isInstanceOf[Option[?]] && v.asInstanceOf[Option[?]].isEmpty)
-      if !isNull then
-        out.writeNonEscapedAsciiKey(names(i))
-        codecs(i).encodeValue(v, out)
-      i += 1
-    out.writeObjectEnd()
 
   private def decodeProduct[P](
     in: JsonReader, mirror: Mirror.ProductOf[P],

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
@@ -1,6 +1,6 @@
 package sanely.jsoniter
 
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, JsonWriter}
 import scala.deriving.Mirror
 import scala.collection.mutable
 import scala.compiletime.*
@@ -59,7 +59,29 @@ object SanelyJsoniter:
       }
       val nullValuesExpr = '{ Array(${Varargs(nullValueExprs)}*) }
 
-      '{ JsoniterRuntime.productCodec[P]($mirror, $namesExpr, () => $codecsArrayExpr, $nullValuesExpr) }
+      val encodeFnExpr = '{ (x: P, codecs: Array[JsonValueCodec[Any]], out: JsonWriter) =>
+        ${ generateFieldWrites[P]('x, 'codecs, 'out, fields) }
+      }
+
+      '{ JsoniterRuntime.productCodec[P]($mirror, $namesExpr, () => $codecsArrayExpr, $nullValuesExpr, $encodeFnExpr) }
+
+    private def generateFieldWrites[P: Type](
+      x: Expr[P], codecs: Expr[Array[JsonValueCodec[Any]]], out: Expr[JsonWriter],
+      fields: List[(String, Type[?], Expr[JsonValueCodec[?]])]
+    ): Expr[Unit] =
+      val stmts = fields.zipWithIndex.map { case ((name, tpe, _), idx) =>
+        tpe match
+          case '[t] =>
+            val fieldAccess = Select.unique(x.asTerm, name).asExprOf[t]
+            '{
+              $out.writeNonEscapedAsciiKey(${Expr(name)})
+              $codecs(${Expr(idx)}).encodeValue($fieldAccess.asInstanceOf[Any], $out)
+            }
+      }
+      if stmts.isEmpty then '{ () }
+      else
+        val terms = stmts.map(_.asTerm)
+        Block(terms.init.toList, terms.last).asExprOf[Unit]
 
     // === Sum derivation ===
 

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
@@ -1,6 +1,6 @@
 package sanely.jsoniter
 
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonValueCodec, JsonWriter}
 import scala.deriving.Mirror
 import scala.collection.mutable
 import scala.compiletime.*
@@ -84,13 +84,60 @@ object SanelyJsoniterConfigured:
       }
       val isOptionArrayExpr = '{ Array(${Varargs(isOptionExprs)}*) }
 
+      val encodeFnExpr = '{ (x: P, names: Array[String], codecs: Array[JsonValueCodec[Any]], out: JsonWriter) =>
+        ${ generateConfiguredFieldWrites[P]('x, 'names, 'codecs, 'out, fields) }
+      }
+      val encodeDropNullFnExpr = '{ (x: P, names: Array[String], codecs: Array[JsonValueCodec[Any]], out: JsonWriter) =>
+        ${ generateConfiguredFieldWritesDropNull[P]('x, 'names, 'codecs, 'out, fields) }
+      }
+
       '{
         JsoniterRuntime.configuredProductCodec[P](
           $mirror, $namesExpr, $conf.transformMemberNames,
           () => $codecsArrayExpr, $nullValuesExpr,
           $hasDefaultArrayExpr, $defaultsArrayExpr, $isOptionArrayExpr,
-          $conf.useDefaults, $conf.dropNullValues, $conf.strictDecoding)
+          $conf.useDefaults, $conf.dropNullValues, $conf.strictDecoding,
+          $encodeFnExpr, $encodeDropNullFnExpr)
       }
+
+    private def generateConfiguredFieldWrites[P: Type](
+      x: Expr[P], names: Expr[Array[String]], codecs: Expr[Array[JsonValueCodec[Any]]], out: Expr[JsonWriter],
+      fields: List[(String, Type[?], Expr[JsonValueCodec[?]])]
+    ): Expr[Unit] =
+      val stmts = fields.zipWithIndex.map { case ((name, tpe, _), idx) =>
+        tpe match
+          case '[t] =>
+            val fieldAccess = Select.unique(x.asTerm, name).asExprOf[t]
+            '{
+              $out.writeNonEscapedAsciiKey($names(${Expr(idx)}))
+              $codecs(${Expr(idx)}).encodeValue($fieldAccess.asInstanceOf[Any], $out)
+            }
+      }
+      if stmts.isEmpty then '{ () }
+      else
+        val terms = stmts.map(_.asTerm)
+        Block(terms.init.toList, terms.last).asExprOf[Unit]
+
+    private def generateConfiguredFieldWritesDropNull[P: Type](
+      x: Expr[P], names: Expr[Array[String]], codecs: Expr[Array[JsonValueCodec[Any]]], out: Expr[JsonWriter],
+      fields: List[(String, Type[?], Expr[JsonValueCodec[?]])]
+    ): Expr[Unit] =
+      val stmts = fields.zipWithIndex.map { case ((name, tpe, _), idx) =>
+        tpe match
+          case '[t] =>
+            val fieldAccess = Select.unique(x.asTerm, name).asExprOf[t]
+            '{
+              val v: Any = $fieldAccess.asInstanceOf[Any]
+              val isNull = v == null || (v.isInstanceOf[Option[?]] && v.asInstanceOf[Option[?]].isEmpty)
+              if !isNull then
+                $out.writeNonEscapedAsciiKey($names(${Expr(idx)}))
+                $codecs(${Expr(idx)}).encodeValue(v, $out)
+            }
+      }
+      if stmts.isEmpty then '{ () }
+      else
+        val terms = stmts.map(_.asTerm)
+        Block(terms.init.toList, terms.last).asExprOf[Unit]
 
     // === Sum derivation (configured) ===
 


### PR DESCRIPTION
## Summary

- Macro-generated encode closures use `Select.unique` for direct field access (`x.name`, `x.age`) instead of `productElement(i)`, eliminating virtual dispatch and reducing boxing overhead
- Applied to both standard and configured product derivation in sanely-jsoniter
- Removed old `productElement`-based encode helpers (`encodeProduct`, `encodeProductDropNull`) — no dead code

## Benchmark

Writing throughput: **~576K → ~638K ops/sec (+10.7%)**. Reading unchanged (decode path untouched).

## Test plan

- [x] `./mill sanely-jsoniter.jvm.test` — 90/90 passed
- [x] `./mill sanely-jsoniter.js.test` — 90/90 passed
- [x] `./mill tapir-test.test` — 8/8 passed
- [x] `bash bench-runtime.sh 5 5` — writing +10.7%

🤖 Generated with [Claude Code](https://claude.com/claude-code)