### PR TITLE
perf: hash-based field key dispatch (P3.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,18 @@ This contract is enforced by 327 tests — including 192 property-based tests au
 | **Memory allocations** | 8,547 samples | **4,168 samples** | **51% less** |
 | **Peak RSS** | 963 MB | **769 MB** | **20% less** |
 
-### Runtime — 4.8x faster reads, 6x faster writes
+### Runtime — 4.8x faster reads, 6.2x faster writes
 
 ~1.4 KB JSON payload, nested products, sealed traits, optional fields:
 
 | Approach | Reading (ops/sec) | | Writing (ops/sec) | |
 |---|---|---|---|---|
-| **circe + jawn** (baseline) | ~136K | 1.0x | ~121K | 1.0x |
-| **circe + jsoniter bridge** | ~197K | 1.5x | ~111K | 0.9x |
-| **sanely-jsoniter** | **~655K** | **4.8x** | **~732K** | **6.0x** |
-| jsoniter-scala native | ~667K | 4.9x | ~729K | 6.0x |
+| **circe + jawn** (baseline) | ~139K | 1.0x | ~126K | 1.0x |
+| **circe + jsoniter bridge** | ~206K | 1.5x | ~112K | 0.9x |
+| **sanely-jsoniter** | **~669K** | **4.8x** | **~783K** | **6.2x** |
+| jsoniter-scala native | ~684K | 4.9x | ~737K | 5.8x |
 
-sanely-jsoniter reaches **98% of jsoniter-scala native** on decode and **matches it** on encode — while producing circe-compatible JSON on the wire.
+sanely-jsoniter reaches **98% of jsoniter-scala native** on decode and **surpasses it by 6%** on encode — while producing circe-compatible JSON on the wire.
 
 <details>
 <summary>Benchmark methodology & cross-session stability</summary>
@@ -60,7 +60,7 @@ sanely-jsoniter reaches **98% of jsoniter-scala native** on decode and **matches
 
 **Compile-time**: Measured with [hyperfine](https://github.com/sharkdp/hyperfine) (`bash bench.sh 10`). Each run cleans only the benchmark module's output then recompiles ~300 types (auto) or ~230 types (configured). One untimed warmup run ensures the Mill daemon JVM is JIT-warm. Ten timed runs follow, with hyperfine randomizing execution order. Dependencies are pre-compiled and cached. Cross-session stability: speedup ranged 2.88x–3.01x across 25 runs in 3 separate sessions.
 
-**Runtime**: Each configuration runs 5 warmup + 5 measured iterations of 1 second each. Three full benchmark runs were performed to verify consistency. Reading ranged 647K–667K ops/sec across runs; writing ranged 660K–770K ops/sec. Numbers reported are the median run.
+**Runtime**: Each configuration runs 5 warmup + 5 measured iterations of 1 second each. Three full benchmark runs were performed to verify consistency. Reading ranged 667K–670K ops/sec across runs; writing ranged 778K–785K ops/sec. Numbers reported are the median run.
 
 **Fairness**: Both libraries compile the same source files, same Scala version, same JVM, same Mill daemon, in the same hyperfine invocation. The only difference is the derivation import.
 </details>
@@ -148,11 +148,24 @@ T  →  JsonValueCodec[T]  →  bytes
 The macro generates optimized codec bodies using TASTy API:
 
 - **Typed local variables** — `var _0: Int = 0; var _1: String = null` instead of `Array[Any]`, keeping primitives unboxed on the stack during the decode loop
-- **Unrolled if-else field matching** — compile-time-known field names in an inlined chain (`if isCharBufEqualsTo(keyLen, "name") then ... else if ...`) instead of runtime linear scan over an array
+- **Hash-based field dispatch** — for types with > 8 fields, `(in.charBufToHashCode(l): @switch) match { ... }` with compile-time pre-computed hashes; small types keep a linear if-else chain
 - **Direct primitive read/write calls** — `in.readInt()`, `out.writeVal(x.age)` instead of virtual dispatch through `codec.decodeValue()`/`codec.encodeValue()` for primitive fields
 - **Boxing only at the boundary** — primitives stay unboxed through the entire field loop, boxing once at the final `mirror.fromProduct` call
+- **Branchless product encoding** — every field is unconditionally written in a straight-line sequence: write-key, write-value, write-key, write-value. No per-field conditional checks
 
-This brings sanely-jsoniter to 98% of jsoniter-scala native speed on decode, and matching on encode.
+This brings sanely-jsoniter to 98% of jsoniter-scala native speed on decode, and surpassing it by 6% on encode.
+
+<details>
+<summary>Why writes are faster than jsoniter-scala native</summary>
+
+sanely-jsoniter surpasses jsoniter-scala native on writes despite producing more output (1414 vs 1394 bytes). The difference comes down to branching:
+
+jsoniter-scala's default configuration (`transientNone`, `transientEmpty`, `transientDefault` all enabled) generates per-field conditional branches. For every `Option` field: `if (v ne None) { writeKey; writeVal(v.get) }`. For every collection: `if (!v.isEmpty) { writeKey; writeArray }`. For every field with a default: `if (v != default) { writeKey; writeVal }`. A type like `User` with 9 fields gets 3+ conditional branches in its encode method.
+
+sanely-jsoniter writes every field unconditionally — the circe format requires `null` for `None` and always includes all fields. The macro emits a branchless straight-line sequence with no decision logic per field. Fewer branches means the CPU pipeline stays full and the JIT compiler can optimize the tight loop more aggressively.
+
+In short: writing more data with a simpler code path beats writing less data with a complex one.
+</details>
 
 ## Compatibility
 

--- a/sanely-jsoniter/ROADMAP.md
+++ b/sanely-jsoniter/ROADMAP.md
@@ -62,23 +62,23 @@ Real codebases use configured derivation for the vast majority of types (default
 
 - [x] **`derives` support** — `JsoniterCodec`, `JsoniterCodec.WithDefaults`, `WithDefaultsDropNull`, `WithSnakeCaseAndDefaults`, `WithSnakeCaseAndDefaultsDropNull`, `Enum`, `ValueEnum`. Each extends `JsonValueCodec[A]` directly so no import conversions needed.
 
-- [x] **Performance benchmarks vs bridge** — Runtime benchmark with realistic payload (~1.4 KB: nested products, sealed trait sum types, optional fields). sanely-jsoniter: **3.4x read / 4.5x write** vs circe-jawn; bridge: **1.5x read / 0.9x write**; jsoniter-scala native: **5.0x read / 5.8x write**.
+- [x] **Performance benchmarks vs bridge** — Runtime benchmark with realistic payload (~1.4 KB: nested products, sealed trait sum types, optional fields). sanely-jsoniter: **4.8x read / 6.2x write** vs circe-jawn; bridge: **1.5x read / 0.9x write**; jsoniter-scala native: **4.9x read / 5.8x write**.
 
 ## P3 — Performance (closing the gap with native jsoniter-scala)
 
-sanely-jsoniter currently reaches **68-78%** of jsoniter-scala native speed. The gap comes from runtime indirection that jsoniter-scala avoids by generating fully-specialized code at compile time. These items address each bottleneck independently — each delivers measurable improvement and can be landed separately.
+With P3.1–P3.4 complete, sanely-jsoniter reaches **98% of jsoniter-scala native** on decode and **surpasses it by 6%** on encode. The remaining gap on decode comes from circe format constraints (external tagging, null-writing for None).
 
 ### Encoding bottlenecks
 
-- [ ] **P3.1: Inline encode with direct field access** — Currently `encodeProduct` calls `x.productElement(i)` which returns `Any`, boxing every primitive (Int, Long, Double, Boolean). The macro should generate the encode loop body directly: `out.writeNonEscapedAsciiKey("name"); codec_name.encodeValue(x.name, out)` — using direct field accessors (`x.name`, `x.age`) instead of indexed `productElement`. This eliminates boxing for all field types. Applies to both standard and configured product codecs, including `encodeFields` (discriminator inline encoding) and `encodeProductDropNull`.
+- [x] **P3.1: Inline encode with direct field access** — Macro generates encode loop with direct field accessors (`x.name`, `x.age`) instead of `x.productElement(i)`, eliminating boxing.
 
-- [ ] **P3.2: Direct primitive write calls** — Building on P3.1, for primitive-typed fields (String, Int, Long, Double, Float, Boolean, Byte, Short, Char, BigDecimal, BigInt), call `out.writeVal(x.age)` directly instead of going through `JsonValueCodec[Int].encodeValue(x.age, out)`. The macro detects primitive types at compile time and emits the direct call, eliminating both codec array lookup and virtual dispatch for the most common field types. Non-primitive fields still go through their codec.
+- [x] **P3.2: Direct primitive write calls** — For primitive-typed fields, emits `out.writeVal(x.age)` directly instead of going through `JsonValueCodec[Int].encodeValue`.
 
 ### Decoding bottlenecks
 
-- [ ] **P3.3: Inline decode with typed locals** — Currently decoded values go into `Array[Any]` (boxing), wrapped in `ArrayProduct`, then passed to `mirror.fromProduct()`. The macro should generate typed local variables: `var _name: String = null; var _age: Int = 0`, assign them during field matching, and construct the result directly (either via `new T(...)` or `mirror.fromProduct` with a typed product). This eliminates boxing on the decode path. Applies to both `decodeProduct` and `decodeProductConfigured`.
+- [x] **P3.3: Inline decode with typed locals** — Macro generates typed local variables (`var _name: String = null; var _age: Int = 0`) instead of `Array[Any]` boxing.
 
-- [ ] **P3.4: Hash-based field key dispatch** — Currently field matching does linear scan: `while i < n && !matched do if in.isCharBufEqualsTo(keyLen, names(i))`. For products with many fields, this is O(fields²) per object. Pre-compute field name hashes at compile time and generate a hash-switch: compute hash from `in.charBuf`, match to candidate field(s), verify with `isCharBufEqualsTo` only for hash collisions. jsoniter-scala uses a trie-based approach; a simpler hash dispatch gets most of the benefit.
+- [x] **P3.4: Hash-based field key dispatch** — For products with > 8 fields or > 64 total field name chars, generates `(in.charBufToHashCode(l): @switch) match { ... }` with compile-time pre-computed hashes. Hash collisions fall back to `isCharBufEqualsTo`. Products with ≤ 8 fields keep the linear if-else chain (hashing overhead not worth it). Matches jsoniter-scala's own strategy.
 
 ### Not optimizable (circe format constraints)
 

--- a/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
+++ b/sanely-jsoniter/src/sanely/jsoniter/SanelyJsoniter.scala
@@ -153,10 +153,13 @@ object SanelyJsoniter:
       // var declarations
       val varDefs: List[Statement] = vars.map(v => ValDef(v.sym, Some(v.defaultTerm)))
 
-      // Build if-else chain for field matching, parameterized by keyLen ref
+      // Build field matching dispatch, parameterized by keyLen ref.
+      // <= 8 fields AND total chars <= 64: linear if-else chain (hashing overhead not worth it).
+      // Otherwise: hash-based match on charBufToHashCode with @switch, collisions resolved by isCharBufEqualsTo.
       def buildMatchChain(keyLenRef: Term): Term =
         val skipTerm = '{ $inExpr.skip() }.asTerm
-        vars.foldRight[Term](skipTerm) { case (vi, elseBranch) =>
+
+        def buildReadAssign(vi: VarInfo, elseBranch: Term): Term =
           vi.tpe match
             case '[t] =>
               val cond = '{ $inExpr.isCharBufEqualsTo(${keyLenRef.asExprOf[Int]}, ${Expr(vi.label)}) }.asTerm
@@ -167,7 +170,23 @@ object SanelyJsoniter:
                   '{ $codecsExpr($idxE).decodeValue($inExpr, $codecsExpr($idxE).nullValue).asInstanceOf[t] }.asTerm
               val assign = Assign(Ref(vi.sym), readTerm)
               If(cond, assign, elseBranch)
-        }
+
+        def buildCollisionChain(fields: collection.Seq[VarInfo]): Term =
+          fields.foldRight[Term](skipTerm)(buildReadAssign)
+
+        val totalChars = vars.foldLeft(0)(_ + _.label.length)
+        if vars.size <= 8 && totalChars <= 64 then
+          buildCollisionChain(vars)
+        else
+          val hashOf = (vi: VarInfo) =>
+            JsonReader.toHashCode(vi.label.toCharArray, vi.label.length)
+          val grouped = groupByOrdered(vars)(hashOf)
+          val cases = grouped.map { case (hash, fields) =>
+            CaseDef(Literal(IntConstant(hash)), None, buildCollisionChain(fields))
+          }
+          val defaultCase = CaseDef(Wildcard(), None, skipTerm)
+          val scrutinee = '{ $inExpr.charBufToHashCode(${keyLenRef.asExprOf[Int]}): @scala.annotation.switch }.asTerm
+          Match(scrutinee, (cases :+ defaultCase).toList)
 
       // Build result: mirror.fromProduct(new ArrayProduct(Array[Any](_f0, _f1, ...)))
       val varRefExprs: List[Expr[Any]] = vars.map { v =>
@@ -589,6 +608,12 @@ object SanelyJsoniter:
             d.typeSymbol.fullName
           case _ => d.show
       go(tpe)
+
+    private def groupByOrdered[X, K](xs: collection.Seq[X])(f: X => K): collection.Seq[(K, collection.Seq[X])] =
+      xs.foldLeft(new mutable.LinkedHashMap[K, mutable.ArrayBuffer[X]]) { (m, x) =>
+        m.getOrElseUpdate(f(x), new mutable.ArrayBuffer[X]).addOne(x)
+        m
+      }.toSeq
 
     private def nullValueExpr[T: Type]: Expr[Any] =
       val tpe = TypeRepr.of[T].dealias

--- a/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
+++ b/sanely-jsoniter/test/src/sanely/jsoniter/SanelyJsoniterTest.scala
@@ -117,6 +117,13 @@ case class DiamondLeaf(x: Int) extends DiamondA with DiamondB
 case class OnlyA(a: Int) extends DiamondA
 case class OnlyB(b: Int) extends DiamondB
 
+// Wide type (12 fields) — exercises hash-based field dispatch (> 8 fields threshold)
+case class WideRecord(
+  alpha: String, bravo: Int, charlie: Boolean, delta: Double,
+  echo: Long, foxtrot: Float, golf: Option[String], hotel: List[Int],
+  india: String, juliet: Int, kilo: Boolean, lima: Double
+)
+
 object SanelyJsoniterTest extends TestSuite:
   import sanely.jsoniter.semiauto.*
 
@@ -137,6 +144,7 @@ object SanelyJsoniterTest extends TestSuite:
   given JsonValueCodec[WithLongMap] = deriveJsoniterCodec
   given JsonValueCodec[WithEither] = deriveJsoniterCodec
   given JsonValueCodec[WithNestedEither] = deriveJsoniterCodec
+  given JsonValueCodec[WideRecord] = deriveJsoniterCodec
 
   private def roundtrip[A: JsonValueCodec](value: A): A =
     val json = writeToString(value)
@@ -165,6 +173,20 @@ object SanelyJsoniterTest extends TestSuite:
       assert(json == "{}")
       val decoded = readFromString[Empty](json)
       assert(decoded == e)
+    }
+
+    test("product - wide (hash dispatch)") {
+      val w = WideRecord("a", 1, true, 2.5, 100L, 3.14f, Some("opt"), List(1, 2), "i", 42, false, 9.9)
+      val json = writeToString(w)
+      val decoded = readFromString[WideRecord](json)
+      assert(decoded == w)
+      // Verify all fields present in JSON
+      assert(json.contains("\"alpha\":\"a\""))
+      assert(json.contains("\"lima\":9.9"))
+      // Verify decode with fields in different order
+      val reordered = """{"lima":9.9,"kilo":false,"juliet":42,"india":"i","hotel":[1,2],"golf":"opt","foxtrot":3.140000104904175,"echo":100,"delta":2.5,"charlie":true,"bravo":1,"alpha":"a"}"""
+      val decoded2 = readFromString[WideRecord](reordered)
+      assert(decoded2 == w)
     }
 
     test("option - some") {


### PR DESCRIPTION
## Summary

- For products with >8 fields or >64 total field name chars, generates `(in.charBufToHashCode(l): @switch) match { ... }` with compile-time pre-computed hashes via `JsonReader.toHashCode`. Hash collisions resolved by `isCharBufEqualsTo` sub-chains. Small types keep the linear if-else chain. Matches jsoniter-scala's own strategy.
- Adds `WideRecord` (12 fields) test exercising the hash dispatch path
- Updates benchmark numbers (3 runs × 5 warmup + 5 measured iterations): write throughput now **6.2x** vs circe, **surpassing jsoniter-scala native by 6%**
- Explains the write speed advantage: branchless unconditional field writing vs jsoniter-scala's per-field conditional branches (`transientNone`, `transientEmpty`, `transientDefault`)
- Marks P3.1–P3.4 complete in ROADMAP.md

## Benchmark results (3 runs)

| | Reading (ops/sec) | | Writing (ops/sec) | |
|---|---|---|---|---|
| **circe + jawn** | ~139K | 1.0x | ~126K | 1.0x |
| **sanely-jsoniter** | **~669K** | **4.8x** | **~783K** | **6.2x** |
| jsoniter-scala native | ~684K | 4.9x | ~737K | 5.8x |

## Test plan

- [x] `./mill sanely-jsoniter.jvm.test` — 80 tests pass (includes new wide type test)
- [x] `./mill sanely-jsoniter.js.test` — 91 tests pass
- [x] `./mill tapir-test.test` — 8 tests pass
- [x] `bash bench-runtime.sh 5 5` — run 3 times, consistent results

🤖 Generated with [Claude Code](https://claude.com/claude-code)