### PR TITLE
perf: direct primitive write calls in encode (P3.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ circe-sanely-auto fixes compile time. For **runtime** performance, there are two
 
 | Approach | Reading (ops/sec) | | Writing (ops/sec) | |
 |---|---|---|---|---|
-| **circe + jawn** (baseline) | ~140K | 1.0x | ~128K | 1.0x |
-| **circe + jsoniter bridge** | ~207K | **1.5x** | ~113K | 0.9x |
-| **sanely-jsoniter** (experimental) | **~476K** | **3.4x** | **~576K** | **4.5x** |
-| jsoniter-scala native | ~696K | 5.0x | ~738K | 5.8x |
+| **circe + jawn** (baseline) | ~131K | 1.0x | ~115K | 1.0x |
+| **circe + jsoniter bridge** | ~190K | **1.5x** | ~110K | 1.0x |
+| **sanely-jsoniter** (experimental) | **~431K** | **3.3x** | **~630K** | **5.5x** |
+| jsoniter-scala native | ~646K | 4.9x | ~682K | 5.9x |
 
 #### Option 1: jsoniter-scala-circe bridge (1.5x read, drop-in)
 

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
@@ -73,15 +73,39 @@ object SanelyJsoniter:
         tpe match
           case '[t] =>
             val fieldAccess = Select.unique(x.asTerm, name).asExprOf[t]
+            val writeValue = tryDirectWrite[t](fieldAccess, out).getOrElse(
+              '{ $codecs(${Expr(idx)}).encodeValue($fieldAccess.asInstanceOf[Any], $out) }
+            )
             '{
               $out.writeNonEscapedAsciiKey(${Expr(name)})
-              $codecs(${Expr(idx)}).encodeValue($fieldAccess.asInstanceOf[Any], $out)
+              $writeValue
             }
       }
       if stmts.isEmpty then '{ () }
       else
         val terms = stmts.map(_.asTerm)
         Block(terms.init.toList, terms.last).asExprOf[Unit]
+
+    private def tryDirectWrite[T: Type](fa: Expr[T], out: Expr[JsonWriter]): Option[Expr[Unit]] =
+      val tpe = TypeRepr.of[T].dealias
+      if tpe =:= TypeRepr.of[Int] then Some('{ $out.writeVal(${fa.asExprOf[Int]}) })
+      else if tpe =:= TypeRepr.of[Long] then Some('{ $out.writeVal(${fa.asExprOf[Long]}) })
+      else if tpe =:= TypeRepr.of[Float] then Some('{ $out.writeVal(${fa.asExprOf[Float]}) })
+      else if tpe =:= TypeRepr.of[Double] then Some('{ $out.writeVal(${fa.asExprOf[Double]}) })
+      else if tpe =:= TypeRepr.of[Boolean] then Some('{ $out.writeVal(${fa.asExprOf[Boolean]}) })
+      else if tpe =:= TypeRepr.of[Short] then Some('{ $out.writeVal(${fa.asExprOf[Short]}.toInt) })
+      else if tpe =:= TypeRepr.of[Byte] then Some('{ $out.writeVal(${fa.asExprOf[Byte]}.toInt) })
+      else if tpe =:= TypeRepr.of[Char] then Some('{ $out.writeVal(${fa.asExprOf[Char]}.toString) })
+      else if tpe =:= TypeRepr.of[String] then
+        val s = fa.asExprOf[String]
+        Some('{ val _v = $s; if _v == null then $out.writeNull() else $out.writeVal(_v) })
+      else if tpe =:= TypeRepr.of[BigDecimal] then
+        val bd = fa.asExprOf[BigDecimal]
+        Some('{ val _v = $bd; if _v == null then $out.writeNull() else $out.writeVal(_v) })
+      else if tpe =:= TypeRepr.of[BigInt] then
+        val bi = fa.asExprOf[BigInt]
+        Some('{ val _v = $bi; if _v == null then $out.writeNull() else $out.writeVal(_v) })
+      else None
 
     // === Sum derivation ===
 

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniterConfigured.scala
@@ -108,9 +108,12 @@ object SanelyJsoniterConfigured:
         tpe match
           case '[t] =>
             val fieldAccess = Select.unique(x.asTerm, name).asExprOf[t]
+            val writeValue = tryDirectWrite[t](fieldAccess, out).getOrElse(
+              '{ $codecs(${Expr(idx)}).encodeValue($fieldAccess.asInstanceOf[Any], $out) }
+            )
             '{
               $out.writeNonEscapedAsciiKey($names(${Expr(idx)}))
-              $codecs(${Expr(idx)}).encodeValue($fieldAccess.asInstanceOf[Any], $out)
+              $writeValue
             }
       }
       if stmts.isEmpty then '{ () }
@@ -126,18 +129,65 @@ object SanelyJsoniterConfigured:
         tpe match
           case '[t] =>
             val fieldAccess = Select.unique(x.asTerm, name).asExprOf[t]
-            '{
-              val v: Any = $fieldAccess.asInstanceOf[Any]
-              val isNull = v == null || (v.isInstanceOf[Option[?]] && v.asInstanceOf[Option[?]].isEmpty)
-              if !isNull then
-                $out.writeNonEscapedAsciiKey($names(${Expr(idx)}))
-                $codecs(${Expr(idx)}).encodeValue(v, $out)
+            val idxExpr = Expr(idx)
+            tryDirectWriteDropNull[t](fieldAccess, names, idxExpr, out).getOrElse {
+              '{
+                val v: Any = $fieldAccess.asInstanceOf[Any]
+                val isNull = v == null || (v.isInstanceOf[Option[?]] && v.asInstanceOf[Option[?]].isEmpty)
+                if !isNull then
+                  $out.writeNonEscapedAsciiKey($names($idxExpr))
+                  $codecs($idxExpr).encodeValue(v, $out)
+              }
             }
       }
       if stmts.isEmpty then '{ () }
       else
         val terms = stmts.map(_.asTerm)
         Block(terms.init.toList, terms.last).asExprOf[Unit]
+
+    private def tryDirectWrite[T: Type](fa: Expr[T], out: Expr[JsonWriter]): Option[Expr[Unit]] =
+      val tpe = TypeRepr.of[T].dealias
+      if tpe =:= TypeRepr.of[Int] then Some('{ $out.writeVal(${fa.asExprOf[Int]}) })
+      else if tpe =:= TypeRepr.of[Long] then Some('{ $out.writeVal(${fa.asExprOf[Long]}) })
+      else if tpe =:= TypeRepr.of[Float] then Some('{ $out.writeVal(${fa.asExprOf[Float]}) })
+      else if tpe =:= TypeRepr.of[Double] then Some('{ $out.writeVal(${fa.asExprOf[Double]}) })
+      else if tpe =:= TypeRepr.of[Boolean] then Some('{ $out.writeVal(${fa.asExprOf[Boolean]}) })
+      else if tpe =:= TypeRepr.of[Short] then Some('{ $out.writeVal(${fa.asExprOf[Short]}.toInt) })
+      else if tpe =:= TypeRepr.of[Byte] then Some('{ $out.writeVal(${fa.asExprOf[Byte]}.toInt) })
+      else if tpe =:= TypeRepr.of[Char] then Some('{ $out.writeVal(${fa.asExprOf[Char]}.toString) })
+      else if tpe =:= TypeRepr.of[String] then
+        val s = fa.asExprOf[String]
+        Some('{ val _v = $s; if _v == null then $out.writeNull() else $out.writeVal(_v) })
+      else if tpe =:= TypeRepr.of[BigDecimal] then
+        val bd = fa.asExprOf[BigDecimal]
+        Some('{ val _v = $bd; if _v == null then $out.writeNull() else $out.writeVal(_v) })
+      else if tpe =:= TypeRepr.of[BigInt] then
+        val bi = fa.asExprOf[BigInt]
+        Some('{ val _v = $bi; if _v == null then $out.writeNull() else $out.writeVal(_v) })
+      else None
+
+    private def tryDirectWriteDropNull[T: Type](
+      fa: Expr[T], names: Expr[Array[String]], idx: Expr[Int], out: Expr[JsonWriter]
+    ): Option[Expr[Unit]] =
+      val tpe = TypeRepr.of[T].dealias
+      if tpe =:= TypeRepr.of[Int] then Some('{ $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(${fa.asExprOf[Int]}) })
+      else if tpe =:= TypeRepr.of[Long] then Some('{ $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(${fa.asExprOf[Long]}) })
+      else if tpe =:= TypeRepr.of[Float] then Some('{ $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(${fa.asExprOf[Float]}) })
+      else if tpe =:= TypeRepr.of[Double] then Some('{ $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(${fa.asExprOf[Double]}) })
+      else if tpe =:= TypeRepr.of[Boolean] then Some('{ $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(${fa.asExprOf[Boolean]}) })
+      else if tpe =:= TypeRepr.of[Short] then Some('{ $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(${fa.asExprOf[Short]}.toInt) })
+      else if tpe =:= TypeRepr.of[Byte] then Some('{ $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(${fa.asExprOf[Byte]}.toInt) })
+      else if tpe =:= TypeRepr.of[Char] then Some('{ $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(${fa.asExprOf[Char]}.toString) })
+      else if tpe =:= TypeRepr.of[String] then
+        val s = fa.asExprOf[String]
+        Some('{ val _v = $s; if _v != null then { $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(_v) } })
+      else if tpe =:= TypeRepr.of[BigDecimal] then
+        val bd = fa.asExprOf[BigDecimal]
+        Some('{ val _v = $bd; if _v != null then { $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(_v) } })
+      else if tpe =:= TypeRepr.of[BigInt] then
+        val bi = fa.asExprOf[BigInt]
+        Some('{ val _v = $bi; if _v != null then { $out.writeNonEscapedAsciiKey($names($idx)); $out.writeVal(_v) } })
+      else None
 
     // === Sum derivation (configured) ===
 


### PR DESCRIPTION
## Summary

- For primitive fields, the macro now emits direct `out.writeVal(x.field)` instead of `codecs(idx).encodeValue(x.field.asInstanceOf[Any], out)` — eliminates virtual dispatch + boxing
- Applies to `generateFieldWrites` (non-configured), `generateConfiguredFieldWrites`, and `generateConfiguredFieldWritesDropNull`
- Codec array unchanged — decode path unaffected

## Benchmark (10 warmup, 10 measured)

Writing throughput:

| | Before (P3.1) | After (P3.2) | vs jsoniter-scala native |
|---|---|---|---|
| sanely-jsoniter | ~576K ops/sec (4.5x) | **~630K ops/sec (5.5x)** | 92% (was 78%) |

Reading unchanged (~431K ops/sec, decode path not modified).

## Test plan

- [x] sanely-jsoniter JVM tests (90 passed)
- [x] sanely-jsoniter JS tests (90 passed)
- [x] tapir integration tests (8 passed)
- [x] Runtime benchmark (10+10 iterations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)